### PR TITLE
ayelet/tabs_active_tab_id_fix

### DIFF
--- a/src/components/Tabs/TabList/TabList.jsx
+++ b/src/components/Tabs/TabList/TabList.jsx
@@ -1,20 +1,30 @@
-import React, { useRef, forwardRef, useState, useCallback } from "react";
+import React, { useRef, forwardRef, useState, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import { useFocusWithin, useKeyboard } from "@react-aria/interactions";
 import useMergeRefs from "../../../hooks/useMergeRefs";
+import usePrevious from "../../../hooks/usePrevious";
 import "./TabList.scss";
 
 const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, size, children }, ref) => {
   const componentRef = useRef(null);
   const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
 
-  const [activeTab, setActiveTab] = useState(activeTabId);
+  const [activeTabState, setActiveTabState] = useState(activeTabId);
   const [focusTab, setFocusTab] = useState(-1);
+
+  const prevActiveTabIdProp = usePrevious(activeTabId);
+
+  useEffect(() => {
+    // Update active tab if changed from props
+    if (activeTabId !== prevActiveTabIdProp && activeTabId !== activeTabState) {
+      setActiveTabState(activeTabId);
+    }
+  }, [activeTabId, prevActiveTabIdProp, activeTabState, setActiveTabState]);
 
   const onTabSelect = useCallback(
     tabId => {
-      setActiveTab(tabId);
+      setActiveTabState(tabId);
       onTabChange && onTabChange(tabId);
     },
     [onTabChange]
@@ -34,7 +44,7 @@ const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, 
     if (keyCode === 37 || keyCode === 39) {
       // left or right arrow
       if (newFocusTab < 0) {
-        newFocusTab = activeTab;
+        newFocusTab = activeTabState;
       }
     }
 
@@ -59,7 +69,7 @@ const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, 
 
   const { focusWithinProps } = useFocusWithin({
     onFocusWithin: () => {
-      setFocusTab(activeTab);
+      setFocusTab(activeTabState);
     },
 
     onBlurWithin: () => {
@@ -73,7 +83,7 @@ const TabList = forwardRef(({ className, id, onTabChange, activeTabId, tabType, 
         {React.Children.map(children, (child, index) => {
           return React.cloneElement(child, {
             value: index,
-            active: activeTab === index,
+            active: activeTabState === index,
             focus: focusTab === index,
             onClick: value => onTabClick(value, child.props.onClick)
           });

--- a/src/components/Tabs/TabsContext/TabsContext.jsx
+++ b/src/components/Tabs/TabsContext/TabsContext.jsx
@@ -1,32 +1,43 @@
-import React, { useRef, forwardRef, useState, useCallback } from "react";
+import React, { useRef, forwardRef, useState, useCallback, useEffect } from "react";
 import PropTypes from "prop-types";
 import cx from "classnames";
 import useMergeRefs from "../../../hooks/useMergeRefs";
+import usePrevious from "../../../hooks/usePrevious";
 import "./TabsContext.scss";
 
 const TabsContext = forwardRef(({ className, id, activeTabId, children }, ref) => {
   const componentRef = useRef(null);
   const mergedRef = useMergeRefs({ refs: [ref, componentRef] });
 
-  const [previousActiveTab, setPreviousActiveTab] = useState(activeTabId);
-  const [activeTab, setActiveTab] = useState(activeTabId);
+  const [previousActiveTabIdState, setPreviousActiveTabIdState] = useState(activeTabId);
+  const [activeTabIdState, setActiveTabIdState] = useState(activeTabId);
+  const prevActiveTabIdProp = usePrevious(activeTabId);
+
+  useEffect(() => {
+    // Update active tab if changed from props
+    if (activeTabId !== prevActiveTabIdProp && activeTabId !== activeTabIdState) {
+      setPreviousActiveTabIdState(activeTabIdState);
+      setActiveTabIdState(activeTabId);
+    }
+  }, [activeTabId, prevActiveTabIdProp, activeTabIdState, setPreviousActiveTabIdState, setActiveTabIdState]);
+
   const onTabClick = useCallback(
     tabId => {
-      setPreviousActiveTab(activeTab);
-      setActiveTab(tabId);
+      setPreviousActiveTabIdState(activeTabIdState);
+      setActiveTabIdState(tabId);
     },
-    [setPreviousActiveTab, activeTab, setActiveTab]
+    [setPreviousActiveTabIdState, activeTabIdState, setActiveTabIdState]
   );
 
   return (
     <div ref={mergedRef} className={cx("tabs-context--wrapper", className)} id={id}>
       {React.Children.map(children, child => {
         if (child.type.isTabList) {
-          return React.cloneElement(child, { onTabChange: onTabClick });
+          return React.cloneElement(child, { activeTabId: activeTabIdState, onTabChange: onTabClick });
         }
         if (child.type.isTabPanels) {
-          const animationDirection = previousActiveTab < activeTab ? "ltr" : "rtl";
-          return React.cloneElement(child, { activeTabId: activeTab, animationDirection });
+          const animationDirection = previousActiveTabIdState < activeTabIdState ? "ltr" : "rtl";
+          return React.cloneElement(child, { activeTabId: activeTabIdState, animationDirection });
         }
         return child;
       })}

--- a/src/components/Tabs/TabsContext/__stories__/tabsContext.stories.js
+++ b/src/components/Tabs/TabsContext/__stories__/tabsContext.stories.js
@@ -1,5 +1,4 @@
 import React from "react";
-import { action } from '@storybook/addon-actions';
 import { text, boolean, number, select } from "@storybook/addon-knobs";
 import { withPerformance } from "storybook-addon-performance";
 import TabsContext from "../TabsContext";
@@ -8,7 +7,6 @@ import Tab from "../../Tab/Tab";
 import TabPanel from "../../TabPanel/TabPanel";
 import { TabPanels } from "../../../index";
 import "./tabsContext.stories.scss";
-
 
 export const DefaultStory = () => (
   <TabsContext>
@@ -26,9 +24,36 @@ export const DefaultStory = () => (
   </TabsContext>
 );
 
-export default {
-    title: "Components|Tabs/TabsContext",
-    component: TabsContext,
-    decorators: [withPerformance]
+export const Sandbox = () => {
+  return (
+    <TabsContext
+      activeTabId={select(
+        "activeTabId",
+        {
+          First: 0,
+          Second: 1,
+          Third: 2
+        },
+        0
+      )}
+    >
+      <TabList>
+        <Tab>First</Tab>
+        <Tab>Second</Tab>
+        <Tab>Third</Tab>
+      </TabList>
 
+      <TabPanels>
+        <TabPanel>First panel</TabPanel>
+        <TabPanel>Second panel</TabPanel>
+        <TabPanel>Third panel</TabPanel>
+      </TabPanels>
+    </TabsContext>
+  );
+};
+
+export default {
+  title: "Components|Tabs/TabsContext",
+  component: TabsContext,
+  decorators: [withPerformance]
 };


### PR DESCRIPTION
Description: 
bug fix - change the state active tab id when the activeTabId prop changes
also added sandbox to the context where we control the activeTabId prop from a dropdown

https://user-images.githubusercontent.com/22417492/138263671-a80c5702-9ae7-49e1-a5de-78a4bef6c6f1.mov

### Updating existing component
#### Basic
- [x] PR has description
- [x] Changes to the component are backward compatible (including selectors structure). If not - add to the title of the PR "BREAKABLE_CHANGE""
- [ ] All changes to the component are reflected in the ReadMe
- [ ] If component is old and was not compliant with the latest guidelines - it was fixed (optional) 
#### Style
- [ ] CSS selectors are named using [BEM convention](http://getbem.com/naming/) 
- [ ] Design is compatible with [Monday Design System](https://design.monday.com/)
#### Storybook
- [x] All the changes to the component should be reflected in the Storybook.
- [x] Component passed Accessibility Plugin checks
#### Tests
- [ ] All current tests are passing
- [ ] New functionality is covered with tests
- [ ] Tests are compliant with TESTING_README.md instructions


