### PR TITLE
fix(TextArea): Spread rest props to the native textarea tag

### DIFF
--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -33,7 +33,8 @@ const TextArea = forwardRef(
       required,
       maxLength,
       resize = true,
-      placeholder
+      placeholder,
+      ...rest
     }: TextAreaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>
   ) => {
@@ -76,6 +77,7 @@ const TextArea = forwardRef(
           aria-describedby={helpTextId ?? undefined}
           placeholder={placeholder}
           maxLength={maxLength}
+          {...rest}
         />
         {helpText && (
           <Text className={cx(styles.helpText)} color={Text.colors.INHERIT} id={helpTextId}>

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -23,17 +23,10 @@ const TextArea = forwardRef(
       className,
       "data-testid": dataTestId,
       id,
-      name,
       disabled,
       readOnly,
-      value,
-      onChange,
-      onBlur,
-      "aria-label": ariaLabel,
       required,
-      maxLength,
       resize = true,
-      placeholder,
       ...rest
     }: TextAreaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>
@@ -62,21 +55,14 @@ const TextArea = forwardRef(
         )}
         <textarea
           id={id}
-          name={name}
           ref={ref}
           disabled={disabled}
           readOnly={readOnly}
           required={required}
           rows={numRows}
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
-          value={value}
-          onChange={onChange}
-          onBlur={onBlur}
           aria-invalid={error}
-          aria-label={ariaLabel}
           aria-describedby={helpTextId ?? undefined}
-          placeholder={placeholder}
-          maxLength={maxLength}
           {...rest}
         />
         {helpText && (

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -54,6 +54,7 @@ const TextArea = forwardRef(
           </label>
         )}
         <textarea
+          {...rest}
           id={id}
           ref={ref}
           disabled={disabled}
@@ -63,7 +64,6 @@ const TextArea = forwardRef(
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
           aria-invalid={error}
           aria-describedby={helpTextId ?? undefined}
-          {...rest}
         />
         {helpText && (
           <Text className={cx(styles.helpText)} color={Text.colors.INHERIT} id={helpTextId}>

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -24,21 +24,9 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    */
   error?: boolean;
   /**
-   * The number of rows in the textarea. Defaults according to the size prop.
-   */
-  rows?: number;
-  /**
    * Label text associated with the textarea element.
    */
   label?: string;
-  /**
-   * If true, the textarea becomes non-interactive
-   */
-  disabled?: boolean;
-  /**
-   * If true, the textarea is read-only and cannot be modified by the user
-   */
-  readOnly?: boolean;
   /**
    * Function to call on textarea value change.
    */
@@ -51,10 +39,6 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    * Accessibility label for the textarea element.
    */
   "aria-label"?: React.AriaAttributes["aria-label"];
-  /**
-   * If true, the textarea is required and must be filled out by the user.
-   */
-  required?: boolean;
   /**
    * If true, the textarea can be resized vertically by the user.
    */

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -2,7 +2,10 @@ import { TextareaHTMLAttributes } from "react";
 import { VibeComponentProps } from "../../types";
 
 export type TextAreaSize = "small" | "large";
-type TextAreaNativeInputProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "role" | "aria-describedby" | "aria-invalid">;
+type TextAreaNativeInputProps = Omit<
+  TextareaHTMLAttributes<HTMLTextAreaElement>,
+  "role" | "aria-describedby" | "aria-invalid"
+>;
 
 export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentProps {
   /**

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -2,7 +2,7 @@ import { TextareaHTMLAttributes } from "react";
 import { VibeComponentProps } from "../../types";
 
 export type TextAreaSize = "small" | "large";
-type TextAreaNativeInputProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "role">;
+type TextAreaNativeInputProps = Omit<TextareaHTMLAttributes<HTMLTextAreaElement>, "role" | "aria-describedby" | "aria-invalid">;
 
 export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentProps {
   /**


### PR DESCRIPTION
**Main Changes:**
1. Spread `rest` props object to the native `textarea` tag in order to support native HTML API.

**Impact:**
1. A more robust component

**Related:** 
- https://monday.monday.com/boards/5896576795/pulses/7480825140
- https://monday.slack.com/archives/C02S6F817JQ/p1726471392017299

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

