### PR TITLE
fix: add null protection for onPickDate callback (#2045)

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -116,6 +116,7 @@ const DatePicker: VibeComponent<DatePickerProps, HTMLElement> = forwardRef<HTMLD
 
     const onDateRangeChange = useCallback(
       (date: RangeDate) => {
+        if (!onPickDate) return;
         if (focusedInput === FocusInput.startDate) {
           onPickDate({ ...date, endDate: null });
         } else {


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

add a null check to avoid a console error when using the DatePicker component without passing the onPickDate prop, to solve this issue:
https://github.com/mondaycom/vibe/issues/2045

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
