### PR TITLE
fix(Table): sync between body scroll and header scroll in virtualized state

### DIFF
--- a/packages/core/src/components/Table/Table/Table.tsx
+++ b/packages/core/src/components/Table/Table/Table.tsx
@@ -8,6 +8,7 @@ import { getTestId } from "../../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../../tests/constants";
 import { RowHeights, RowSizes } from "./TableConsts";
 import styles from "./Table.module.scss";
+import { TableProvider } from "../context/TableContext/TableContext";
 
 export type TableLoadingStateType = "long-text" | "medium-text" | "circle" | "rectangle";
 
@@ -38,16 +39,6 @@ export interface ITableProps extends VibeComponentProps {
   size?: RowSizes;
   withoutBorder?: boolean;
 }
-
-export interface ITableContext {
-  columns: ITableProps["columns"];
-  dataState?: ITableProps["dataState"];
-  emptyState: ITableProps["emptyState"];
-  errorState: ITableProps["errorState"];
-  size: ITableProps["size"];
-}
-
-export const TableContext = React.createContext<ITableContext>(null);
 
 const Table: VibeComponent<ITableProps, HTMLDivElement> & {
   sizes?: typeof RowSizes;
@@ -84,11 +75,11 @@ const Table: VibeComponent<ITableProps, HTMLDivElement> & {
     const testId = dataTestId || getTestId(ComponentDefaultTestId.TABLE, id);
 
     return (
-      <TableContext.Provider value={{ columns, emptyState, errorState, dataState, size }}>
+      <TableProvider value={{ columns, dataState, emptyState, errorState, size }}>
         <div ref={ref} id={id} className={classNames} data-testid={testId} role="table" style={calculatedStyle}>
           {children}
         </div>
-      </TableContext.Provider>
+      </TableProvider>
     );
   }
 );

--- a/packages/core/src/components/Table/Table/__tests__/Table.test.tsx
+++ b/packages/core/src/components/Table/Table/__tests__/Table.test.tsx
@@ -7,6 +7,22 @@ import TableRow from "../../TableRow/TableRow";
 import TableHeaderCell, { ITableHeaderCellProps } from "../../TableHeaderCell/TableHeaderCell";
 import TableHeader from "../../TableHeader/TableHeader";
 import TableCellSkeleton from "../../TableCellSkeleton/TableCellSkeleton";
+import * as TableContextModule from "../../context/TableContext/TableContext";
+import { RowSizes } from "../TableConsts";
+
+function mockUseTable() {
+  jest.spyOn(TableContextModule, "useTable").mockImplementation(() => ({
+    columns: [],
+    emptyState: <div />,
+    errorState: <div />,
+    size: RowSizes.MEDIUM
+  }));
+}
+
+jest.mock("../../context/TableContext/TableContext", () => ({
+  __esModule: true,
+  ...jest.requireActual("../../context/TableContext/TableContext")
+}));
 
 interface TableNode {
   role: string;
@@ -69,6 +85,14 @@ describe("Table", () => {
   });
 
   describe("TableRow", () => {
+    beforeEach(() => {
+      mockUseTable();
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
     it("should render without a highlight state", () => {
       const { getByRole } = render(<TableRow />);
       expect(getByRole("row")).toHaveAttribute("aria-selected", "false");

--- a/packages/core/src/components/Table/TableBody/TableBody.tsx
+++ b/packages/core/src/components/Table/TableBody/TableBody.tsx
@@ -1,10 +1,10 @@
-import React, { ReactElement, ComponentProps, useContext, forwardRef } from "react";
+import React, { ReactElement, ComponentProps, forwardRef } from "react";
 import cx from "classnames";
 import { VibeComponent, VibeComponentProps } from "../../../types";
 import TableRow, { ITableRowProps } from "../TableRow/TableRow";
 import VirtualizedList from "../../VirtualizedList/VirtualizedList";
 import styles from "./TableBody.module.scss";
-import { TableContext } from "../Table/Table";
+import { useTable } from "../context/TableContext/TableContext";
 import TableCellSkeleton from "../TableCellSkeleton/TableCellSkeleton";
 import { SKELETON_ROWS_AMOUNT } from "../Table/TableConsts";
 import { getLoadingTypeForCell } from "../Table/tableHelpers";
@@ -20,7 +20,7 @@ export interface ITableBodyProps extends VibeComponentProps {
 
 const TableBody: VibeComponent<ITableBodyProps, HTMLDivElement> = forwardRef(
   ({ id, className, "data-testid": dataTestId, children }, ref) => {
-    const { dataState, emptyState, errorState, columns } = useContext(TableContext);
+    const { dataState, emptyState, errorState, columns } = useTable();
     const { isLoading, isError } = dataState || {};
 
     const skeletonRender = [...new Array(SKELETON_ROWS_AMOUNT)].map((_, rowIndex) => (

--- a/packages/core/src/components/Table/TableRow/TableRow.tsx
+++ b/packages/core/src/components/Table/TableRow/TableRow.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from "react";
+import React, { forwardRef, useEffect, useRef } from "react";
 import { VibeComponent, VibeComponentProps } from "../../../types";
 import { ITableCellProps } from "../TableCell/TableCell";
 import useMergeRef from "../../../hooks/useMergeRef";
@@ -6,6 +6,7 @@ import { getTestId } from "../../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../../tests/constants";
 import cx from "classnames";
 import styles from "./TableRow.module.scss";
+import { useTable } from "../context/TableContext/TableContext";
 
 export interface ITableRowProps extends VibeComponentProps {
   /**
@@ -18,11 +19,16 @@ export interface ITableRowProps extends VibeComponentProps {
 
 const TableRow: VibeComponent<ITableRowProps, HTMLDivElement> = forwardRef(
   ({ highlighted, children, style, id, className, "data-testid": dataTestId }, ref) => {
+    const { rowWidth, setRowWidth } = useTable();
     const componentRef = useRef(null);
     const mergedRef = useMergeRef(componentRef, ref);
 
+    useEffect(() => {
+      if (rowWidth > 0 || !componentRef.current?.scrollWidth) return;
+      setRowWidth(componentRef.current.scrollWidth);
+    }, [rowWidth, setRowWidth]);
+
     return (
-      // eslint-disable-next-line jsx-a11y/click-events-have-key-events
       <div
         id={id}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.TABLE_ROW, id)}

--- a/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -7,19 +7,19 @@ import { useTable } from "../context/TableContext/TableContext";
 import { RowHeights } from "../Table/TableConsts";
 import AutoSizer from "react-virtualized-auto-sizer";
 
-type Rows = Array<Record<string, unknown> & { id: string }>;
-type Row = Rows[number];
+export type TableVirtualizedRows = Array<Record<string, unknown> & { id: string }>;
+export type TableVirtualizedRow = TableVirtualizedRows[number];
 
 export interface ITableVirtualizedBodyProps extends VibeComponentProps {
-  items: Rows;
-  rowRenderer: (item: Row) => JSX.Element;
+  items: TableVirtualizedRows;
+  rowRenderer: (item: TableVirtualizedRow) => JSX.Element;
   onScroll?: (horizontalScrollDirection: ScrollDirection, scrollTop: number, scrollUpdateWasRequested: boolean) => void;
 }
 
 const TableVirtualizedBody: FC<ITableVirtualizedBodyProps> = ({ items, rowRenderer, onScroll }) => {
   const { size, rowWidth } = useTable();
 
-  const itemRenderer = useCallback<ComponentType<ListChildComponentProps<Row>>>(
+  const itemRenderer = useCallback<ComponentType<ListChildComponentProps<TableVirtualizedRow>>>(
     ({ index, style }) => {
       const currentItem = items[index];
       const element = rowRenderer(currentItem);

--- a/packages/core/src/components/Table/context/TableContext/TableContext.tsx
+++ b/packages/core/src/components/Table/context/TableContext/TableContext.tsx
@@ -1,0 +1,25 @@
+import React, { createContext, useContext, useMemo, useState } from "react";
+import { ITableContext, ITableProviderProps } from "./TableContext.types";
+
+const TableContext = createContext<ITableContext | undefined>(undefined);
+
+export const TableProvider = ({ value, children }: ITableProviderProps) => {
+  const [rowWidth, setRowWidth] = useState<number>(0);
+  const contextValue = useMemo(
+    () => ({
+      ...value,
+      rowWidth,
+      setRowWidth
+    }),
+    [value, rowWidth]
+  );
+  return <TableContext.Provider value={contextValue}>{children}</TableContext.Provider>;
+};
+
+export const useTable = () => {
+  const context = useContext(TableContext);
+  if (context === undefined) {
+    throw new Error("useTable must be used within a TableProvider");
+  }
+  return context;
+};

--- a/packages/core/src/components/Table/context/TableContext/TableContext.types.ts
+++ b/packages/core/src/components/Table/context/TableContext/TableContext.types.ts
@@ -1,0 +1,17 @@
+import { ITableProps } from "../../Table/Table";
+import React from "react";
+
+export interface ITableContext {
+  columns: ITableProps["columns"];
+  dataState?: ITableProps["dataState"];
+  emptyState: ITableProps["emptyState"];
+  errorState: ITableProps["errorState"];
+  size: ITableProps["size"];
+  rowWidth?: number;
+  setRowWidth?: (width: number) => void;
+}
+
+export type ITableProviderProps = {
+  value: ITableContext;
+  children: React.ReactNode;
+};

--- a/packages/core/src/components/Table/index.ts
+++ b/packages/core/src/components/Table/index.ts
@@ -7,7 +7,9 @@ export {
 export { default as TableBody, ITableBodyProps as TableBodyProps } from "./TableBody/TableBody";
 export {
   default as TableVirtualizedBody,
-  ITableVirtualizedBodyProps as TableVirtualizedBodyProps
+  ITableVirtualizedBodyProps as TableVirtualizedBodyProps,
+  TableVirtualizedRows,
+  TableVirtualizedRow
 } from "./TableVirtualizedBody/TableVirtualizedBody";
 export { default as TableRow, ITableRowProps as TableRowProps } from "./TableRow/TableRow";
 export { default as TableCell, ITableCellProps as TableCellProps } from "./TableCell/TableCell";


### PR DESCRIPTION
this is a temp workaround until the virtualized table component would get a big revamp. this workaround sets List width to be the full width and not the parent container's width

https://monday.monday.com/boards/3532714909/pulses/6513670146