### PR TITLE
fix: pass on attributes such as name, onBlur and maxLength to textarea element

### DIFF
--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -23,12 +23,15 @@ const TextArea = forwardRef(
       className,
       "data-testid": dataTestId,
       id,
+      name,
       disabled,
       readOnly,
       value,
       onChange,
+      onBlur,
       "aria-label": ariaLabel,
       required,
+      maxLength,
       resize = true,
       placeholder
     }: TextAreaProps,
@@ -58,6 +61,7 @@ const TextArea = forwardRef(
         )}
         <textarea
           id={id}
+          name={name}
           ref={ref}
           disabled={disabled}
           readOnly={readOnly}
@@ -66,10 +70,12 @@ const TextArea = forwardRef(
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
           value={value}
           onChange={onChange}
+          onBlur={onBlur}
           aria-invalid={error}
           aria-label={ariaLabel}
           aria-describedby={helpTextId ?? undefined}
           placeholder={placeholder}
+          maxLength={maxLength}
         />
         {helpText && (
           <Text className={cx(styles.helpText)} color={Text.colors.INHERIT} id={helpTextId}>


### PR DESCRIPTION
I work with `Formik` library to build a form consisting of several components from Vibe including `TextArea`. Some crucial attributes are not passed on to the native `textarea` element such as `onBlur`, `name` and `maxLength`. This PR fixes it.

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
