### PR TITLE
ci(prerelease): use commit sha for prerelease version naming

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -35,7 +35,7 @@ jobs:
         id: generate-versions
         run: |
           commit_sha=$COMMIT_SHA
-          preid="test-${commit_sha:0:5}"
+          preid="alpha-${commit_sha:0:5}"
 
           full_output=$(yarn lerna version --exact --conventional-commits --conventional-prerelease --json --no-changelog --no-push --preid "$preid" -y)
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -22,6 +22,9 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
+      - name: Set variables
+        run: |
+          echo "COMMIT_SHA=${GITHUB_SHA}" >> $GITHUB_ENV
       - name: Run Setup
         uses: ./.github/actions/setup
         with:
@@ -31,10 +34,10 @@ jobs:
       - name: Generate new versions
         id: generate-versions
         run: |
-          preid=${{ github.ref_name }}
-          normalized_pre_id=$(echo "$preid" | tr -dc '[:alnum:]\n\r' | tr '[:upper:]' '[:lower:]')
+          commit_sha=$COMMIT_SHA
+          preid="test-${commit_sha:0:5}"
 
-          full_output=$(yarn lerna version --exact --conventional-commits --conventional-prerelease --json --no-changelog --no-push --preid "$normalized_pre_id" -y)
+          full_output=$(yarn lerna version --exact --conventional-commits --conventional-prerelease --json --no-changelog --no-push --preid "$preid" -y)
 
           # extract only the JSON portion from the full output, excluding yarn logs
           json_output=$(echo "$full_output" | awk '/^\[/{p=1} p; /\]/{p=0}' )

--- a/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.helpers.tsx
+++ b/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.helpers.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { StorybookLink, Tip } from "vibe-storybook-components";
+import { Tip, StorybookLink } from "vibe-storybook-components";
 
 export const TipCheckYourself = () => (
   <Tip title="Check yourself">

--- a/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.helpers.tsx
+++ b/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.helpers.tsx
@@ -1,5 +1,5 @@
 import React from "react";
-import { Tip, StorybookLink } from "vibe-storybook-components";
+import { StorybookLink, Tip } from "vibe-storybook-components";
 
 export const TipCheckYourself = () => (
   <Tip title="Check yourself">

--- a/packages/core/src/components/Menu/Menu/__stories__/Menu.stories.helpers.tsx
+++ b/packages/core/src/components/Menu/Menu/__stories__/Menu.stories.helpers.tsx
@@ -3,7 +3,7 @@ import DialogContentContainer from "../../../DialogContentContainer/DialogConten
 import Menu from "../../../Menu/Menu/Menu";
 import MenuItem from "../../../Menu/MenuItem/MenuItem";
 import Search from "../../../Search/Search";
-import { Filter, Calendar, Wand } from "../../../Icon/Icons";
+import { Calendar, Filter, Wand } from "../../../Icon/Icons";
 import styles from "./Menu.stories.module.scss";
 import React from "react";
 

--- a/packages/core/src/components/Menu/Menu/__stories__/Menu.stories.helpers.tsx
+++ b/packages/core/src/components/Menu/Menu/__stories__/Menu.stories.helpers.tsx
@@ -3,7 +3,7 @@ import DialogContentContainer from "../../../DialogContentContainer/DialogConten
 import Menu from "../../../Menu/Menu/Menu";
 import MenuItem from "../../../Menu/MenuItem/MenuItem";
 import Search from "../../../Search/Search";
-import { Calendar, Filter, Wand } from "../../../Icon/Icons";
+import { Filter, Calendar, Wand } from "../../../Icon/Icons";
 import styles from "./Menu.stories.module.scss";
 import React from "react";
 


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/7086730463
https://monday.monday.com/boards/3532714909/pulses/7086725168

<img width="798" alt="Screenshot 2024-08-15 at 16 42 02" src="https://github.com/user-attachments/assets/f0350f65-9578-45b2-bf3c-7dcb44d6da5f">


It looks much cleaner IMO, and the purpose of such version is clearer (alpha versions). Plus it's based on the commit sha so it'll be unique and can be published multiple times per PR