### PR TITLE
feat(ModalTopActions): top actions component for internal use

### DIFF
--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
@@ -1,0 +1,5 @@
+.actions {
+  position: absolute;
+  right: var(--spacing-large);
+  top: var(--spacing-large);
+}

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
@@ -1,23 +1,22 @@
 import React from "react";
 import styles from "./ModalTopActions.module.scss";
-import { ModalTopActionsButtonColor, ModalTopActionsProps } from "./ModalTopActions.types";
+import { ModalTopActionsButtonColor, ModalTopActionsColor, ModalTopActionsProps } from "./ModalTopActions.types";
 import Flex from "../../Flex/Flex";
 import IconButton from "../../IconButton/IconButton";
 import { CloseSmall } from "../../Icon/Icons";
 import { ButtonColor } from "../../Button/ButtonConstants";
 
+const colorToButtonColor: Record<ModalTopActionsColor, ModalTopActionsButtonColor> = {
+  dark: ButtonColor.ON_INVERTED_BACKGROUND,
+  light: ButtonColor.ON_PRIMARY_COLOR
+};
+
 const ModalTopActions = ({ renderAction, color, closeButtonAriaLabel, onClose }: ModalTopActionsProps) => {
-  const buttonColor: ModalTopActionsButtonColor =
-    color === "dark"
-      ? ButtonColor.ON_INVERTED_BACKGROUND
-      : color === "light"
-      ? ButtonColor.ON_PRIMARY_COLOR
-      : ButtonColor.PRIMARY;
+  const buttonColor = colorToButtonColor[color] || ButtonColor.PRIMARY;
 
   return (
     <Flex className={styles.actions}>
-      {/* this allows passing back to consumer the color he chose, so he won't have to define it twice */}
-      {renderAction && renderAction(buttonColor)}
+      {typeof renderAction === "function" ? renderAction(buttonColor) : renderAction}
       <IconButton
         icon={CloseSmall}
         onClick={onClose}

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+import styles from "./ModalTopActions.module.scss";
+import { ModalTopActionsButtonColor, ModalTopActionsProps } from "./ModalTopActions.types";
+import Flex from "../../Flex/Flex";
+import IconButton from "../../IconButton/IconButton";
+import { CloseSmall } from "../../Icon/Icons";
+import { ButtonColor } from "../../Button/ButtonConstants";
+
+const ModalTopActions = ({ renderAction, color, closeButtonAriaLabel, onClose }: ModalTopActionsProps) => {
+  const buttonColor: ModalTopActionsButtonColor =
+    color === "dark"
+      ? ButtonColor.ON_INVERTED_BACKGROUND
+      : color === "light"
+      ? ButtonColor.ON_PRIMARY_COLOR
+      : ButtonColor.PRIMARY;
+
+  return (
+    <Flex className={styles.actions}>
+      {/* this allows passing back to consumer the color he chose, so he won't have to define it twice */}
+      {renderAction && renderAction(buttonColor)}
+      <IconButton
+        icon={CloseSmall}
+        onClick={onClose}
+        size={IconButton.sizes.SMALL}
+        kind={IconButton.kinds.TERTIARY}
+        color={buttonColor}
+        ariaLabel={closeButtonAriaLabel}
+      />
+    </Flex>
+  );
+};
+
+export default ModalTopActions;

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.types.ts
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.types.ts
@@ -1,0 +1,17 @@
+import React from "react";
+import MenuButton from "../../MenuButton/MenuButton";
+import IconButton from "../../IconButton/IconButton";
+import { ButtonColor } from "../../Button/ButtonConstants";
+
+export type ModalTopActionsColor = "light" | "dark";
+export type ModalTopActionsButtonColor =
+  | ButtonColor.PRIMARY
+  | ButtonColor.ON_PRIMARY_COLOR
+  | ButtonColor.ON_INVERTED_BACKGROUND;
+
+export interface ModalTopActionsProps {
+  renderAction?: (color?: ModalTopActionsButtonColor) => React.ReactElement<typeof MenuButton | typeof IconButton>;
+  color?: ModalTopActionsColor;
+  closeButtonAriaLabel?: string;
+  onClose?: React.MouseEventHandler<HTMLDivElement>;
+}

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.types.ts
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.types.ts
@@ -10,7 +10,13 @@ export type ModalTopActionsButtonColor =
   | ButtonColor.ON_INVERTED_BACKGROUND;
 
 export interface ModalTopActionsProps {
-  renderAction?: (color?: ModalTopActionsButtonColor) => React.ReactElement<typeof MenuButton | typeof IconButton>;
+  /**
+   * action can be passed either as a function or direct
+   * it allows passing back to consumer the color he chose, so he won't have to define it twice
+   */
+  renderAction?:
+    | React.ReactElement<typeof MenuButton | typeof IconButton>
+    | ((color?: ModalTopActionsButtonColor) => React.ReactElement<typeof MenuButton | typeof IconButton>);
   color?: ModalTopActionsColor;
   closeButtonAriaLabel?: string;
   onClose?: React.MouseEventHandler<HTMLDivElement>;

--- a/packages/core/src/components/ModalNew/ModalTopActions/__tests__/ModalTopActions.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalTopActions/__tests__/ModalTopActions.test.tsx
@@ -32,7 +32,7 @@ describe("ModalTopActions", () => {
     expect(() => getByLabelText(closeButtonAriaLabel)).not.toThrow();
   });
 
-  it("renders the action button using the renderAction prop", () => {
+  it("renders the action button using the renderAction prop as a function", () => {
     const renderAction = jest.fn(color => <IconButton data-testid="extra-action" icon={FeedbackIcon} color={color} />);
     const { getByTestId } = render(<ModalTopActions renderAction={renderAction} />);
 
@@ -44,6 +44,15 @@ describe("ModalTopActions", () => {
     render(<ModalTopActions color="dark" renderAction={renderAction} />);
 
     expect(renderAction).toHaveBeenCalledWith(ButtonColor.ON_INVERTED_BACKGROUND);
+  });
+
+  it("renders the action button using the renderAction prop directly", () => {
+    const renderAction = (
+      <IconButton data-testid="extra-action" icon={FeedbackIcon} color={IconButton.colors.ON_PRIMARY_COLOR} />
+    );
+    const { getByTestId } = render(<ModalTopActions renderAction={renderAction} />);
+
+    expect(within(getByTestId("extra-action")).getByTestId("icon")).toBeInTheDocument();
   });
 
   it("applies the correct color when 'dark' is passed", () => {

--- a/packages/core/src/components/ModalNew/ModalTopActions/__tests__/ModalTopActions.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalTopActions/__tests__/ModalTopActions.test.tsx
@@ -1,0 +1,63 @@
+import React from "react";
+import { render, fireEvent, within } from "@testing-library/react";
+import ModalTopActions from "../ModalTopActions";
+import IconButton from "../../../IconButton/IconButton";
+import { Feedback as FeedbackIcon } from "../../../Icon/Icons";
+import { ButtonColor } from "../../../Button/ButtonConstants";
+import { camelCase } from "lodash-es";
+
+describe("ModalTopActions", () => {
+  const closeButtonAriaLabel = "Close modal";
+
+  it("renders the close button with the correct aria-label", () => {
+    const { getByLabelText } = render(<ModalTopActions closeButtonAriaLabel={closeButtonAriaLabel} />);
+
+    expect(getByLabelText(closeButtonAriaLabel)).toBeInTheDocument();
+  });
+
+  it("calls onClose when the close button is clicked", () => {
+    const mockOnClose = jest.fn();
+
+    const { getByLabelText } = render(
+      <ModalTopActions onClose={mockOnClose} closeButtonAriaLabel={closeButtonAriaLabel} />
+    );
+
+    fireEvent.click(getByLabelText(closeButtonAriaLabel));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+
+  it("does not fail when onClose is not provided", () => {
+    const { getByLabelText } = render(<ModalTopActions closeButtonAriaLabel={closeButtonAriaLabel} />);
+    fireEvent.click(getByLabelText(closeButtonAriaLabel));
+    expect(() => getByLabelText(closeButtonAriaLabel)).not.toThrow();
+  });
+
+  it("renders the action button using the renderAction prop", () => {
+    const renderAction = jest.fn(color => <IconButton data-testid="extra-action" icon={FeedbackIcon} color={color} />);
+    const { getByTestId } = render(<ModalTopActions renderAction={renderAction} />);
+
+    expect(within(getByTestId("extra-action")).getByTestId("icon")).toBeInTheDocument();
+  });
+
+  it("calls renderAction with correct color argument", () => {
+    const renderAction = jest.fn(color => <IconButton data-testid="extra-action" icon={FeedbackIcon} color={color} />);
+    render(<ModalTopActions color="dark" renderAction={renderAction} />);
+
+    expect(renderAction).toHaveBeenCalledWith(ButtonColor.ON_INVERTED_BACKGROUND);
+  });
+
+  it("applies the correct color when 'dark' is passed", () => {
+    const { getByLabelText } = render(<ModalTopActions color="dark" closeButtonAriaLabel={closeButtonAriaLabel} />);
+    expect(getByLabelText(closeButtonAriaLabel)).toHaveClass(camelCase("color-" + ButtonColor.ON_INVERTED_BACKGROUND));
+  });
+
+  it("applies the correct color when 'light' is passed", () => {
+    const { getByLabelText } = render(<ModalTopActions color="light" closeButtonAriaLabel={closeButtonAriaLabel} />);
+    expect(getByLabelText(closeButtonAriaLabel)).toHaveClass(camelCase("color-" + ButtonColor.ON_PRIMARY_COLOR));
+  });
+
+  it("applies the default color when no color is passed", () => {
+    const { getByLabelText } = render(<ModalTopActions closeButtonAriaLabel={closeButtonAriaLabel} />);
+    expect(getByLabelText(closeButtonAriaLabel)).toHaveClass(camelCase("color-" + ButtonColor.PRIMARY));
+  });
+});


### PR DESCRIPTION
### ModalTopActions 🔒

![image](https://github.com/user-attachments/assets/3b8c7abc-c0a0-42c8-922e-779f4923c3cf)

Which shows next to the Header, at the top of the modal

![image](https://github.com/user-attachments/assets/cf44d073-138f-4549-8eca-0c530d3bb8d6)

- When X button is triggered, call the `onClose` that was assigned by consumer to the `onClose` of the `Modal`.
- Renders the extra header action received initially by `Modal`.
- Positioned absolute, not actual part of the Header.

Props:

Name | Type | Description
-- | -- | --
renderAction | (color?: ModalTopActionsColor) => React.ReactElement<typeof MenuButton \| typeof IconButton> | 
color | ModalTopActionsColor 🔒(which is "light" \| "dark") | 
closeButtonAriaLabel | string | 
onClose | React.MouseEventHandler<HTMLDivElement> | 

Usage example:

```typescript
<ModalTopActions
  onClose={() => console.log("Hi!")}
  closeButtonAriaLabel="Close"
  renderAction={() => (
    <MenuButton size={MenuButton.sizes.SMALL} ariaLabel="Options">
      <Menu id="menu" size={Menu.sizes.MEDIUM}>
        <MenuItem icon={Sun} iconType={MenuItem.iconType.SVG} title="The sun" />
        <MenuItem icon={Moon} iconType={MenuItem.iconType.SVG} title="The moon" />
        <MenuItem icon={Favorite} iconType={MenuItem.iconType.SVG} title="And the stars" />
      </Menu>
    </MenuButton>
  )}
/>
```

https://monday.monday.com/boards/3532715121/pulses/7360589183