### PR TITLE
fix: hide RenderAction when have inputValue

### DIFF
--- a/packages/core/src/components/Search/Search.tsx
+++ b/packages/core/src/components/Search/Search.tsx
@@ -88,7 +88,7 @@ const Search = forwardRef(
           />
         )}
         {inputValue && !disabled && ClearIcon}
-        {RenderAction}
+        {!inputValue && RenderAction}
       </>
     );
 


### PR DESCRIPTION
<!-- Thank you for contributing!

Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

Looking to make a small change to the logic of the new search component - we don't want the renderAction component to show once we have a search term entered.

Currently there's not a way to do this that doesn't result in both the renderAction and the clear button both showing briefly (see below), due the input value change inside the search component not being debounced, so the clear button renders before the onChange method is called and we're able to check for the presence of an input value outside the search component.

Current behaviour when handling hiding renderAction outside of search component:
![2024-04-30 13 36 12](https://github.com/mondaycom/vibe/assets/129850036/aa114681-783f-4a67-a3ac-10fdc2a53071)

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
