### PR TITLE
fix(useSwitch): type guard to fix breaking change we accidentally introduced in previous version

### DIFF
--- a/packages/core/src/hooks/useSwitch/__tests__/useSwitch.test.ts
+++ b/packages/core/src/hooks/useSwitch/__tests__/useSwitch.test.ts
@@ -71,7 +71,7 @@ describe("useSwitch", () => {
       const { result } = renderHookForTest({ defaultChecked: true, onChange });
       callOnChange(result);
       expect(onChange).toBeCalledTimes(1);
-      expect(onChange).toBeCalledWith(false, expect.anything());
+      expect(onChange).toBeCalledWith(false);
     });
   });
 

--- a/packages/core/src/hooks/useSwitch/index.ts
+++ b/packages/core/src/hooks/useSwitch/index.ts
@@ -8,7 +8,7 @@ enum SwitchRole {
 export interface UseSwitchProps {
   isChecked?: boolean;
   defaultChecked?: boolean;
-  onChange?: (value: boolean, event?: ChangeEvent<HTMLInputElement>) => void;
+  onChange?: (value: boolean, event?: ChangeEvent<HTMLInputElement> | any) => void;
   isDisabled?: boolean;
 }
 
@@ -18,7 +18,8 @@ export default function useSwitch({ isChecked, defaultChecked, onChange, isDisab
   const [overrideChecked, setOverrideChecked] = useState(overrideCheckedInitial);
 
   const overrideOnChange = useCallback(
-    (event?: ChangeEvent<HTMLInputElement>) => {
+    // TODO fix in next major. We need to remove any type
+    (event?: ChangeEvent<HTMLInputElement> | any) => {
       if (isDisabled) {
         return;
       }
@@ -26,7 +27,8 @@ export default function useSwitch({ isChecked, defaultChecked, onChange, isDisab
       if (isChecked === undefined) {
         setOverrideChecked(newChecked);
       }
-      onChange && onChange(newChecked, event);
+      // TODO fix in next major. We should always pass the event
+      onChange && onChange(newChecked, event && typeof event === "object" && "target" in event ? event : undefined);
     },
     [isChecked, isDisabled, onChange, overrideChecked]
   );

--- a/packages/core/src/hooks/useSwitch/index.ts
+++ b/packages/core/src/hooks/useSwitch/index.ts
@@ -28,7 +28,11 @@ export default function useSwitch({ isChecked, defaultChecked, onChange, isDisab
         setOverrideChecked(newChecked);
       }
       // TODO fix in next major. We should always pass the event
-      onChange && onChange(newChecked, event && typeof event === "object" && "target" in event ? event : undefined);
+      if (event && typeof event === "object" && "target" in event) {
+        onChange?.(newChecked, event);
+      } else {
+        onChange?.(newChecked);
+      }
     },
     [isChecked, isDisabled, onChange, overrideChecked]
   );


### PR DESCRIPTION
We introduced breaking changes by mistake in #2243.
We should type the `event` as `any` and only send it back in the callback if it is a real event.

https://monday.monday.com/boards/3532714909/pulses/7139886355

Created a task for next major to remove the typeguard:
https://monday.monday.com/boards/6841644723/pulses/7169775263