### PR TITLE
feat(ModalContent): content component to be used in modal by consumers

### DIFF
--- a/packages/core/src/components/ModalNew/ModalContent/ModalContent.module.scss
+++ b/packages/core/src/components/ModalNew/ModalContent/ModalContent.module.scss
@@ -1,0 +1,7 @@
+@import "~monday-ui-style/dist/mixins";
+
+.content {
+  padding-block-end: var(--spacing-xl);
+  overflow: auto;
+  @include scroller;
+}

--- a/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
+++ b/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
@@ -1,0 +1,26 @@
+import React, { forwardRef } from "react";
+import cx from "classnames";
+import { getTestId } from "../../../tests/test-ids-utils";
+import { ComponentDefaultTestId } from "../../../tests/constants";
+import styles from "./ModalContent.module.scss";
+import { ModalContentProps } from "./ModalContent.types";
+
+const ModalContent = forwardRef(
+  (
+    { children, className, id, "data-testid": dataTestId }: ModalContentProps,
+    ref: React.ForwardedRef<HTMLDivElement>
+  ) => {
+    return (
+      <div
+        ref={ref}
+        className={cx(styles.content, className)}
+        id={id}
+        data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT_CONTENT, id)}
+      >
+        {children}
+      </div>
+    );
+  }
+);
+
+export default ModalContent;

--- a/packages/core/src/components/ModalNew/ModalContent/ModalContent.types.ts
+++ b/packages/core/src/components/ModalNew/ModalContent/ModalContent.types.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import { VibeComponentProps } from "../../../types";
+
+export interface ModalContentProps extends VibeComponentProps {
+  children?: React.ReactNode;
+}

--- a/packages/core/src/tests/constants.ts
+++ b/packages/core/src/tests/constants.ts
@@ -103,6 +103,7 @@ export enum ComponentDefaultTestId {
   MODAL_CONTENT = "modal-content",
   MODAL_HEADER = "modal-header",
   MODAL_FOOTER_BUTTONS = "modal-footer-buttons",
+  MODAL_NEXT_CONTENT = "modal-content",
   FORMATTED_NUMBER = "formatted-number",
   HIDDEN_TEXT = "hidden-text",
   DIALOG_CONTENT_CONTAINER = "dialog-content-container",


### PR DESCRIPTION
### ModalContent 🌐

![image](https://github.com/user-attachments/assets/fd1dd708-8fe6-411d-a237-c16be696b675)

Props:

Name | Type | Default | Description
-- | -- | -- | --
children | React.ReactNode |   | Can be anything

Usage example:
```typescript
<ModalContent>
  Whatever you want it to be
</ModalContent>
```