### PR TITLE
chore: update repository directory in package json

### DIFF
--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -10,6 +10,9 @@
   "author": "monday.com",
   "license": "MIT",
   "bin": "./dist/bin/vibe-codemod.js",
+  "files": [
+    "dist"
+  ]
   "scripts": {
     "test": "vitest",
     "plop": "plop",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -2,7 +2,11 @@
   "name": "@vibe/codemod",
   "version": "0.0.8",
   "description": "Vibe's component library migration tool",
-  "repository": "git+https://github.com/mondaycom/vibe.git",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mondaycom/vibe.git",
+    "directory": "packages/codemod"
+  },
   "author": "monday.com",
   "license": "MIT",
   "bin": "./dist/bin/vibe-codemod.js",

--- a/packages/codemod/package.json
+++ b/packages/codemod/package.json
@@ -12,7 +12,7 @@
   "bin": "./dist/bin/vibe-codemod.js",
   "files": [
     "dist"
-  ]
+  ],
   "scripts": {
     "test": "vitest",
     "plop": "plop",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -2,9 +2,23 @@
   "name": "@vibe/core",
   "version": "3.0.0-alpha.8",
   "description": "Official monday.com UI resources for application development in React.js",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mondaycom/vibe.git",
+    "directory": "packages/core"
+  },
+  "bugs": {
+    "url": "https://github.com/mondaycom/vibe/issues"
+  },
+  "homepage": "https://github.com/mondaycom/vibe#readme",
+  "author": "monday.com",
+  "license": "MIT",
   "type": "module",
   "main": "dist/src/index.js",
   "types": "dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
@@ -65,19 +79,6 @@
     "stylelint": "stylelint \"**/*.scss\"",
     "stylelint:fix": "yarn stylelint -- --fix"
   },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mondaycom/vibe.git"
-  },
-  "author": "",
-  "license": "MIT",
-  "files": [
-    "dist"
-  ],
-  "bugs": {
-    "url": "https://github.com/mondaycom/vibe/issues"
-  },
-  "homepage": "https://github.com/mondaycom/vibe#readme",
   "dependencies": {
     "@popperjs/core": "2.11.6",
     "@vibe/icons": "0.0.4",

--- a/packages/storybook-blocks/package.json
+++ b/packages/storybook-blocks/package.json
@@ -122,5 +122,5 @@
   },
   "browserslist": [
     "extends browserslist-config-monday"
-  ],
+  ]
 }

--- a/packages/storybook-blocks/package.json
+++ b/packages/storybook-blocks/package.json
@@ -2,16 +2,23 @@
   "name": "vibe-storybook-components",
   "version": "0.19.3",
   "description": "Collection of Vibe's Storybook components",
-  "license": "MIT",
   "repository": {
     "type": "git",
-    "url": "git@github.com:mondaycom/vibe.git"
+    "url": "git+https://github.com/mondaycom/vibe.git",
+    "directory": "packages/storybook-blocks"
   },
+  "author": "monday.com",
+  "license": "MIT",
   "sideEffects": [
     "*.scss",
     "*.css"
   ],
   "main": "dist/index.js",
+  "files": [
+    "dist/",
+    "src/",
+    "README.md"
+  ],
   "exports": {
     ".": "./dist/index.js",
     "./index.css": "./dist/index.css",
@@ -27,11 +34,6 @@
       ]
     }
   },
-  "files": [
-    "dist/",
-    "src/",
-    "README.md"
-  ],
   "scripts": {
     "build": "rollup -c --bundleConfigAsCjs && yarn copy-mixins-to-dist",
     "copy-mixins-to-dist": "scripts/copy-mixins-to-dist.sh",
@@ -43,9 +45,6 @@
     "storybook": "storybook dev -p 7012",
     "build-storybook": "storybook build"
   },
-  "browserslist": [
-    "extends browserslist-config-monday"
-  ],
   "dependencies": {
     "@storybook/types": "^7.5.0",
     "browserslist-config-monday": "^1.0.6",
@@ -120,5 +119,8 @@
   "peerDependencies": {
     "react": ">=16.9.0",
     "react-dom": ">=16.9.0"
-  }
+  },
+  "browserslist": [
+    "extends browserslist-config-monday"
+  ],
 }

--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -2,7 +2,27 @@
   "name": "monday-ui-style",
   "version": "0.14.1",
   "description": "Monday UI CSS Foundations",
+  "keywords": [
+    "CSS",
+    "THEMES"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/mondaycom/vibe.git",
+    "directory": "packages/style"
+  },
+  "bugs": {
+    "url": "https://github.com/mondaycom/vibe/issues"
+  },
+  "homepage": "https://github.com/mondaycom/vibe#readme",
+  "author": "monday.com",
+  "license": "MIT",
   "main": "dist/index.css",
+  "files": [
+    "src/",
+    "dist/",
+    "stylelint-config/"
+  ],
   "scripts": {
     "test": "yarn build && yarn test:without-build",
     "test:without-build": "jest",
@@ -16,28 +36,6 @@
     "stylelint:fix": "stylelint \"**/*.scss\" --fix",
     "fix-lint": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx,scss}\""
   },
-  "peerDependencies": {
-    "stylelint": "^14.1.0"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/mondaycom/vibe.git"
-  },
-  "keywords": [
-    "CSS",
-    "THEMES"
-  ],
-  "author": "monday.com",
-  "license": "MIT",
-  "files": [
-    "src/",
-    "dist/",
-    "stylelint-config/"
-  ],
-  "bugs": {
-    "url": "https://github.com/mondaycom/vibe/issues"
-  },
-  "homepage": "https://github.com/mondaycom/vibe#readme",
   "dependencies": {
     "postcss": "8.4.31",
     "postcss-scss": "^4.0.9",
@@ -55,5 +53,8 @@
     "prettier": "^2.0.5",
     "sass": "^1.70.0",
     "stylelint-config-recommended-scss": "^6.0.0"
+  },
+  "peerDependencies": {
+    "stylelint": "^14.1.0"
   }
 }


### PR DESCRIPTION
fix order for some of the fields to keep consistency (let's consider to later use linter specifically for the package json, for new packages as well)

this PR adds the "directory" subattr for each of the "repository" attribute in each of the package.json of the monorepo packages