### PR TITLE
chore(chromatic): update chromatic cli to latest version

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -202,7 +202,7 @@
     "babel-preset-react": "^6.24.1",
     "boxt": "^1.1.1",
     "chalk": "^4.1.2",
-    "chromatic": "^7.5.3",
+    "chromatic": "^11.5.4",
     "copy-webpack-plugin": "^6.0.3",
     "css-loader": "^6.5.1",
     "csstype": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7436,10 +7436,10 @@ chromatic@^11.3.2:
   resolved "https://registry.npmjs.org/chromatic/-/chromatic-11.4.0.tgz#411a51e82599472b2131a08895faf000e0f9a0fa"
   integrity sha512-/O6OwEUckqKTBGbm9KvYsR/eKCXy4s2eelO38yyfimBIJiL8+TS/pVnBqdtzUqO2hVK4GjrFiea9CnZUG9Akzw==
 
-chromatic@^7.5.3:
-  version "7.6.0"
-  resolved "https://registry.npmjs.org/chromatic/-/chromatic-7.6.0.tgz#b05cad35d47f6410efa5bca6b35af6fae6e540bc"
-  integrity sha512-4MwlX8EDMyfQKf1NXTdUhJ2b0EYueByaVrF75pdFaOzHH7n3OhzknmQYbUSegLiFhKvHuvM8nZvf9SCajO+Cow==
+chromatic@^11.5.4:
+  version "11.5.4"
+  resolved "https://registry.npmjs.org/chromatic/-/chromatic-11.5.4.tgz#57e71f8a5ad54d10656da53c1761198067c189b5"
+  integrity sha512-+J+CopeUSyGUIQJsU6X7CfvSmeVBs0j6LZ9AgF4+XTjI4pFmUiUXsTc00rH9x9W1jCppOaqDXv2kqJJXGDK3mA==
 
 chrome-trace-event@^1.0.2:
   version "1.0.3"


### PR DESCRIPTION
At the end, the publish is done through the GitHub Actions action of Chromatic, so we are, currently, using the latest - it is just to keep up to date also the local dep for running Chromatic locally
Found it out during Chromatic's outage when I've tried to run build through local and got a warning from Chromatic regarding this

https://monday.monday.com/boards/3532714909/pulses/6957006224