### PR TITLE
fix(colors): align dark orange to a11y requirments

### DIFF
--- a/packages/core/src/constants/colors.json
+++ b/packages/core/src/constants/colors.json
@@ -89,7 +89,7 @@
   "dark-red": "#bb3354",
   "trolley-grey": "#757575",
   "dark-purple": "#784bd1",
-  "dark-orange": "#ff642e",
+  "dark-orange": "#ff6d3b",
   "sofia_pink": "#ff007f",
   "dark-pink": "#ff007f",
   "turquoise": "#66ccff",


### PR DESCRIPTION
See https://github.com/mondaycom/vibe/pull/2009

Missed this specific color in original PR ⏫ 


https://monday.monday.com/docs/5264487294