### PR TITLE
fix: Add support for generic types in the TableVirtualizedBody component

### DIFF
--- a/packages/core/src/components/Table/Table/__stories__/Table.stories.helpers.tsx
+++ b/packages/core/src/components/Table/Table/__stories__/Table.stories.helpers.tsx
@@ -2,7 +2,6 @@ import React from "react";
 import Avatar from "../../../Avatar/Avatar";
 import { Calendar, Doc, Status } from "../../../Icon/Icons";
 import { LabelColor } from "../../../Label/LabelConstants";
-import { TableVirtualizedRow } from "../../TableVirtualizedBody/TableVirtualizedBody";
 import { ITableColumn } from "../Table";
 
 export const doAndDontIconsRuleColumns = [

--- a/packages/core/src/components/Table/Table/__stories__/Table.stories.helpers.tsx
+++ b/packages/core/src/components/Table/Table/__stories__/Table.stories.helpers.tsx
@@ -118,7 +118,7 @@ export const emailTableData = [
   }
 ];
 
-export const emailColumns = [
+export const emailColumns: ITableColumn[] = [
   {
     id: "sentOn",
     title: "Sent on",
@@ -258,14 +258,14 @@ export const highlightableTableData = [
   }
 ];
 
-export const priorityColumnToLabelColor = {
+export const priorityColumnToLabelColor: { [key: string]: LabelColor } = {
   Urgent: LabelColor.NEGATIVE,
   High: LabelColor.DARK,
   Normal: LabelColor.PRIMARY,
   Low: LabelColor.POSITIVE
 };
 
-export const statusColumnToLabelColor = {
+export const statusColumnToLabelColor: { [key: string]: LabelColor } = {
   Sent: LabelColor.POSITIVE,
   Queued: LabelColor.DARK,
   Failed: LabelColor.NEGATIVE,
@@ -307,7 +307,7 @@ export const scrollTableColumns = [
   }
 ];
 
-export const virtualizedScrollTableData: TableVirtualizedRow[] = [...new Array(5000)].map((_, index) => ({
+export const virtualizedScrollTableData = [...new Array(5000)].map((_, index) => ({
   id: index.toString(),
   num: index,
   text: `This is line number ${index}`
@@ -325,7 +325,7 @@ export const virtualizedScrollTableColumns: ITableColumn[] = [
   }
 ];
 
-export function sort(columnId: string, sortState: "asc" | "desc" | "none", tableData: []) {
+export function sort<T>(columnId: keyof T, sortState: "asc" | "desc" | "none", tableData: T[]) {
   if (sortState === "asc") {
     return [...tableData].sort((a, b) => {
       return b[columnId] > a[columnId] ? 1 : -1;

--- a/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
@@ -403,14 +403,14 @@ export const Borders = {
 export const TableHeaderFunctionality = {
   render: () => {
     const [tableData, setTableData] = useState(emailTableData);
-    const [sorting, setSorting] = useState<{[key: string]: "asc" | "desc" | "none"}>({});
+    const [sorting, setSorting] = useState<{ [key: string]: "asc" | "desc" | "none" }>({});
 
     const onSort = (columnId: string, sortState: "asc" | "desc" | "none") => {
       setSorting({
         [columnId]: sortState
       });
 
-      setTableData(sort(columnId as keyof typeof tableData[number], sortState, tableData));
+      setTableData(sort(columnId as keyof (typeof tableData)[number], sortState, tableData));
     };
 
     return (
@@ -530,7 +530,7 @@ export const Scroll = {
 
 export const VirtualizedScroll = {
   render: () => {
-    const Row = ({ num, text }: typeof virtualizedScrollTableData[number]) => {
+    const Row = ({ num, text }: (typeof virtualizedScrollTableData)[number]) => {
       return (
         <TableRow>
           <TableCell>{num}</TableCell>
@@ -563,7 +563,7 @@ export const VirtualizedScroll = {
 
 export const HighlightedRow = {
   render: () => {
-    const shouldRowBeHighlighted = (rowItem: typeof emailTableData[number]) => {
+    const shouldRowBeHighlighted = (rowItem: (typeof emailTableData)[number]) => {
       return rowItem.id === "2";
     };
 

--- a/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from "react";
-import Table from "../Table";
+import Table, { ITableColumn, ITableProps } from "../Table";
 import TableHeader from "../../TableHeader/TableHeader";
 import TableHeaderCell from "../../TableHeaderCell/TableHeaderCell";
 import TableBody from "../../TableBody/TableBody";
@@ -23,6 +23,7 @@ import {
   virtualizedScrollTableColumns,
   virtualizedScrollTableData
 } from "./Table.stories.helpers";
+import { LabelColor } from "../../../Label/LabelConstants";
 
 const metaSettings = createStoryMetaSettingsDecorator({
   component: Table,
@@ -44,7 +45,7 @@ export default {
   decorators: metaSettings.decorators
 };
 
-const tableTemplate = args => <Table {...args}></Table>;
+const tableTemplate = (args: ITableProps) => <Table {...args}></Table>;
 
 export const Overview = {
   render: tableTemplate.bind({}),
@@ -167,7 +168,7 @@ export const Overview = {
               <TableAvatar text={rowItem.sentBy} />
             </TableCell>
             <TableCell>
-              <Label text={rowItem.status} color="positive" isAnimationDisabled />
+              <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
             </TableCell>
             <TableCell>{rowItem.emailsSent}</TableCell>
           </TableRow>
@@ -180,7 +181,7 @@ export const Overview = {
 
 export const Sizes = {
   render: () => {
-    const columns = [
+    const columns: ITableColumn[] = [
       {
         id: "sentOn",
         title: "Sent on",
@@ -264,7 +265,7 @@ export const Sizes = {
     );
   },
   decorators: [
-    Story => (
+    (Story: typeof React.Component) => (
       <Flex align={Flex.align.START} justify={Flex.justify.SPACE_BETWEEN} style={{ flex: 1 }}>
         <Story />
       </Flex>
@@ -275,7 +276,7 @@ export const Sizes = {
 
 export const Borders = {
   render: () => {
-    const columns = [
+    const columns: ITableColumn[] = [
       {
         id: "sentOn",
         title: "Sent on",
@@ -357,7 +358,7 @@ export const Borders = {
                   <TableAvatar text={rowItem.sentBy} />
                 </TableCell>
                 <TableCell>
-                  <Label text={rowItem.status} color="positive" isAnimationDisabled />
+                  <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
                 </TableCell>
                 <TableCell>{rowItem.emailsSent}</TableCell>
               </TableRow>
@@ -379,7 +380,7 @@ export const Borders = {
                   <TableAvatar text={rowItem.sentBy} />
                 </TableCell>
                 <TableCell>
-                  <Label text={rowItem.status} color="positive" isAnimationDisabled />
+                  <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
                 </TableCell>
                 <TableCell>{rowItem.emailsSent}</TableCell>
               </TableRow>
@@ -390,7 +391,7 @@ export const Borders = {
     );
   },
   decorators: [
-    Story => (
+    (Story: typeof React.Component) => (
       <Flex direction={Flex.directions.COLUMN} gap={40}>
         <Story />
       </Flex>
@@ -402,14 +403,14 @@ export const Borders = {
 export const TableHeaderFunctionality = {
   render: () => {
     const [tableData, setTableData] = useState(emailTableData);
-    const [sorting, setSorting] = useState({});
+    const [sorting, setSorting] = useState<{[key: string]: "asc" | "desc" | "none"}>({});
 
-    const onSort = (columnId, sortState) => {
+    const onSort = (columnId: string, sortState: "asc" | "desc" | "none") => {
       setSorting({
         [columnId]: sortState
       });
 
-      setTableData(sort(columnId, sortState, tableData));
+      setTableData(sort(columnId as keyof typeof tableData[number], sortState, tableData));
     };
 
     return (
@@ -435,7 +436,7 @@ export const TableHeaderFunctionality = {
                 <TableAvatar text={rowItem.sentBy} />
               </TableCell>
               <TableCell>
-                <Label text={rowItem.status} isAnimationDisabled color="positive" />
+                <Label text={rowItem.status} isAnimationDisabled color={LabelColor.POSITIVE} />
               </TableCell>
               <TableCell>{rowItem.emailsSent}</TableCell>
             </TableRow>
@@ -472,7 +473,7 @@ export const Loading = {
               <TableAvatar text={rowItem.sentBy} />
             </TableCell>
             <TableCell>
-              <Label text={rowItem.status} color="positive" isAnimationDisabled />
+              <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
             </TableCell>
             <TableCell>{rowItem.emailsSent}</TableCell>
           </TableRow>
@@ -529,7 +530,7 @@ export const Scroll = {
 
 export const VirtualizedScroll = {
   render: () => {
-    const Row = ({ _id, num, text }) => {
+    const Row = ({ num, text }: typeof virtualizedScrollTableData[number]) => {
       return (
         <TableRow>
           <TableCell>{num}</TableCell>
@@ -562,7 +563,7 @@ export const VirtualizedScroll = {
 
 export const HighlightedRow = {
   render: () => {
-    const shouldRowBeHighlighted = rowItem => {
+    const shouldRowBeHighlighted = (rowItem: typeof emailTableData[number]) => {
       return rowItem.id === "2";
     };
 
@@ -582,7 +583,7 @@ export const HighlightedRow = {
                 <TableAvatar text={rowItem.sentBy} />
               </TableCell>
               <TableCell>
-                <Label text={rowItem.status} isAnimationDisabled color="positive" />
+                <Label text={rowItem.status} isAnimationDisabled color={LabelColor.POSITIVE} />
               </TableCell>
               <TableCell>{rowItem.emailsSent}</TableCell>
             </TableRow>

--- a/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
+++ b/packages/core/src/components/Table/Table/__stories__/Table.stories.tsx
@@ -23,7 +23,6 @@ import {
   virtualizedScrollTableColumns,
   virtualizedScrollTableData
 } from "./Table.stories.helpers";
-import { LabelColor } from "../../../Label/LabelConstants";
 
 const metaSettings = createStoryMetaSettingsDecorator({
   component: Table,
@@ -168,7 +167,7 @@ export const Overview = {
               <TableAvatar text={rowItem.sentBy} />
             </TableCell>
             <TableCell>
-              <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
+              <Label text={rowItem.status} color={Label.colors.POSITIVE} isAnimationDisabled />
             </TableCell>
             <TableCell>{rowItem.emailsSent}</TableCell>
           </TableRow>
@@ -358,7 +357,7 @@ export const Borders = {
                   <TableAvatar text={rowItem.sentBy} />
                 </TableCell>
                 <TableCell>
-                  <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
+                  <Label text={rowItem.status} color={Label.colors.POSITIVE} isAnimationDisabled />
                 </TableCell>
                 <TableCell>{rowItem.emailsSent}</TableCell>
               </TableRow>
@@ -380,7 +379,7 @@ export const Borders = {
                   <TableAvatar text={rowItem.sentBy} />
                 </TableCell>
                 <TableCell>
-                  <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
+                  <Label text={rowItem.status} color={Label.colors.POSITIVE} isAnimationDisabled />
                 </TableCell>
                 <TableCell>{rowItem.emailsSent}</TableCell>
               </TableRow>
@@ -436,7 +435,7 @@ export const TableHeaderFunctionality = {
                 <TableAvatar text={rowItem.sentBy} />
               </TableCell>
               <TableCell>
-                <Label text={rowItem.status} isAnimationDisabled color={LabelColor.POSITIVE} />
+                <Label text={rowItem.status} isAnimationDisabled color={Label.colors.POSITIVE} />
               </TableCell>
               <TableCell>{rowItem.emailsSent}</TableCell>
             </TableRow>
@@ -473,7 +472,7 @@ export const Loading = {
               <TableAvatar text={rowItem.sentBy} />
             </TableCell>
             <TableCell>
-              <Label text={rowItem.status} color={LabelColor.POSITIVE} isAnimationDisabled />
+              <Label text={rowItem.status} color={Label.colors.POSITIVE} isAnimationDisabled />
             </TableCell>
             <TableCell>{rowItem.emailsSent}</TableCell>
           </TableRow>
@@ -583,7 +582,7 @@ export const HighlightedRow = {
                 <TableAvatar text={rowItem.sentBy} />
               </TableCell>
               <TableCell>
-                <Label text={rowItem.status} isAnimationDisabled color={LabelColor.POSITIVE} />
+                <Label text={rowItem.status} isAnimationDisabled color={Label.colors.POSITIVE} />
               </TableCell>
               <TableCell>{rowItem.emailsSent}</TableCell>
             </TableRow>

--- a/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -13,14 +13,15 @@ import { useTableRowMenu } from "../context/TableRowMenuContext/TableRowMenuCont
 
 export type TableVirtualizedRow = Record<string, unknown> & { id: string };
 
-export interface ITableVirtualizedBodyProps<T extends TableVirtualizedRow> extends VibeComponentProps {
+export interface ITableVirtualizedBodyProps<T extends TableVirtualizedRow = TableVirtualizedRow>
+  extends VibeComponentProps {
   items: T[];
   rowRenderer: (item: T) => JSX.Element;
   onScroll?: (horizontalScrollDirection: ScrollDirection, scrollTop: number, scrollUpdateWasRequested: boolean) => void;
 }
 
 const TableVirtualizedBody = forwardRef(
-  <T extends TableVirtualizedRow>(
+  <T extends TableVirtualizedRow = TableVirtualizedRow>(
     { items, rowRenderer, onScroll, id, className, "data-testid": dataTestId }: ITableVirtualizedBodyProps<T>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {

--- a/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -11,18 +11,17 @@ import { RowHeights } from "../Table/TableConsts";
 import AutoSizer, { Size as AutoSizerSize } from "react-virtualized-auto-sizer";
 import { useTableRowMenu } from "../context/TableRowMenuContext/TableRowMenuContext";
 
-export type TableVirtualizedRows = Array<Record<string, unknown> & { id: string }>;
-export type TableVirtualizedRow = TableVirtualizedRows[number];
+export type TableVirtualizedRow = Record<string, unknown> & { id: string };
 
-export interface ITableVirtualizedBodyProps extends VibeComponentProps {
-  items: TableVirtualizedRows;
-  rowRenderer: (item: TableVirtualizedRow) => JSX.Element;
+export interface ITableVirtualizedBodyProps<T extends TableVirtualizedRow> extends VibeComponentProps {
+  items: T[];
+  rowRenderer: (item: T) => JSX.Element;
   onScroll?: (horizontalScrollDirection: ScrollDirection, scrollTop: number, scrollUpdateWasRequested: boolean) => void;
 }
 
 const TableVirtualizedBody = forwardRef(
-  (
-    { items, rowRenderer, onScroll, id, className, "data-testid": dataTestId }: ITableVirtualizedBodyProps,
+  <T extends TableVirtualizedRow>(
+    { items, rowRenderer, onScroll, id, className, "data-testid": dataTestId }: ITableVirtualizedBodyProps<T>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
     const { size, virtualizedListRef, onVirtualizedListScroll, markTableAsVirtualized } = useTable();


### PR DESCRIPTION
## Overview
TableVirtualizedBody doesn't support generic types. Which means that if you have typescript configured in the project with `"strict": true`, you will get an error like this:
![image](https://github.com/user-attachments/assets/4a456ae7-e2cd-4211-a9a0-6f79eeaf1605)

## Changes:
- Added support for generic types in `TableVirtualizedBody` component, to make it more type-safe
- Converted `Table.stories.js` file to `.tsx` + necessary types updates (without logic changes)

### P.S. 
At the moment vibe repository is NOT strictly typed (`"strict": true` in `tsconfig.json`). Therefore, TableVirtualizedBody component works fine in storybook even without my changes. Which makes almost impossible to catch that kind of bug during development.

To avoid similar bugs in future, make Vibe type-safe and basically make it possible to use Vibe safely in the projects which are strictly typed, I highly encourage you to start gradually migrating to `"strict": true` typescript setting. It might be a long process, but it worth it.
