### PR TITLE
fix(Dialog.tsx): getContainer causing react error 200

### DIFF
--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -171,7 +171,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
   static positions = DialogPosition;
   static animationTypes = AnimationType;
   static defaultProps = {
-    // position: "top",
+    position: "top",
     modifiers: [] as Modifier<any>[],
     moveBy: { main: 0, secondary: 0 },
     showDelay: 100,

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -281,7 +281,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
     }
 
     const containerElement = document.querySelector(containerSelector);
-    if (!containerElement || !(containerElement instanceof HTMLElement)) {
+    if (!containerElement || !(containerElement instanceof Element)) {
       // TODO add env check - if not jest env - trashing the logs - https://monday.monday.com/boards/3532714909/pulses/5570955392
       // console.error(
       //   `Dialog: Container element with selector "${containerSelector}" was not found or is not an HTMLElement. Dialog may not be correctly positioned.`

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -171,7 +171,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
   static positions = DialogPosition;
   static animationTypes = AnimationType;
   static defaultProps = {
-    position: "top",
+    // position: "top",
     modifiers: [] as Modifier<any>[],
     moveBy: { main: 0, secondary: 0 },
     showDelay: 100,
@@ -281,10 +281,10 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
     }
 
     const containerElement = document.querySelector(containerSelector);
-    if (!containerElement) {
+    if (!containerElement || !(containerElement instanceof HTMLElement)) {
       // TODO add env check - if not jest env - trashing the logs - https://monday.monday.com/boards/3532714909/pulses/5570955392
       // console.error(
-      //   `Dialog: Container element with selector "${containerSelector}" was not found. Dialog may not be correctly positioned.`
+      //   `Dialog: Container element with selector "${containerSelector}" was not found or is not an HTMLElement. Dialog may not be correctly positioned.`
       // );
       return document.body;
     }


### PR DESCRIPTION
When document.querySelector(containerSelector) returned a `node` that was not a `Element` the react-dom createPortal threw a [react error 200](https://react.dev/errors/200?invariant=200).
Here we fix the issue by validating the returned `contanerElement` as an Element.

- [x ] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
