### PR TITLE
fix(Dropdown): nanoid 4+ supports only ESM, we should still support CJS

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "framer-motion": "^6.5.1",
     "lodash-es": "^4.17.21",
     "monday-ui-style": "0.10.0",
-    "nanoid": "^5.0.7",
+    "nanoid": "^3.3.7",
     "prop-types": "^15.8.1",
     "react-dates": "21.8.0",
     "react-inlinesvg": "^3.0.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14690,11 +14690,6 @@ nanoid@^3.3.6, nanoid@^3.3.7:
   resolved "https://registry.npmjs.org/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
-nanoid@^5.0.7:
-  version "5.0.7"
-  resolved "https://registry.npmjs.org/nanoid/-/nanoid-5.0.7.tgz#6452e8c5a816861fd9d2b898399f7e5fd6944cc6"
-  integrity sha512-oLxFY2gd2IqnjcYyOXD8XGCftpGtZP2AbHbOkthDkvRywH5ayNtPVy9YlOPcHckXzbLTCHpkb7FB+yuxKV13pQ==
-
 nanomatch@^1.2.9:
   version "1.2.13"
   resolved "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz#b87a8aa4fc0de8fe6be88895b38983ff265bd119"


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/7086495216

@rivka-ungar @talkor 