### PR TITLE
feat: add onClear prop to Search component

### DIFF
--- a/packages/core/src/components/Search/Search.tsx
+++ b/packages/core/src/components/Search/Search.tsx
@@ -34,6 +34,7 @@ const Search = forwardRef(
       onChange,
       onFocus,
       onBlur,
+      onClear,
       className,
       ariaExpanded,
       ariaHasPopup,
@@ -54,6 +55,10 @@ const Search = forwardRef(
     const onClearButtonClick = useCallback(() => {
       if (disabled) {
         return;
+      }
+
+      if (onClear) {
+        onClear();
       }
 
       inputRef.current?.focus?.();

--- a/packages/core/src/components/Search/Search.types.ts
+++ b/packages/core/src/components/Search/Search.types.ts
@@ -89,4 +89,8 @@ export interface SearchProps extends VibeComponentProps {
    * Callback function that is called when the search input gains focus.
    */
   onFocus?: (event: React.FocusEvent) => void;
+  /**
+   * Callback function that is called when the clear button is clicked.
+   */
+  onClear?: () => void;
 }


### PR DESCRIPTION
Hi everyone!

Attending the idea discussion [#2101](https://github.com/mondaycom/vibe/discussions/2101), I've added the `onClear` prop to the `Search` component. It's a simple change, but at the same time, a useful one.

I decided to just add a verification inside of the function that clears the search input value once the users clicks the clear button, keeping the existing logic untouched and adding another step before clearing the input value.

I hope this change make sense to you guys!

### Checklist
- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

Thanks in advance!