### PR TITLE
feat(Search): adds hideRenderActionOnInput option

### DIFF
--- a/packages/core/src/components/Search/Search.tsx
+++ b/packages/core/src/components/Search/Search.tsx
@@ -19,6 +19,7 @@ const Search = forwardRef(
       clearIconName = CloseSmallIcon,
       clearIconLabel = "Clear",
       renderAction: RenderAction,
+      hideRenderActionOnInput = false,
       value,
       placeholder,
       size = "medium",
@@ -88,7 +89,7 @@ const Search = forwardRef(
           />
         )}
         {inputValue && !disabled && ClearIcon}
-        {RenderAction}
+        {!(hideRenderActionOnInput && inputValue) && RenderAction}
       </>
     );
 

--- a/packages/core/src/components/Search/Search.tsx
+++ b/packages/core/src/components/Search/Search.tsx
@@ -19,7 +19,7 @@ const Search = forwardRef(
       clearIconName = CloseSmallIcon,
       clearIconLabel = "Clear",
       renderAction: RenderAction,
-      hideRenderActionOnInput = false,
+      hideRenderActionOnInput,
       value,
       placeholder,
       size = "medium",

--- a/packages/core/src/components/Search/Search.types.ts
+++ b/packages/core/src/components/Search/Search.types.ts
@@ -22,6 +22,10 @@ export interface SearchProps extends VibeComponentProps {
    */
   renderAction?: React.ReactElement<typeof IconButton | typeof MenuButton>;
   /**
+   * If true, hides the additional action when the user types in the search input.
+   */
+  hideRenderActionOnInput?: boolean;
+  /**
    * The value of the search input.
    */
   value?: HTMLInputElement["value"];

--- a/packages/core/src/components/Search/__tests__/Search.jest.tsx
+++ b/packages/core/src/components/Search/__tests__/Search.jest.tsx
@@ -92,6 +92,22 @@ describe("Search", () => {
     expect(getByText("Extra Action")).toBeInTheDocument();
   });
 
+  it("should display additional action render with hideRenderActionOnInput option true and no input value", () => {
+    const AdditionalActionButton = <button type="button">Extra Action</button>;
+    const { getByText } = renderSearch({ renderAction: AdditionalActionButton, hideRenderActionOnInput: true });
+    expect(getByText("Extra Action")).toBeInTheDocument();
+  });
+
+  it("should not display additional action render with hideRenderActionOnInput option true and input value", () => {
+    const AdditionalActionButton = <button type="button">Extra Action</button>;
+    const { queryByText } = renderSearch({
+      renderAction: AdditionalActionButton,
+      hideRenderActionOnInput: true,
+      value: "Test"
+    });
+    expect(queryByText("Extra Action")).not.toBeInTheDocument();
+  });
+
   describe("a11y", () => {
     it("should have default input role when searchResultsContainerId is not provided", () => {
       const { getByRole } = renderSearch();


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

We have a use case for being able to hide the renderAction component passed in to the Search component once a search term is entered, which is not easily achieved by logic outside of the component (see below, clear icon showing at same time as renderAction).

Adding a `hideRenderActionOnInput` option, that defaults to false, which can be enabled so that the RenderAction is not displayed once a search term is entered.

Current behaviour when handling hiding renderAction outside of search component:
![2024-04-30 13 36 12](https://github.com/mondaycom/vibe/assets/129850036/aa114681-783f-4a67-a3ac-10fdc2a53071)


- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
