### PR TITLE
fix: <Dropdown> multi single line use hidden options - for all the sizes

### DIFF
--- a/src/components/Dropdown/Dropdown.jsx
+++ b/src/components/Dropdown/Dropdown.jsx
@@ -361,6 +361,7 @@ const Dropdown = forwardRef(
   }
 );
 
+// TODO Should be BASE_SIZES, but breaking change?
 Dropdown.size = SIZES;
 Dropdown.chipColors = DROPDOWN_CHIP_COLORS;
 Dropdown.createFilter = createFilter;

--- a/src/components/Dropdown/__stories__/dropdown.stories.mdx
+++ b/src/components/Dropdown/__stories__/dropdown.stories.mdx
@@ -201,6 +201,24 @@ The Dropdown component supports multiple options selection in two different stat
 <Canvas>
   <Story name="Multi-choice with different states">
     {() => {
+      const customOptions = [
+        {
+          value: "Video",
+          label: "Video"
+        },
+        {
+          value: "Photo",
+          label: "Photo"
+        },
+        {
+          value: "Sound",
+          label: "Sound"
+        },
+        {
+          value: "Blank",
+          label: "Blank"
+        }
+      ];
       const options = useMemo(
         () => [
           {
@@ -225,39 +243,98 @@ The Dropdown component supports multiple options selection in two different stat
       return (
         <Flex wrap gap={Flex.gaps.MEDIUM}>
           <StoryDescription description="Single line" vertical>
-            <div style={{ width: "400px" }}>
-              <Dropdown
-                placeholder="Single line multi state"
-                defaultValue={[options[0]]}
-                options={options}
-                multi
-                className="dropdown-stories-styles_with-chips"
-              />
-            </div>
+            <Flex direction={Flex.directions.COLUMN}>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  placeholder="Single line multi state"
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  size={Dropdown.size.LARGE}
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  placeholder="Single line multi state"
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  size={Dropdown.size.MEDIUM}
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+              <div style={{ width: "350px" }}>
+                <Dropdown
+                  placeholder="Single line multi state"
+                  defaultValue={[customOptions[0], customOptions[1]]}
+                  options={customOptions}
+                  multi
+                  size={Dropdown.size.MEDIUM}
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  placeholder="Single line multi state"
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  size={Dropdown.size.SMALL}
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+            </Flex>
           </StoryDescription>
           <StoryDescription description="Multiple lines" vertical>
-            <div style={{ width: "400px" }}>
-              <Dropdown
-                placeholder="Multiple line multi state"
-                defaultValue={[options[0]]}
-                options={options}
-                multi
-                multiline
-                className="dropdown-stories-styles_with-chips"
-              />
-            </div>
+            <Flex direction={Flex.directions.COLUMN}>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  placeholder="Multiple line multi state"
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  multiline
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  placeholder="Multiple line multi state"
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  size={Dropdown.size.SMALL}
+                  multiline
+                  className="dropdown-stories-styles_with-chips"
+                />
+              </div>
+            </Flex>
           </StoryDescription>
           <StoryDescription description="Mandatory default values" vertical headerStyle={{ width: 190 }}>
-            <div style={{ width: "400px" }}>
-              <Dropdown
-                defaultValue={[options[0]]}
-                options={options}
-                multi
-                multiline
-                className="dropdown-stories-styles_with-chips"
-                withMandatoryDefaultOptions
-              />
-            </div>
+            <Flex direction={Flex.directions.COLUMN}>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  multiline
+                  className="dropdown-stories-styles_with-chips"
+                  withMandatoryDefaultOptions
+                />
+              </div>
+              <div style={{ width: "400px" }}>
+                <Dropdown
+                  defaultValue={[options[0]]}
+                  options={options}
+                  multi
+                  multiline
+                  size={Dropdown.size.SMALL}
+                  className="dropdown-stories-styles_with-chips"
+                  withMandatoryDefaultOptions
+                />
+              </div>
+            </Flex>
           </StoryDescription>
         </Flex>
       );

--- a/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.jsx
+++ b/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.jsx
@@ -8,6 +8,7 @@ import Dialog from "../../../Dialog/Dialog";
 import DialogContentContainer from "../../../DialogContentContainer/DialogContentContainer";
 import Chips from "../../../Chips/Chips";
 import { DROPDOWN_CHIP_COLORS } from "../../dropdown-constants";
+import { BASE_SIZES } from "../../../../constants";
 import classes from "./MultiValueContainer.module.scss";
 
 export default function Container({ children, selectProps, ...otherProps }) {
@@ -17,7 +18,8 @@ export default function Container({ children, selectProps, ...otherProps }) {
     inputValue,
     selectProps: customProps = {},
     withMandatoryDefaultOptions,
-    readOnly
+    readOnly,
+    size
   } = selectProps;
   const { selectedOptions, onSelectedDelete, isMultiline, popupsContainerSelector } = customProps;
   const clickHandler = children[1];
@@ -27,7 +29,10 @@ export default function Container({ children, selectProps, ...otherProps }) {
   const chipWrapperClassName = classes["chip-with-input-wrapper"];
   const chipClassName = cx(
     isMultiline ? classes["multiselect-chip-multi-line"] : classes["multiselect-chip-single-line"],
-    { [classes["multiselect-chip-disabled"]]: isDisabled }
+    {
+      [classes["multiselect-chip-disabled"]]: isDisabled,
+      [classes["multiselect-chip-single-line-size-small"]]: size === BASE_SIZES.SMALL
+    }
   );
 
   const { overflowIndex, hiddenOptionsCount } = useHiddenOptionsData({

--- a/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
+++ b/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
@@ -14,7 +14,8 @@
 .multiselect-chip-single-line {
   --chips-margin: 5px 2px;
   &-size-small {
-    --chips-margin: 0 2px;
+    // TODO causing incorrect display of hidden options?
+    --chips-margin: 1px 2px;
   }
 }
 

--- a/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
+++ b/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
@@ -13,6 +13,7 @@
 
 .multiselect-chip-single-line {
   --chips-margin: 5px 2px;
+  // TODO -size-large? cause second-line should be hidden
   &-size-small {
     // TODO causing incorrect display of hidden options?
     --chips-margin: 1px 2px;

--- a/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
+++ b/src/components/Dropdown/components/MultiValueContainer/MultiValueContainer.module.scss
@@ -13,6 +13,9 @@
 
 .multiselect-chip-single-line {
   --chips-margin: 5px 2px;
+  &-size-small {
+    --chips-margin: 0 2px;
+  }
 }
 
 .multiselect-chip-disabled {

--- a/src/components/Dropdown/hooks/useHiddenOptionsData.js
+++ b/src/components/Dropdown/hooks/useHiddenOptionsData.js
@@ -34,7 +34,9 @@ export function useHiddenOptionsData({
     }
 
     setOverflowIndex(finalOverflowingIndex);
-  }, [ref, isMultiline, selectedOptionsCount, chipWrapperClassName, chipClassName, isCounterShown]);
+  }, [ref, isMultiline, selectedOptionsCount, chipWrapperClassName, chipClassName]);
+  // TODO removed isCounterShown from the dependencies array because it was causing an infinite loop for specific cases
+  // }, [ref, isMultiline, selectedOptionsCount, chipWrapperClassName, chipClassName, isCounterShown]);
 
   const hiddenOptionsCount = overflowIndex > -1 ? selectedOptionsCount - overflowIndex : 0;
   return { overflowIndex, hiddenOptionsCount };


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/5495680889

Should contain fix for this, cause it leading to infinite cycle in some cases (with not medium size) https://github.com/mondaycom/monday-ui-react-core/pull/1708

<img width="434" alt="image" src="https://github.com/mondaycom/monday-ui-react-core/assets/104433616/a82a9cf6-2ae8-43fe-a3aa-a9f2686b85af">
