### PR TITLE
docs: add missing related components section for VirtualizedGrid and VirtualizedList stories

### DIFF
--- a/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.mdx
+++ b/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.mdx
@@ -1,6 +1,7 @@
 import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import * as VirtualizedGridStories from "./VirtualizedGrid.stories";
+import { TABLE, VIRTUALIZED_LIST, MENU_GRID_ITEM } from "../../../storybook/components/related-components/component-description-map";
 
 <Meta of={VirtualizedGridStories} />
 
@@ -9,6 +10,7 @@ import * as VirtualizedGridStories from "./VirtualizedGrid.stories";
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
+- [Related components](#related-components)
 - [Feedback](#feedback)
 
 ## Overview
@@ -31,3 +33,7 @@ Under the hood we are using - [react-window](https://github.com/bvaughn/react-wi
     "Rendering only the visible grid items instead of all the grid's items will create better performance and a smoother experience for users while using the grid."
   ]}
 />
+
+## Related components
+
+<RelatedComponents componentsNames={[TABLE, VIRTUALIZED_LIST, MENU_GRID_ITEM]} />

--- a/packages/core/src/components/VirtualizedList/__stories__/VirtualizedList.mdx
+++ b/packages/core/src/components/VirtualizedList/__stories__/VirtualizedList.mdx
@@ -2,6 +2,7 @@ import { Canvas, Meta } from "@storybook/blocks";
 import { UsageGuidelines } from "vibe-storybook-components";
 import { TipItemRenderer } from "./VirtualizedList.stories.helpers";
 import * as VirtualizedListStories from "./VirtualizedList.stories";
+import { LIST, VIRTUALIZED_GRID, TABLE } from "../../../storybook/components/related-components/component-description-map";
 
 <Meta of={VirtualizedListStories} />
 
@@ -10,6 +11,7 @@ import * as VirtualizedListStories from "./VirtualizedList.stories";
 - [Overview](#overview)
 - [Props](#props)
 - [Usage](#usage)
+- [Related components](#related-components)
 - [Feedback](#feedback)
 
 ## Overview
@@ -31,3 +33,7 @@ Under the hood we are using - [react-window](https://github.com/bvaughn/react-wi
 <UsageGuidelines guidelines={["Use this when you expect to have many items in your list"]} />
 
 <TipItemRenderer />
+
+## Related components
+
+<RelatedComponents componentsNames={[LIST, VIRTUALIZED_GRID, TABLE]} />

--- a/packages/core/src/storybook/components/related-components/component-description-map.tsx
+++ b/packages/core/src/storybook/components/related-components/component-description-map.tsx
@@ -58,6 +58,7 @@ import { IconDescription } from "./descriptions/icon-description";
 import { BoxDescription } from "./descriptions/box-description";
 import { TableDescription } from "./descriptions/table-description";
 import { VirtualizedGridDescription } from "./descriptions/virtualized-grid-description/virtualized-grid-description";
+import { MenuGridItemDescription } from "./descriptions/menu-grid-item-description";
 
 export const SPLIT_BUTTON = "split-button";
 export const BUTTON_GROUP = "button-group";
@@ -112,6 +113,7 @@ export const COLOR_PICKER = "color-picker";
 export const SLIDER = "slider";
 export const BOX = "box";
 export const TABLE = "table";
+export const MENU_GRID_ITEM = "menu-grid-item";
 
 export const COLORS = "colors";
 export const TYPOGRAPHY = "typography";
@@ -172,7 +174,8 @@ const COMPONENTS_DESCRIPTIONS_ENTRIES: [string, JSX.Element][] = [
   [VIRTUALIZED_GRID, <VirtualizedGridDescription />],
   [COLOR_PICKER, <ColorPickerDescription />],
   [BOX, <BoxDescription />],
-  [TABLE, <TableDescription />]
+  [TABLE, <TableDescription />],
+  [MENU_GRID_ITEM, <MenuGridItemDescription />]
 ];
 
 // General description names (not related to specific components)

--- a/packages/core/src/storybook/components/related-components/descriptions/menu-grid-item-description.tsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/menu-grid-item-description.tsx
@@ -1,0 +1,27 @@
+import React, { useMemo } from "react";
+import { RelatedComponent } from "vibe-storybook-components";
+import { DummyNavigableGrid } from "../../../../components/GridKeyboardNavigationContext/__stories__/useGridKeyboardNavigationContext.stories.helpers";
+import MenuGridItem from "../../../../components/Menu/MenuGridItem/MenuGridItem";
+
+export const MenuGridItemDescription = () => {
+  const component = useMemo(() => {
+    return (
+      <MenuGridItem>
+        <DummyNavigableGrid
+          itemsCount={8}
+          numberOfItemsInLine={3}
+          withoutBorder
+        />
+      </MenuGridItem>
+    );
+  }, []);
+  return (
+    <RelatedComponent
+      component={component}
+      title="MenuGridItem"
+      href="?path=/docs/navigation-menu-menugriditem--docs"
+      description="MenuGridItem can be used to place a grid-like, keyboard navigable container, inside a Menu. The user will be
+able to interact and navigate into and from the grid in a natural way."
+    />
+  );
+};


### PR DESCRIPTION

<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

I've added missing sections to VirtualizedGrid and VirtualizedList stories.
I had to create `MenuGridItemDescription` as it was only one missing. I've took the description from `MenuGridItem` story.
