### PR TITLE
fix(Button): dispatch onclick event on edge

### DIFF
--- a/src/components/Button/Button.module.scss
+++ b/src/components/Button/Button.module.scss
@@ -74,7 +74,9 @@ $disabled-on-primary-color-opacity: 0.5;
 }
 
 .button:active:not(.preventClickAnimation) {
-  transform: scale(0.95) translate3d(0, 0, 0);
+  --button-scale-factor: 0.95;
+  transform: scale(var(--button-scale-factor)) translate3d(0, 0, 0);
+  margin: calc(1% * (1 - var(--button-scale-factor)));
 }
 
 .button .leftIcon {

--- a/src/components/Button/__tests__/button.jest.js
+++ b/src/components/Button/__tests__/button.jest.js
@@ -9,7 +9,7 @@ function renderComponent(props) {
   return render(<Button {...props}>{text}</Button>);
 }
 
-describe("<Buttoon />", () => {
+describe("<Button />", () => {
   let clickActionStub;
   let onMouseDownStub;
   let buttonComponent;


### PR DESCRIPTION
## Description
The button doesn't dispatch on click event when clicking on the button's edge.
Issue #1766 

## Symptoms
Clicking on the Button component causes the edges of the button to move inward before the click event can be fully registered.

## Solution
The added margin calculation compensates for the button's size reduction due to scaling.

