### PR TITLE
feat(ModalBasicLayout): basic layout component for new Modal

### DIFF
--- a/packages/core/src/components/ModalNew/Modal/Modal.module.scss
+++ b/packages/core/src/components/ModalNew/Modal/Modal.module.scss
@@ -5,6 +5,8 @@
 }
 
 .modal {
+  --top-actions-spacing: var(--spacing-large);
+  --top-actions-width: var(--spacing-xl);
   --modal-inline-padding: var(--spacing-xl);
 
   position: fixed;
@@ -20,6 +22,10 @@
   overflow: hidden;
   border-radius: var(--border-radius-big);
   box-shadow: var(--box-shadow-large);
+
+  &.withHeaderAction {
+    --top-actions-width: calc(var(--spacing-xl) * 2);
+  }
 
   &.sizeSmall {
     --modal-max-height: 50%;

--- a/packages/core/src/components/ModalNew/Modal/Modal.module.scss
+++ b/packages/core/src/components/ModalNew/Modal/Modal.module.scss
@@ -5,6 +5,8 @@
 }
 
 .modal {
+  --modal-inline-padding: var(--spacing-xl);
+
   position: fixed;
   top: 50%;
   left: 50%;

--- a/packages/core/src/components/ModalNew/Modal/Modal.tsx
+++ b/packages/core/src/components/ModalNew/Modal/Modal.tsx
@@ -10,7 +10,7 @@ import ModalTopActions from "../ModalTopActions/ModalTopActions";
 import { getStyle } from "../../../helpers/typesciptCssModulesHelper";
 import { camelCase } from "lodash-es";
 import { ModalProvider } from "../context/ModalContext";
-import { ModalContextProps } from "../context/ModalContext.types";
+import { ModalProviderValue } from "../context/ModalContext.types";
 import useKeyEvent from "../../../hooks/useKeyEvent";
 import { keyCodes } from "../../../constants";
 
@@ -36,7 +36,7 @@ const Modal = forwardRef(
     const setTitleIdCallback = useCallback((id: string) => setTitleId(id), []);
     const setDescriptionIdCallback = useCallback((id: string) => setDescriptionId(id), []);
 
-    const contextValue = useMemo<ModalContextProps>(
+    const contextValue = useMemo<ModalProviderValue>(
       () => ({
         modalId: id,
         setTitleId: setTitleIdCallback,

--- a/packages/core/src/components/ModalNew/Modal/Modal.tsx
+++ b/packages/core/src/components/ModalNew/Modal/Modal.tsx
@@ -83,7 +83,12 @@ const Modal = forwardRef(
           <FocusLock returnFocus>
             <div
               ref={ref}
-              className={cx(styles.modal, getStyle(styles, camelCase("size-" + size)), className)}
+              className={cx(
+                styles.modal,
+                getStyle(styles, camelCase("size-" + size)),
+                { [styles.withHeaderAction]: !!renderHeaderAction },
+                className
+              )}
               id={id}
               data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT, id)}
               role="dialog"

--- a/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
+++ b/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
@@ -1,21 +1,32 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, UIEventHandler, useCallback } from "react";
 import cx from "classnames";
 import { getTestId } from "../../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../../tests/constants";
 import styles from "./ModalContent.module.scss";
 import { ModalContentProps } from "./ModalContent.types";
+import { useModal } from "../context/ModalContext";
 
 const ModalContent = forwardRef(
   (
     { children, className, id, "data-testid": dataTestId }: ModalContentProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
+    const { setContentScrolled } = useModal();
+
+    const onScroll: UIEventHandler<HTMLDivElement> = useCallback(
+      e => {
+        setContentScrolled(e.currentTarget?.scrollTop > 0);
+      },
+      [setContentScrolled]
+    );
+
     return (
       <div
         ref={ref}
         className={cx(styles.content, className)}
         id={id}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT_CONTENT, id)}
+        onScroll={onScroll}
       >
         {children}
       </div>

--- a/packages/core/src/components/ModalNew/ModalContent/__tests__/ModalContent.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalContent/__tests__/ModalContent.test.tsx
@@ -15,7 +15,7 @@ describe("ModalContent", () => {
     modalId: "modal-id",
     setTitleId: jest.fn(),
     setDescriptionId: jest.fn(),
-    contentScrolled: false,
+    isContentScrolled: false,
     setContentScrolled: jest.fn()
   };
 

--- a/packages/core/src/components/ModalNew/ModalContent/__tests__/ModalContent.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalContent/__tests__/ModalContent.test.tsx
@@ -1,9 +1,27 @@
 import React from "react";
-import { render } from "@testing-library/react";
+import { render, fireEvent } from "@testing-library/react";
 import ModalContent from "../ModalContent";
+import { useModal } from "../../context/ModalContext";
+
+jest.mock("../../context/ModalContext", () => ({
+  useModal: jest.fn()
+}));
+const useModalMocked = jest.mocked(useModal);
 
 describe("ModalContent", () => {
   const childrenContent = <span>My content</span>;
+
+  const useModalMockedReturnedValue = {
+    modalId: "modal-id",
+    setTitleId: jest.fn(),
+    setDescriptionId: jest.fn(),
+    contentScrolled: false,
+    setContentScrolled: jest.fn()
+  };
+
+  beforeEach(() => {
+    useModalMocked.mockReturnValue(useModalMockedReturnedValue);
+  });
 
   it("renders the children correctly", () => {
     const { getByText } = render(<ModalContent>{childrenContent}</ModalContent>);
@@ -13,5 +31,43 @@ describe("ModalContent", () => {
   it("renders when no children are provided", () => {
     const { container } = render(<ModalContent />);
     expect(container.firstChild).toBeInTheDocument();
+  });
+
+  it("calls setContentScrolled with 'true' when scrolled down", () => {
+    const { getByTestId } = render(
+      <ModalContent id="modal-content" data-testid="modal-content">
+        {childrenContent}
+      </ModalContent>
+    );
+
+    const contentDiv = getByTestId("modal-content");
+    fireEvent.scroll(contentDiv, { target: { scrollTop: 100 } });
+
+    expect(useModalMockedReturnedValue.setContentScrolled).toHaveBeenCalledWith(true);
+  });
+
+  it("calls setContentScrolled with 'false' when scrolled to the top", () => {
+    const { getByTestId } = render(
+      <ModalContent id="modal-content" data-testid="modal-content">
+        {childrenContent}
+      </ModalContent>
+    );
+
+    const contentDiv = getByTestId("modal-content");
+
+    fireEvent.scroll(contentDiv, { target: { scrollTop: 100 } });
+    fireEvent.scroll(contentDiv, { target: { scrollTop: 0 } });
+
+    expect(useModalMockedReturnedValue.setContentScrolled).toHaveBeenLastCalledWith(false);
+  });
+
+  it("does not call setContentScrolled if no scroll occurs", () => {
+    render(
+      <ModalContent id="modal-content" data-testid="modal-content">
+        {childrenContent}
+      </ModalContent>
+    );
+
+    expect(useModalMockedReturnedValue.setContentScrolled).not.toHaveBeenCalled();
   });
 });

--- a/packages/core/src/components/ModalNew/ModalHeader/__tests__/ModalHeader.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalHeader/__tests__/ModalHeader.test.tsx
@@ -18,7 +18,7 @@ describe("ModalHeader", () => {
     modalId: "modal-id",
     setTitleId: jest.fn(),
     setDescriptionId: jest.fn(),
-    contentScrolled: false,
+    isContentScrolled: false,
     setContentScrolled: jest.fn()
   };
 

--- a/packages/core/src/components/ModalNew/ModalHeader/__tests__/ModalHeader.test.tsx
+++ b/packages/core/src/components/ModalNew/ModalHeader/__tests__/ModalHeader.test.tsx
@@ -17,7 +17,9 @@ describe("ModalHeader", () => {
   const useModalMockedReturnedValue = {
     modalId: "modal-id",
     setTitleId: jest.fn(),
-    setDescriptionId: jest.fn()
+    setDescriptionId: jest.fn(),
+    contentScrolled: false,
+    setContentScrolled: jest.fn()
   };
 
   beforeEach(() => {

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
@@ -1,5 +1,5 @@
 .actions {
   position: absolute;
-  right: var(--spacing-large);
-  top: var(--spacing-large);
+  right: var(--top-actions-spacing);
+  top: var(--top-actions-spacing);
 }

--- a/packages/core/src/components/ModalNew/context/ModalContext.tsx
+++ b/packages/core/src/components/ModalNew/context/ModalContext.tsx
@@ -4,15 +4,15 @@ import { ModalContextProps, ModalProviderProps } from "./ModalContext.types";
 const ModalContext = createContext<ModalContextProps | undefined>(undefined);
 
 export const ModalProvider = ({ value, children }: ModalProviderProps) => {
-  const [contentScrolled, setContentScrolled] = useState<boolean>(false);
+  const [isContentScrolled, setContentScrolled] = useState<boolean>(false);
 
   const contextValue = useMemo<ModalContextProps>(
     () => ({
       ...value,
-      contentScrolled,
+      isContentScrolled,
       setContentScrolled: (newContentScrolled: boolean) => setContentScrolled(newContentScrolled)
     }),
-    [contentScrolled, value]
+    [isContentScrolled, value]
   );
 
   return <ModalContext.Provider value={contextValue}>{children}</ModalContext.Provider>;

--- a/packages/core/src/components/ModalNew/context/ModalContext.tsx
+++ b/packages/core/src/components/ModalNew/context/ModalContext.tsx
@@ -1,10 +1,21 @@
-import React, { createContext, useContext } from "react";
+import React, { createContext, useContext, useMemo, useState } from "react";
 import { ModalContextProps, ModalProviderProps } from "./ModalContext.types";
 
 const ModalContext = createContext<ModalContextProps | undefined>(undefined);
 
 export const ModalProvider = ({ value, children }: ModalProviderProps) => {
-  return <ModalContext.Provider value={value}>{children}</ModalContext.Provider>;
+  const [contentScrolled, setContentScrolled] = useState<boolean>(false);
+
+  const contextValue = useMemo<ModalContextProps>(
+    () => ({
+      ...value,
+      contentScrolled,
+      setContentScrolled: (newContentScrolled: boolean) => setContentScrolled(newContentScrolled)
+    }),
+    [contentScrolled, value]
+  );
+
+  return <ModalContext.Provider value={contextValue}>{children}</ModalContext.Provider>;
 };
 
 export const useModal = (): ModalContextProps => {

--- a/packages/core/src/components/ModalNew/context/ModalContext.types.ts
+++ b/packages/core/src/components/ModalNew/context/ModalContext.types.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
 export interface ModalContextProps extends ModalProviderValue {
-  contentScrolled?: boolean;
+  contentScrolled: boolean;
   setContentScrolled: (scrolled: boolean) => void;
 }
 

--- a/packages/core/src/components/ModalNew/context/ModalContext.types.ts
+++ b/packages/core/src/components/ModalNew/context/ModalContext.types.ts
@@ -4,6 +4,8 @@ export type ModalProviderValue = {
   modalId: string;
   setTitleId: (id: string) => void;
   setDescriptionId: (id: string) => void;
+  contentScrolled?: boolean;
+  setContentScrolled: (scrolled: boolean) => void;
 };
 
 export type ModalContextProps = ModalProviderValue;

--- a/packages/core/src/components/ModalNew/context/ModalContext.types.ts
+++ b/packages/core/src/components/ModalNew/context/ModalContext.types.ts
@@ -1,14 +1,15 @@
 import React from "react";
 
+export interface ModalContextProps extends ModalProviderValue {
+  contentScrolled?: boolean;
+  setContentScrolled: (scrolled: boolean) => void;
+}
+
 export type ModalProviderValue = {
   modalId: string;
   setTitleId: (id: string) => void;
   setDescriptionId: (id: string) => void;
-  contentScrolled?: boolean;
-  setContentScrolled: (scrolled: boolean) => void;
 };
-
-export type ModalContextProps = ModalProviderValue;
 
 export interface ModalProviderProps {
   value: ModalProviderValue;

--- a/packages/core/src/components/ModalNew/context/ModalContext.types.ts
+++ b/packages/core/src/components/ModalNew/context/ModalContext.types.ts
@@ -1,7 +1,7 @@
 import React from "react";
 
 export interface ModalContextProps extends ModalProviderValue {
-  contentScrolled: boolean;
+  isContentScrolled: boolean;
   setContentScrolled: (scrolled: boolean) => void;
 }
 

--- a/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.module.scss
+++ b/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.module.scss
@@ -1,0 +1,20 @@
+.layout {
+  width: 100%;
+  flex-grow: 1;
+  overflow: hidden;
+
+  .header {
+    width: 100%;
+    margin-block: var(--spacing-xl) var(--spacing-medium);
+    // avoid overlapping top actions -> top actions margin + top actions width + additional spacing
+    padding-inline-end: calc(var(--spacing-large) + var(--spacing-xl) + var(--spacing-medium));
+  }
+
+  .divider {
+    flex-shrink: 0;
+  }
+
+  .content {
+    padding-inline: var(--modal-inline-padding);
+  }
+}

--- a/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.module.scss
+++ b/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.module.scss
@@ -6,8 +6,7 @@
   .header {
     width: 100%;
     margin-block: var(--spacing-xl) var(--spacing-medium);
-    // avoid overlapping top actions -> top actions margin + top actions width + additional spacing
-    padding-inline-end: calc(var(--spacing-large) + var(--spacing-xl) + var(--spacing-medium));
+    padding-inline-end: calc(var(--top-actions-spacing) + var(--top-actions-width) + var(--spacing-medium));
   }
 
   .divider {

--- a/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.tsx
+++ b/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.tsx
@@ -1,0 +1,36 @@
+import React, { forwardRef } from "react";
+import cx from "classnames";
+import { getTestId } from "../../../../tests/test-ids-utils";
+import { ComponentDefaultTestId } from "../../../../tests/constants";
+import styles from "./ModalBasicLayout.module.scss";
+import { ModalBasicLayoutProps } from "./ModalBasicLayout.types";
+import { useModal } from "../../context/ModalContext";
+import Flex from "../../../Flex/Flex";
+import Divider from "../../../Divider/Divider";
+
+const ModalBasicLayout = forwardRef(
+  (
+    { children, className, id, "data-testid": dataTestId }: ModalBasicLayoutProps,
+    ref: React.ForwardedRef<HTMLDivElement>
+  ) => {
+    const [header, content] = React.Children.toArray(children);
+    const { contentScrolled } = useModal();
+
+    return (
+      <Flex
+        direction={Flex.directions.COLUMN}
+        align={Flex.align.START}
+        ref={ref}
+        className={cx(styles.layout, className)}
+        id={id}
+        data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT_BASIC_LAYOUT, id)}
+      >
+        <div className={styles.header}>{header}</div>
+        {contentScrolled && <Divider className={styles.divider} withoutMargin />}
+        <div className={styles.content}>{content}</div>
+      </Flex>
+    );
+  }
+);
+
+export default ModalBasicLayout;

--- a/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.tsx
+++ b/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.tsx
@@ -14,7 +14,7 @@ const ModalBasicLayout = forwardRef(
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
     const [header, content] = React.Children.toArray(children);
-    const { contentScrolled } = useModal();
+    const { isContentScrolled } = useModal();
 
     return (
       <Flex
@@ -26,7 +26,7 @@ const ModalBasicLayout = forwardRef(
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT_BASIC_LAYOUT, id)}
       >
         <div className={styles.header}>{header}</div>
-        {contentScrolled && <Divider className={styles.divider} withoutMargin />}
+        {isContentScrolled && <Divider className={styles.divider} withoutMargin />}
         <div className={styles.content}>{content}</div>
       </Flex>
     );

--- a/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.types.ts
+++ b/packages/core/src/components/ModalNew/layouts/ModalBasicLayout/ModalBasicLayout.types.ts
@@ -1,0 +1,6 @@
+import React from "react";
+import { VibeComponentProps } from "../../../../types";
+
+export interface ModalBasicLayoutProps extends VibeComponentProps {
+  children: React.ReactNode;
+}

--- a/packages/core/src/tests/constants.ts
+++ b/packages/core/src/tests/constants.ts
@@ -107,6 +107,7 @@ export enum ComponentDefaultTestId {
   MODAL_NEXT_OVERLAY = "modal-overlay",
   MODAL_NEXT_HEADER = "modal-header",
   MODAL_NEXT_CONTENT = "modal-content",
+  MODAL_NEXT_BASIC_LAYOUT = "modal-basic-layout",
   FORMATTED_NUMBER = "formatted-number",
   HIDDEN_TEXT = "hidden-text",
   DIALOG_CONTENT_CONTAINER = "dialog-content-container",


### PR DESCRIPTION
### Basic layout

![image](https://github.com/user-attachments/assets/a504e900-149d-462d-bb29-c1eea7880c66)

Usage example:
```typescript
<Modal size="small">
  <ModalBasicLayout>
    <ModalHeader title="I'm title" />
    <ModalContent>I'm content</ModalContent>
  </ModalBasicLayout>
  <ModalFooter /> // TBD
</Modal>
```

https://monday.monday.com/boards/3532714909/pulses/7360987899