### PR TITLE
feat(Modal): use titleId and descriptionId for appropriate arias, allow setting those values through context

### DIFF
--- a/packages/core/src/components/ModalNew/Modal/Modal.tsx
+++ b/packages/core/src/components/ModalNew/Modal/Modal.tsx
@@ -28,8 +28,8 @@ const Modal = forwardRef(
     }: ModalProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const [titleId, setTitleId] = useState<string>("");
-    const [descriptionId, setDescriptionId] = useState<string>("");
+    const [titleId, setTitleId] = useState<string>();
+    const [descriptionId, setDescriptionId] = useState<string>();
 
     const setTitleIdCallback = useCallback((id: string) => setTitleId(id), []);
     const setDescriptionIdCallback = useCallback((id: string) => setDescriptionId(id), []);
@@ -53,8 +53,8 @@ const Modal = forwardRef(
             data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL, id)}
             role="dialog"
             aria-modal
-            aria-labelledby={titleId || undefined}
-            aria-describedby={descriptionId || undefined}
+            aria-labelledby={titleId}
+            aria-describedby={descriptionId}
           >
             <ModalTopActions
               renderAction={renderHeaderAction}

--- a/packages/core/src/components/ModalNew/Modal/Modal.tsx
+++ b/packages/core/src/components/ModalNew/Modal/Modal.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useCallback, useMemo, useState } from "react";
 import cx from "classnames";
 import { getTestId } from "../../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../../tests/constants";
@@ -7,10 +7,13 @@ import { ModalProps } from "./Modal.types";
 import ModalTopActions from "../ModalTopActions/ModalTopActions";
 import { getStyle } from "../../../helpers/typesciptCssModulesHelper";
 import { camelCase } from "lodash-es";
+import { ModalProvider } from "../context/ModalContext";
+import { ModalContextProps } from "../context/ModalContext.types";
 
 const Modal = forwardRef(
   (
     {
+      id,
       // Would be implemented in a later PR
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       show,
@@ -21,32 +24,48 @@ const Modal = forwardRef(
       onClose,
       children,
       className,
-      id,
       "data-testid": dataTestId
     }: ModalProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
+    const [titleId, setTitleId] = useState<string>("");
+    const [descriptionId, setDescriptionId] = useState<string>("");
+
+    const setTitleIdCallback = useCallback((id: string) => setTitleId(id), []);
+    const setDescriptionIdCallback = useCallback((id: string) => setDescriptionId(id), []);
+
+    const contextValue = useMemo<ModalContextProps>(
+      () => ({
+        modalId: id,
+        setTitleId: setTitleIdCallback,
+        setDescriptionId: setDescriptionIdCallback
+      }),
+      [id, setTitleIdCallback, setDescriptionIdCallback]
+    );
+
     return (
-      <div id="overlay" className={styles.overlay}>
-        <div
-          ref={ref}
-          className={cx(styles.modal, getStyle(styles, camelCase("size-" + size)), className)}
-          id={id}
-          data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL, id)}
-          role="dialog"
-          aria-modal
-          aria-labelledby="TODO" // TODO
-          aria-describedby="TODO" // TODO
-        >
-          <ModalTopActions
-            renderAction={renderHeaderAction}
-            color={closeButtonTheme}
-            closeButtonAriaLabel={closeButtonAriaLabel}
-            onClose={onClose}
-          />
-          {children}
+      <ModalProvider value={contextValue}>
+        <div id="overlay" className={styles.overlay}>
+          <div
+            ref={ref}
+            className={cx(styles.modal, getStyle(styles, camelCase("size-" + size)), className)}
+            id={id}
+            data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL, id)}
+            role="dialog"
+            aria-modal
+            aria-labelledby={titleId || undefined}
+            aria-describedby={descriptionId || undefined}
+          >
+            <ModalTopActions
+              renderAction={renderHeaderAction}
+              color={closeButtonTheme}
+              closeButtonAriaLabel={closeButtonAriaLabel}
+              onClose={onClose}
+            />
+            {children}
+          </div>
         </div>
-      </div>
+      </ModalProvider>
     );
   }
 );

--- a/packages/core/src/components/ModalNew/Modal/Modal.types.tsx
+++ b/packages/core/src/components/ModalNew/Modal/Modal.types.tsx
@@ -5,6 +5,7 @@ import { ModalTopActionsProps } from "../ModalTopActions/ModalTopActions.types";
 export type ModalSize = "small" | "medium" | "large";
 
 export interface ModalProps extends VibeComponentProps {
+  id: string;
   show: boolean;
   size?: ModalSize;
   closeButtonTheme?: ModalTopActionsProps["color"];

--- a/packages/core/src/components/ModalNew/Modal/__tests__/Modal.test.tsx
+++ b/packages/core/src/components/ModalNew/Modal/__tests__/Modal.test.tsx
@@ -3,12 +3,13 @@ import { render, fireEvent } from "@testing-library/react";
 import Modal from "../Modal";
 
 describe("Modal", () => {
+  const id = "modal-id";
   const closeButtonAriaLabel = "Close modal";
   const childrenContent = <span>My content</span>;
 
   it("renders the modal with the correct role", () => {
     const { getByTestId } = render(
-      <Modal show data-testid="modal">
+      <Modal id={id} show data-testid="modal">
         {childrenContent}
       </Modal>
     );
@@ -18,7 +19,7 @@ describe("Modal", () => {
 
   it("renders the modal with the correct aria-modal", () => {
     const { getByTestId } = render(
-      <Modal show data-testid="modal">
+      <Modal id={id} show data-testid="modal">
         {childrenContent}
       </Modal>
     );
@@ -28,7 +29,7 @@ describe("Modal", () => {
 
   it("renders the children content correctly", () => {
     const { getByText } = render(
-      <Modal show closeButtonAriaLabel={closeButtonAriaLabel}>
+      <Modal id={id} show>
         {childrenContent}
       </Modal>
     );
@@ -37,14 +38,18 @@ describe("Modal", () => {
   });
 
   it("applies default size as 'medium' when not supplied with a size", () => {
-    const { getByRole } = render(<Modal show>{childrenContent}</Modal>);
+    const { getByRole } = render(
+      <Modal id={id} show>
+        {childrenContent}
+      </Modal>
+    );
 
     expect(getByRole("dialog")).toHaveClass("sizeMedium");
   });
 
   it("applies the correct given 'large' size", () => {
     const { getByRole } = render(
-      <Modal show size="large">
+      <Modal id={id} show size="large">
         {childrenContent}
       </Modal>
     );
@@ -55,7 +60,7 @@ describe("Modal", () => {
   it("calls onClose when the close button is clicked", () => {
     const mockOnClose = jest.fn();
     const { getByLabelText } = render(
-      <Modal show onClose={mockOnClose} closeButtonAriaLabel={closeButtonAriaLabel}>
+      <Modal id={id} show onClose={mockOnClose} closeButtonAriaLabel={closeButtonAriaLabel}>
         {childrenContent}
       </Modal>
     );

--- a/packages/core/src/components/ModalNew/context/ModalContext.tsx
+++ b/packages/core/src/components/ModalNew/context/ModalContext.tsx
@@ -1,0 +1,16 @@
+import React, { createContext, useContext } from "react";
+import { ModalContextProps, ModalProviderProps } from "./ModalContext.types";
+
+const ModalContext = createContext<ModalContextProps | undefined>(undefined);
+
+export const ModalProvider = ({ value, children }: ModalProviderProps) => {
+  return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>;
+};
+
+export const useModal = (): ModalContextProps => {
+  const context = useContext(ModalContext);
+  if (!context) {
+    throw new Error("useModal must be used within a ModalProvider");
+  }
+  return context;
+};

--- a/packages/core/src/components/ModalNew/context/ModalContext.types.ts
+++ b/packages/core/src/components/ModalNew/context/ModalContext.types.ts
@@ -1,0 +1,14 @@
+import React from "react";
+
+export type ModalProviderValue = {
+  modalId: string;
+  setTitleId: (id: string) => void;
+  setDescriptionId: (id: string) => void;
+};
+
+export type ModalContextProps = ModalProviderValue;
+
+export interface ModalProviderProps {
+  value: ModalProviderValue;
+  children: React.ReactNode;
+}


### PR DESCRIPTION
### Implementing Modal's arias for title and description

- Set `aria-labelledby` for the Modal's title element id
- Set `aria-describedby` for the Modal's description element id

The reason for it to be a setter, rather than passing a plain value to the Context and then use it (without states), is because we cannot tell if a description would be provided to the Modal by consumer.
So in ModalHeader we should call the setters according to the ids supplied there.

See https://www.w3.org/WAI/ARIA/apg/patterns/dialog-modal/examples/dialog/#rps_label for further best practices regarding `Modal`'s arias

Next steps:
- Consume the context inside `ModalHeader`
- Set the id for the title and description elements inside `ModalHeader`, using the `Modal`'s `id` prop (to have unique ids):
	- `[my-modal-id]_label`
	- `[my-modal-id]_desc`

https://monday.monday.com/boards/3532715121/pulses/7367625236