### PR TITLE
fix(Table): hover cell background var should be declared inside the table selector and not on :root

### DIFF
--- a/packages/core/src/components/Table/Table/Table.module.scss
+++ b/packages/core/src/components/Table/Table/Table.module.scss
@@ -1,13 +1,11 @@
-:root {
+.table {
   --sticky-cell-hover-background: linear-gradient(
       to right,
       var(--primary-background-hover-color),
       var(--primary-background-hover-color)
     ),
     linear-gradient(to right, var(--primary-background-color), var(--primary-background-color));
-}
 
-.table {
   background-color: var(--primary-background-color);
   overflow: auto;
   width: 100%;


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/6996492663