### PR TITLE
chore: init 'codemod' - a new package to store Vibe's codemods

### DIFF
--- a/packages/codemod/.eslintrc.json
+++ b/packages/codemod/.eslintrc.json
@@ -1,0 +1,20 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "extends": ["eslint:recommended", "plugin:@typescript-eslint/recommended", "plugin:prettier/recommended"],
+  "ignorePatterns": ["dist", ".eslintrc.json"],
+  "plugins": ["@typescript-eslint", "prettier"],
+  "rules": {
+    "no-unused-vars": "off",
+    "@typescript-eslint/no-unused-vars": [
+      "warn",
+      {
+        "argsIgnorePattern": "^_",
+        "varsIgnorePattern": "^_",
+        "caughtErrorsIgnorePattern": "^_"
+      }
+    ],
+    "no-empty-function": "off",
+    "@typescript-eslint/no-empty-function": ["error", { "allow": ["arrowFunctions"] }],
+    "prettier/prettier": "error"
+  }
+}

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@vibe/codemod",
+  "version": "0.0.0",
+  "description": "Vibe's component library migration tool",
+  "repository": "git+https://github.com/mondaycom/vibe.git",
+  "author": "monday.com",
+  "license": "MIT",
+  "scripts": {
+    "lint": "eslint . --max-warnings 0",
+    "lint:fix": "yarn lint -- --fix"
+  },
+  "dependencies": {
+    "jscodeshift": "^0.16.0"
+  },
+  "devDependencies": {
+    "@types/jscodeshift": "^0.11.11",
+    "@typescript-eslint/eslint-plugin": "^6.21.0",
+    "@typescript-eslint/parser": "^6.21.0",
+    "eslint": "^8.57.0",
+    "eslint-plugin-prettier": "^5.1.3",
+    "jscodeshift": "^0.16.0",
+    "prettier": "^3.3.2",
+    "vitest": "^1.6.0"
+  }
+}

--- a/packages/codemod/tsconfig.json
+++ b/packages/codemod/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "rootDir": ".",
+    "target": "ES6",
+    "module": "commonjs",
+    "lib": ["ES6"],
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true,
+    "moduleResolution": "node",
+    "noImplicitAny": true,
+    "declaration": true,
+    "sourceMap": false,
+    "types": ["node", "jscodeshift"],
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*", "transformations/**/*", "types/**/*"],
+  "exclude": ["node_modules", "dist", "**/*.test.ts"]
+}

--- a/packages/codemod/tsconfig.test.json
+++ b/packages/codemod/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "./dist-test",
+    "noEmit": false,
+    "types": ["vitest/globals"]
+  },
+  "include": ["vitest.config.ts", "test/**/setup.ts", "**/*.test.ts"],
+  "exclude": ["node_modules", "dist"]
+}

--- a/packages/codemod/vitest.config.ts
+++ b/packages/codemod/vitest.config.ts
@@ -1,0 +1,14 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    globals: true,
+    environment: "node",
+    setupFiles: ["test/setup.ts"],
+    include: ["**/__tests__/**/*.test.ts"],
+    clearMocks: true,
+    typecheck: {
+      enabled: true
+    }
+  }
+});


### PR DESCRIPTION
initiating a new package called "codemod"
at the end, this should publish a package to act as a CLI tool for migrating between Vibe's majors (currently for `core`).
package name should be `@vibe/codemod`

https://monday.monday.com/boards/3532714909/pulses/6798809703