### PR TITLE
fix: Block text selection on monday-ui-react-core disabled button

### DIFF
--- a/src/components/Button/Button.scss
+++ b/src/components/Button/Button.scss
@@ -17,13 +17,13 @@
   align-items: center;
   justify-content: center;
 
-  // Prevent selection of the buttons text
+  // Prevent text selection
   -webkit-user-select: none;
   -moz-user-select: none;
   -ms-user-select: none;
   user-select: none;
 
-  // will be updated dynamically after render by js
+  // Will be updated dynamically after render by js
   --element-width: 32;
   --element-height: 32;
 


### PR DESCRIPTION
## Go over this checklist before submitting your Pull Request

Description: fix: Block text selection on monday-ui-react-core disabled button. solve #250 

### Updating existing component
#### Basic
- [x] PR has description
- [ ] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [x] All the changes to the component should be reflected in the Storybook.
- [ ] Component passed Accessibility Plugin checks
#### Tests
- [x] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


