### PR TITLE
build: add sourcemaps to esm

### DIFF
--- a/packages/core/rollup.config.js
+++ b/packages/core/rollup.config.js
@@ -60,7 +60,8 @@ export default {
     strict: false,
     exports: "named",
     preserveModules: true,
-    preserveModulesRoot: "."
+    preserveModulesRoot: ".",
+    sourcemap: true
   },
   input: {
     index: path.join(SRC_PATH, "index.js"),


### PR DESCRIPTION
As the rollup build doesn't affect the unpackaged size - bringing it back
https://monday.monday.com/boards/3532714909/pulses/6494836185