### PR TITLE
feat: add inputAriaLabel to Dropdown component

### DIFF
--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -19,6 +19,7 @@ import {
   defaultCustomStyles,
   DROPDOWN_CHIP_COLORS,
   DROPDOWN_ID,
+  DROPDOWN_INPUT_ARIA_LABEL,
   DROPDOWN_MENU_ARIA_LABEL,
   DROPDOWN_MENU_ID,
   DROPDOWN_MENU_PLACEMENT,
@@ -92,6 +93,7 @@ const Dropdown: VibeComponent<DropdownComponentProps, HTMLElement> & {
       id = DROPDOWN_ID,
       menuId = DROPDOWN_MENU_ID,
       menuAriaLabel = DROPDOWN_MENU_ARIA_LABEL,
+      inputAriaLabel = DROPDOWN_INPUT_ARIA_LABEL,
       autoFocus = false,
       multi = false,
       multiline = false,
@@ -263,7 +265,7 @@ const Dropdown: VibeComponent<DropdownComponentProps, HTMLElement> & {
             aria-activedescendant={ariaActiveDescendant}
             role="combobox"
             aria-expanded={!readOnly && menuIsOpen}
-            aria-label="Dropdown input"
+            aria-label={inputAriaLabel}
             aria-controls={menuId}
           />
         );

--- a/packages/core/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/core/src/components/Dropdown/Dropdown.types.ts
@@ -34,6 +34,10 @@ export interface CustomMenuBaseProps {
    * aria-label attribute for the menu container
    */
   menuAriaLabel?: string;
+  /**
+   * aria-label attribute for the dropdown input
+   */
+  inputAriaLabel?: string;
 }
 
 export type CustomMenuProps = CustomMenuBaseProps & MenuProps<OptionTypeBase, boolean>;

--- a/packages/core/src/components/Dropdown/DropdownConstants.ts
+++ b/packages/core/src/components/Dropdown/DropdownConstants.ts
@@ -5,6 +5,7 @@ export const ADD_AUTO_HEIGHT_COMPONENTS = ["container", "control", "valueContain
 export const DROPDOWN_ID = "dropdown-menu-id";
 export const DROPDOWN_MENU_ID = "dropdown-menu-list-id";
 export const DROPDOWN_MENU_ARIA_LABEL = "Dropdown menu";
+export const DROPDOWN_INPUT_ARIA_LABEL = "Dropdown input";
 
 export const DROPDOWN_CHIP_COLORS = {
   PRIMARY: "PRIMARY",


### PR DESCRIPTION
- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

Adding the ability to provide an `ariaLabel` specifically for the input of the `Dropdown` component. This is fully backwards compatible, providing the aria label `"Dropdown input"` that it used to by default, but if you provide the `inputAriaLabel` prop then it will use that instead.