### PR TITLE
feat(Toggle): pass event as 2nd argument to allow working with react-hook-form

### DIFF
--- a/packages/core/src/components/Switch/Switch.tsx
+++ b/packages/core/src/components/Switch/Switch.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, ReactElement, useMemo } from "react";
+import React, { ChangeEvent, forwardRef, ReactElement, useMemo } from "react";
 import cx from "classnames";
 import useSwitch from "../../hooks/useSwitch";
 import { VibeComponent, VibeComponentProps } from "../../types";
@@ -14,7 +14,7 @@ export interface SwitchProps extends VibeComponentProps {
   ariaLabelledBy?: string;
   checked?: boolean;
   inputClassName?: string;
-  onChange?: (value: boolean) => void;
+  onChange?: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void;
   ariaControls?: string;
   defaultChecked?: boolean;
   children?: ReactElement<MockToggleProps>;

--- a/packages/core/src/components/Toggle/Toggle.tsx
+++ b/packages/core/src/components/Toggle/Toggle.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { ChangeEvent, forwardRef } from "react";
 import cx from "classnames";
 import { noop as NOOP } from "lodash-es";
 import { Switch } from "../Switch/Switch";
@@ -20,7 +20,7 @@ export interface ToggleProps extends VibeComponentProps {
   toggleSelectedClassName?: string;
   isDefaultSelected?: boolean;
   isSelected?: boolean;
-  onChange?: (value: boolean) => void;
+  onChange?: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void;
   value?: string;
   name?: string;
   /**

--- a/packages/core/src/components/Toggle/__tests__/Toggle.test.js
+++ b/packages/core/src/components/Toggle/__tests__/Toggle.test.js
@@ -57,7 +57,7 @@ describe("Toggle tests", () => {
 
       const toggle = getByRole(toggleRole);
       userEvent.click(toggle);
-      expect(onClickMock).toHaveBeenCalledWith(false);
+      expect(onClickMock).toHaveBeenCalledWith(false, expect.anything());
     });
   });
 
@@ -71,7 +71,7 @@ describe("Toggle tests", () => {
 
     const toggle = getByRole(toggleRole);
     userEvent.click(toggle);
-    expect(onClickMock).toHaveBeenCalledWith(false);
+    expect(onClickMock).toHaveBeenCalledWith(false, expect.anything());
   });
 
   describe("a11y", () => {

--- a/packages/core/src/hooks/useSwitch/__tests__/useSwitch.test.ts
+++ b/packages/core/src/hooks/useSwitch/__tests__/useSwitch.test.ts
@@ -1,5 +1,6 @@
 import { act, cleanup, renderHook, RenderResult } from "@testing-library/react-hooks";
 import useSwitch, { UseSwitchProps } from "../index";
+import { ChangeEvent } from "react";
 
 describe("useSwitch", () => {
   afterEach(() => {
@@ -70,7 +71,7 @@ describe("useSwitch", () => {
       const { result } = renderHookForTest({ defaultChecked: true, onChange });
       callOnChange(result);
       expect(onChange).toBeCalledTimes(1);
-      expect(onChange).toBeCalledWith(false);
+      expect(onChange).toBeCalledWith(false, expect.anything());
     });
   });
 
@@ -79,8 +80,9 @@ describe("useSwitch", () => {
   }
 
   function callOnChange(result: RenderResult<ReturnType<typeof useSwitch>>) {
+    const mockEvent = {} as ChangeEvent<HTMLInputElement>;
     act(() => {
-      result.current.onChange();
+      result.current.onChange(mockEvent);
     });
   }
 });

--- a/packages/core/src/hooks/useSwitch/index.ts
+++ b/packages/core/src/hooks/useSwitch/index.ts
@@ -1,4 +1,4 @@
-import { ChangeEvent, ChangeEventHandler, useCallback, useEffect, useState } from "react";
+import { ChangeEvent, useCallback, useEffect, useState } from "react";
 
 enum SwitchRole {
   CHECKBOX = "checkbox",
@@ -8,7 +8,7 @@ enum SwitchRole {
 export interface UseSwitchProps {
   isChecked?: boolean;
   defaultChecked?: boolean;
-  onChange?: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (value: boolean, event?: ChangeEvent<HTMLInputElement>) => void;
   isDisabled?: boolean;
 }
 
@@ -17,8 +17,8 @@ export default function useSwitch({ isChecked, defaultChecked, onChange, isDisab
   const overrideCheckedInitial = isChecked ?? !!defaultChecked;
   const [overrideChecked, setOverrideChecked] = useState(overrideCheckedInitial);
 
-  const overrideOnChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
-    event => {
+  const overrideOnChange = useCallback(
+    (event?: ChangeEvent<HTMLInputElement>) => {
       if (isDisabled) {
         return;
       }

--- a/packages/core/src/hooks/useSwitch/index.ts
+++ b/packages/core/src/hooks/useSwitch/index.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useState } from "react";
+import { ChangeEvent, ChangeEventHandler, useCallback, useEffect, useState } from "react";
 
 enum SwitchRole {
   CHECKBOX = "checkbox",
@@ -8,7 +8,7 @@ enum SwitchRole {
 export interface UseSwitchProps {
   isChecked?: boolean;
   defaultChecked?: boolean;
-  onChange?: (value: boolean) => void;
+  onChange?: (value: boolean, event: ChangeEvent<HTMLInputElement>) => void;
   isDisabled?: boolean;
 }
 
@@ -17,16 +17,19 @@ export default function useSwitch({ isChecked, defaultChecked, onChange, isDisab
   const overrideCheckedInitial = isChecked ?? !!defaultChecked;
   const [overrideChecked, setOverrideChecked] = useState(overrideCheckedInitial);
 
-  const overrideOnChange = useCallback(() => {
-    if (isDisabled) {
-      return;
-    }
-    const newChecked = !overrideChecked;
-    if (isChecked === undefined) {
-      setOverrideChecked(newChecked);
-    }
-    onChange && onChange(newChecked);
-  }, [isChecked, isDisabled, onChange, overrideChecked]);
+  const overrideOnChange = useCallback<ChangeEventHandler<HTMLInputElement>>(
+    event => {
+      if (isDisabled) {
+        return;
+      }
+      const newChecked = !overrideChecked;
+      if (isChecked === undefined) {
+        setOverrideChecked(newChecked);
+      }
+      onChange && onChange(newChecked, event);
+    },
+    [isChecked, isDisabled, onChange, overrideChecked]
+  );
 
   useEffect(() => {
     if (isChecked !== undefined) {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/7035594767

- **useSwitch**: pass `event` as 2nd argument for `onChange`
- **Toggle**: pass `event` as 2nd argument for `onChange`
- **Switch**: pass `event` as 2nd argument for `onChange`