### PR TITLE
build: remove sourcemaps

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -60,8 +60,7 @@ export default {
     strict: false,
     exports: "named",
     preserveModules: true,
-    preserveModulesRoot: ".",
-    sourcemap: true
+    preserveModulesRoot: "."
   },
   input: {
     index: path.join(SRC_PATH, "index.js"),

--- a/packages/core/webpack.config.js
+++ b/packages/core/webpack.config.js
@@ -54,7 +54,7 @@ module.exports = () => {
       }
     }
   ];
-  const devtool = "source-map";
+  const devtool = IS_DEV ? "source-map" : false;
   const publishedComponents = getPublishedComponents();
 
   const entry = {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/6494836185

Bundle size (unpackaged) reduced from 205MB to ~40MB. Without webpack build it's less than 2MB