### PR TITLE
feat(colors): remove overrides of content colors in black and dark themes

### DIFF
--- a/packages/style/src/Themes/black/_black-theme-content-colors.scss
+++ b/packages/style/src/Themes/black/_black-theme-content-colors.scss
@@ -1,204 +1,169 @@
 @mixin define-black-theme-content-colors() {
   // grass green
-  --color-grass_green: #359970;
   --color-grass_green-hover: #116846;
   --color-grass_green-selected: #0a482e;
 
   // done green
-  --color-done-green: #33d391;
   --color-done-green-hover: #0f9b63;
   --color-done-green-selected: #096c43;
   --color-done-green-selected-with-opacity: rgba(9, 108, 67, 0.6);
 
   // Bright Green
-  --color-bright-green: #b0dc51;
   --color-bright-green-hover: #7ca32b;
   --color-bright-green-selected: #56721b;
 
   // Saladish
-  --color-saladish: #d5c567;
   --color-saladish-hover: #9d8f3e;
   --color-saladish-selected: #6d6329;
 
   // Egg Yolk
-  --color-egg_yolk: #ffd533;
   --color-egg_yolk-hover: #c29e11;
   --color-egg_yolk-selected: #886e09;
   --color-egg_yolk-rgb: 255, 213, 51;
 
   // Working on it
-  --color-working_orange: #fdbc64;
   --color-working_orange-hover: #c0873c;
   --color-working_orange-selected: #875e27;
 
   // Dark orange
-  --color-dark-orange: #ff6d3b;
   --color-dark-orange-hover: #c25531;
   --color-dark-orange-selected: #883a1f;
 
   // Peach Color
-  --color-peach: #ffbdbd;
   --color-peach-hover: #c2888a;
   --color-peach-selected: #885f5f;
 
   // Sunset Color
-  --color-sunset: #ff9191;
   --color-sunset-hover: #c26163;
   --color-sunset-selected: #884343;
   --color-sunset-selected-with-opacity: rgba(136, 67, 67, 0.6);
 
   // Stuck red
-  --color-stuck-red: #e8697d;
   --color-stuck-red-hover: #ad3f51;
   --color-stuck-red-selected: #792a36;
 
   // Dark red
-  --color-dark-red: #c95c76;
   --color-dark-red-hover: #92334c;
   --color-dark-red-selected: #662232;
 
   // Sofia
-  --color-sofia_pink: #ff44a1;
   --color-sofia_pink-hover: #c21e71;
   --color-sofia_pink-selected: #88134d;
 
   // Lipstick color
-  --color-lipstick: #ff7bd0;
   --color-lipstick-hover: #c24e9a;
   --color-lipstick-selected: #88356a;
 
   // Bubble
-  --color-bubble: #fbb4f4;
   --color-bubble-hover: #be80ba;
   --color-bubble-selected: #855981;
 
   // Purple
-  --color-purple: #b57de3;
   --color-purple-hover: #8050ab;
   --color-purple-selected: #593776;
 
   // Dark purple
-  --color-dark_purple: #936fda;
   --color-dark_purple-hover: #6344a3;
   --color-dark_purple-selected: #442e71;
 
   // Berry
-  --color-berry: #9862a1;
   --color-berry-hover: #673971;
   --color-berry-selected: #47264d;
 
   // Dark indigo
-  --color-dark_indigo: #6645a9;
+  --color-dark_indigo: #6129ff;
   --color-dark_indigo-hover: #3c1f78;
   --color-dark_indigo-selected: #291452;
 
   // Indigo
-  --color-indigo: #777ae5;
   --color-indigo-hover: #4b4ead;
   --color-indigo-selected: #333578;
 
   // Navy
-  --color-navy: #4e73a7;
+  --color-navy: #5684c5;
   --color-navy-hover: #274776;
   --color-navy-selected: #193151;
 
   // Light Blue
-  --color-bright-blue: #79affd;
   --color-bright-blue-hover: #4c7cc1;
   --color-bright-blue-selected: #345686;
 
   // Dark blue
-  --color-dark-blue: #339ecd;
   --color-dark-blue-hover: #0f6d97;
   --color-dark-blue-selected: #094b69;
 
   // Aquamarine
-  --color-aquamarine: #71d6d1;
   --color-aquamarine-hover: #469e9b;
   --color-aquamarine-selected: #2f6e6b;
 
   // Chili Blue
-  --color-chili-blue: #85d6ff;
   --color-chili-blue-hover: #569ec3;
   --color-chili-blue-selected: #3b6e88;
 
   // River
-  --color-river: #86b4ca;
   --color-river-hover: #588095;
   --color-river-selected: #3c5967;
 
   // winter
-  --color-winter: #aebdca;
   --color-winter-hover: #7b8895;
   --color-winter-selected: #555f67;
 
   // Explosive
-  --color-explosive: #d0d0d0;
   --color-explosive-hover: #98999a;
   --color-explosive-selected: #6a6a6a;
 
   // American Grey
-  --color-american_gray: #999999;
   --color-american_gray-hover: #69696a;
   --color-american_gray-selected: #494949;
 
   // Blackish
-  --color-blackish: #5c5c5c;
+  --color-blackish: #9a9a9a;
   --color-blackish-hover: #222222;
   --color-blackish-selected: #111111;
 
   // Brown
-  --color-brown: #99756c;
   --color-brown-hover: #684943;
   --color-brown-selected: #48322c;
 
   // Orchid
-  --color-orchid: #e190c0;
   --color-orchid-hover: #b4739a;
   --color-orchid-selected: #7e516c;
 
   // Tan
-  --color-tan: #bdab95;
   --color-tan-hover: #978977;
   --color-tan-selected: #6a6053;
 
   // Sky
-  --color-sky: #b4e9f8;
   --color-sky-hover: #90bac6;
   --color-sky-selected: #65828b;
 
   // Coffee
-  --color-coffee: #ca9a8b;
   --color-coffee-hover: #a27b6f;
   --color-coffee-selected: #71564e;
 
   // Royal
-  --color-royal: #5591ea;
   --color-royal-hover: #4474bb;
   --color-royal-selected: #305183;
 
   // Teal
-  --color-teal: #457b82;
+  --color-teal: #4a8f98;
   --color-teal-hover: #376268;
   --color-teal-selected: #274549;
 
   // Lavender
-  --color-lavender: #cab9fa;
   --color-lavender-hover: #a294c8;
   --color-lavender-selected: #71688c;
 
   // Steel
-  --color-steel: #bacbed;
   --color-steel-hover: #95a2be;
   --color-steel-selected: #687185;
 
   // Lilac
-  --color-lilac: #b1adc7;
   --color-lilac-hover: #8e8a9f;
   --color-lilac-selected: #63616f;
 
   // Pecan
-  --color-pecan: #786565;
+  --color-pecan: #806363;
   --color-pecan-hover: #605151;
   --color-pecan-selected: #433939;
 }

--- a/packages/style/src/Themes/black/_black-theme-content-colors.scss
+++ b/packages/style/src/Themes/black/_black-theme-content-colors.scss
@@ -72,8 +72,8 @@
 
   // Dark indigo
   --color-dark_indigo: #6129ff;
-  --color-dark_indigo-hover: #3c1f78;
-  --color-dark_indigo-selected: #291452;
+  --color-dark_indigo-hover: #4c18dc;
+  --color-dark_indigo-selected: #3c13ae;
 
   // Indigo
   --color-indigo-hover: #4b4ead;
@@ -81,8 +81,8 @@
 
   // Navy
   --color-navy: #5684c5;
-  --color-navy-hover: #274776;
-  --color-navy-selected: #193151;
+  --color-navy-hover: #3468b2;
+  --color-navy-selected: #24508f;
 
   // Light Blue
   --color-bright-blue-hover: #4c7cc1;
@@ -117,9 +117,9 @@
   --color-american_gray-selected: #494949;
 
   // Blackish
-  --color-blackish: #9a9a9a;
-  --color-blackish-hover: #222222;
-  --color-blackish-selected: #111111;
+  --color-blackish: #7a7a7a;
+  --color-blackish-hover: #525252;
+  --color-blackish-selected: #383838;
 
   // Brown
   --color-brown-hover: #684943;
@@ -147,8 +147,8 @@
 
   // Teal
   --color-teal: #4a8f98;
-  --color-teal-hover: #376268;
-  --color-teal-selected: #274549;
+  --color-teal-hover: #347179;
+  --color-teal-selected: #245960;
 
   // Lavender
   --color-lavender-hover: #a294c8;
@@ -164,6 +164,6 @@
 
   // Pecan
   --color-pecan: #806363;
-  --color-pecan-hover: #605151;
-  --color-pecan-selected: #433939;
+  --color-pecan-hover: #674c4c;
+  --color-pecan-selected: #513939;
 }

--- a/packages/style/src/Themes/dark/_dark-theme-content-colors.scss
+++ b/packages/style/src/Themes/dark/_dark-theme-content-colors.scss
@@ -1,204 +1,169 @@
 @mixin define-dark-theme-content-colors() {
   // green grass
-  --color-grass_green: #359970;
   --color-grass_green-hover: #116846;
   --color-grass_green-selected: #0f4f43;
 
   // done green
-  --color-done-green: #33d391;
   --color-done-green-hover: #0f9b63;
   --color-done-green-selected: #0e7358;
   --color-done-green-selected-with-opacity: rgba(14, 115, 88, 0.6);
 
   // Bright Green
-  --color-bright-green: #b0dc51;
   --color-bright-green-hover: #7ca32b;
   --color-bright-green-selected: #5c7930;
 
   // Saladish
-  --color-saladish: #d5c567;
   --color-saladish-hover: #9d8f3e;
   --color-saladish-selected: #736a3e;
 
   // Egg Yolk
-  --color-egg_yolk: #ffd533;
   --color-egg_yolk-hover: #c29e11;
   --color-egg_yolk-selected: #8d751e;
   --color-egg_yolk-rgb: 255, 213, 51;
 
   // Working on it
-  --color-working_orange: #fdbc64;
   --color-working_orange-hover: #c0873c;
   --color-working_orange-selected: #8c653c;
 
   // Dark orange
-  --color-dark-orange: #ff6d3b;
   --color-dark-orange-hover: #c25531;
   --color-dark-orange-selected: #8d4134;
 
   // Peach Color
-  --color-peach: #ffbdbd;
   --color-peach-hover: #c2888a;
   --color-peach-selected: #8d6674;
 
   // Sunset Color
-  --color-sunset: #ff9191;
   --color-sunset-hover: #c26163;
   --color-sunset-selected: #8d4a58;
   --color-sunset-selected-with-opacity: rgba(141, 74, 88, 0.6);
 
   // Stuck red
-  --color-stuck-red: #e8697d;
   --color-stuck-red-hover: #ad3f51;
   --color-stuck-red-selected: #7f314b;
 
   // Dark red
-  --color-dark-red: #c95c76;
   --color-dark-red-hover: #92334c;
   --color-dark-red-selected: #6b2947;
 
   // Sofia
-  --color-sofia_pink: #ff44a1;
   --color-sofia_pink-hover: #c21e71;
   --color-sofia_pink-selected: #8d1a62;
 
   // Lipstick color
-  --color-lipstick: #ff7bd0;
   --color-lipstick-hover: #c24e9a;
   --color-lipstick-selected: #8d3c7f;
 
   // Bubble
-  --color-bubble: #fbb4f4;
   --color-bubble-hover: #be80ba;
   --color-bubble-selected: #8b6096;
 
   // Purple
-  --color-purple: #b57de3;
   --color-purple-hover: #8050ab;
   --color-purple-selected: #5f3e8b;
 
   // Dark purple
-  --color-dark_purple: #936fda;
   --color-dark_purple-hover: #6344a3;
   --color-dark_purple-selected: #4a3586;
 
   // Berry
-  --color-berry: #9862a1;
   --color-berry-hover: #673971;
   --color-berry-selected: #4d2d62;
 
   // Dark indigo
-  --color-dark_indigo: #6645a9;
+  --color-dark_indigo: #6129ff;
   --color-dark_indigo-hover: #3c1f78;
   --color-dark_indigo-selected: #2e1b67;
 
   // Indigo
-  --color-indigo: #777ae5;
   --color-indigo-hover: #4b4ead;
   --color-indigo-selected: #383c8d;
 
   // Navy
-  --color-navy: #4e73a7;
+  --color-navy: #5684c5;
   --color-navy-hover: #274776;
   --color-navy-selected: #1f3866;
 
   // Light Blue
-  --color-bright-blue: #79affd;
   --color-bright-blue-hover: #4c7cc1;
   --color-bright-blue-selected: #395d9b;
 
   // Dark blue
-  --color-dark-blue: #339ecd;
   --color-dark-blue-hover: #0f6d97;
   --color-dark-blue-selected: #0e527e;
 
   // Aquamarine
-  --color-aquamarine: #71d6d1;
   --color-aquamarine-hover: #469e9b;
   --color-aquamarine-selected: #357580;
 
   // Chili Blue
-  --color-chili-blue: #85d6ff;
   --color-chili-blue-hover: #569ec3;
   --color-chili-blue-selected: #41759d;
 
   // River
-  --color-river: #86b4ca;
   --color-river-hover: #588095;
   --color-river-selected: #42607c;
 
   // winter
-  --color-winter: #aebdca;
   --color-winter-hover: #7b8895;
   --color-winter-selected: #5b667c;
 
   // Explosive
-  --color-explosive: #d0d0d0;
   --color-explosive-hover: #98999a;
   --color-explosive-selected: #70717f;
 
   // American Grey
-  --color-american_gray: #999999;
   --color-american_gray-hover: #69696a;
   --color-american_gray-selected: #4e505e;
 
   // Blackish
-  --color-blackish: #5c5c5c;
+  --color-blackish: #9a9a9a;
   --color-blackish-hover: #222222;
   --color-blackish-selected: #272937;
 
   // Brown
-  --color-brown: #99756c;
   --color-brown-hover: #684943;
   --color-brown-selected: #4d3941;
 
   // Orchid
-  --color-orchid: #e190c0;
   --color-orchid-hover: #b4739a;
   --color-orchid-selected: #85597b;
 
   // Tan
-  --color-tan: #bdab95;
   --color-tan-hover: #978977;
   --color-tan-selected: #716863;
 
   // Sky
-  --color-sky: #b4e9f8;
   --color-sky-hover: #90bac6;
   --color-sky-selected: #6c8a9a;
 
   // Coffee
-  --color-coffee: #ca9a8b;
   --color-coffee-hover: #a27b6f;
   --color-coffee-selected: #795e5d;
 
   // Royal
-  --color-royal: #5591ea;
   --color-royal-hover: #4474bb;
   --color-royal-selected: #375993;
 
   // Teal
-  --color-teal: #457b82;
+  --color-teal: #4a8f98;
   --color-teal-hover: #376268;
   --color-teal-selected: #2e4d58;
 
   // Lavender
-  --color-lavender: #cab9fa;
   --color-lavender-hover: #a294c8;
   --color-lavender-selected: #79709c;
 
   // Steel
-  --color-steel: #bacbed;
   --color-steel-hover: #95a2be;
   --color-steel-selected: #707a95;
 
   // Lilac
-  --color-lilac: #b1adc7;
   --color-lilac-hover: #8e8a9f;
   --color-lilac-selected: #6b697f;
 
   // Pecan
-  --color-pecan: #786565;
+  --color-pecan: #806363;
   --color-pecan-hover: #605151;
   --color-pecan-selected: #4a4148;
 }

--- a/packages/style/src/Themes/dark/_dark-theme-content-colors.scss
+++ b/packages/style/src/Themes/dark/_dark-theme-content-colors.scss
@@ -72,8 +72,8 @@
 
   // Dark indigo
   --color-dark_indigo: #6129ff;
-  --color-dark_indigo-hover: #3c1f78;
-  --color-dark_indigo-selected: #2e1b67;
+  --color-dark_indigo-hover: #4c18dc;
+  --color-dark_indigo-selected: #3c13ae;
 
   // Indigo
   --color-indigo-hover: #4b4ead;
@@ -81,8 +81,8 @@
 
   // Navy
   --color-navy: #5684c5;
-  --color-navy-hover: #274776;
-  --color-navy-selected: #1f3866;
+  --color-navy-hover: #3468b2;
+  --color-navy-selected: #24508f;
 
   // Light Blue
   --color-bright-blue-hover: #4c7cc1;
@@ -117,9 +117,9 @@
   --color-american_gray-selected: #4e505e;
 
   // Blackish
-  --color-blackish: #9a9a9a;
-  --color-blackish-hover: #222222;
-  --color-blackish-selected: #272937;
+  --color-blackish: #7a7a7a;
+  --color-blackish-hover: #525252;
+  --color-blackish-selected: #383838;
 
   // Brown
   --color-brown-hover: #684943;
@@ -147,8 +147,8 @@
 
   // Teal
   --color-teal: #4a8f98;
-  --color-teal-hover: #376268;
-  --color-teal-selected: #2e4d58;
+  --color-teal-hover: #347179;
+  --color-teal-selected: #245960;
 
   // Lavender
   --color-lavender-hover: #a294c8;
@@ -164,6 +164,6 @@
 
   // Pecan
   --color-pecan: #806363;
-  --color-pecan-hover: #605151;
-  --color-pecan-selected: #4a4148;
+  --color-pecan-hover: #674c4c;
+  --color-pecan-selected: #513939;
 }


### PR DESCRIPTION
Due to a11y:
Content colors are now consistent between the themes expect for the specific colors that have changed:
Dark indigo - #6129FF
Navy - #5684C5
Blackish - #9A9A9A
Teal - #4A8F98
Pecan - #806363

https://monday.monday.com/boards/3532714909/pulses/6901932066