### PR TITLE
tooltip_flickering_fix

### DIFF
--- a/packages/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.tsx
@@ -318,6 +318,7 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       tip,
       arrowClassName,
       id,
+      position,
       "data-testid": dataTestId
     } = this.props;
 
@@ -329,9 +330,16 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       return this.renderTooltipContent();
     }
 
+    let moveAmount : MoveBy = this.props.moveBy;
+
+    if (position && (position.includes("top") || position.includes("bottom"))) {
+        moveAmount = { main: 11, secondary: 0 };
+    }
+
     const content = this.renderTooltipContent;
     const dialogProps = {
       ...this.props,
+      moveBy: moveAmount,
       "data-testid": dataTestId || getTestId(ComponentDefaultTestId.TOOLTIP, id),
       startingEdge: justify,
       tooltip: tip,


### PR DESCRIPTION
This pull request has been raised for the issue #2225 pointed out by [Ma1kovich](https://github.com/Ma1kovich).

When tooltip component hovers over an element (Say Button), and you scroll near the area where the tooltip and the element meet. The tooltip starts to flicker.

I saw in the default moveby offset was {main: 4 , secondary: 0} which was not for enought for all top and bottom tooltips. 
For the rest is was ok.

So I added a little more main offset to increase the gap between the tooltip and the element for which tooltip is there. This solved the flickering issue for all top and bottom tooltips

I'm attaching a video with the fix for your reference. 


https://github.com/user-attachments/assets/bdddb831-b4de-418c-bf3a-58c9aa5c4b53

@talkor  let me know your thoughts on this. 

Thanks,
Ritik
