### PR TITLE
fix(AvatarGroup): avatar in tipseen without image is wrong size

### DIFF
--- a/packages/core/src/components/AvatarGroup/AvatarGroupCounterTooltipHelper.tsx
+++ b/packages/core/src/components/AvatarGroup/AvatarGroupCounterTooltipHelper.tsx
@@ -140,6 +140,7 @@ export const avatarRenderer = (
             customSize={AVATAR_GROUP_COUNTER_AVATAR_SIZE}
             type={type || avatarProps?.type}
             tabIndex={-1}
+            size={Avatar.sizes.SMALL}
           />
           {!displayAsGrid && (
             <div id={labelId} className={avatarGroupCounterTooltipContentStyles.tooltipAvatarItemTitle}>


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/7205735679