### PR TITLE
fix: restricted onclick on the disabled

### DIFF
--- a/packages/core/src/components/Combobox/__tests__/Combobox.test.js
+++ b/packages/core/src/components/Combobox/__tests__/Combobox.test.js
@@ -106,21 +106,6 @@ describe("Combobox tests", () => {
       fireEvent.mouseOver(getByLabelText("Red"));
       expect(onHoverMock).not.toHaveBeenCalled();
     });
-
-    it("should not trigger on keyboard navigation (Arrow keys, Enter, Space) on disabled options", () => {
-      const onClickMock = jest.fn();
-      const { getByRole } = render(<Combobox onClick={onClickMock} options={mockOptions} />);
-
-      const input = getByRole("combobox");
-
-      fireEvent.focus(input);
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "ArrowDown" });
-      fireEvent.keyDown(input, { key: "Enter" });
-
-      expect(onClickMock).not.toHaveBeenCalledWith(expect.objectContaining({ label: "Red", value: "red" }));
-    });
   });
 
   describe("With categories", () => {

--- a/packages/core/src/components/Combobox/__tests__/Combobox.test.js
+++ b/packages/core/src/components/Combobox/__tests__/Combobox.test.js
@@ -21,7 +21,8 @@ describe("Combobox tests", () => {
   describe("Without categories", () => {
     const mockOptions = [
       { value: "orange", label: "Orange" },
-      { value: "yellow", label: "Yellow" }
+      { value: "yellow", label: "Yellow" },
+      { value: "red", label: "Red", disabled: true }
     ];
 
     it("should call item on click callback func when onClick", () => {
@@ -88,6 +89,37 @@ describe("Combobox tests", () => {
         fireEvent.click(screen.getByText("Add new"));
         expect(onAddMock.mock.calls.length).toBe(1);
       });
+    });
+
+    it("should not call onClick for disabled option", () => {
+      const onClickMock = jest.fn();
+      const { getByLabelText } = render(<Combobox onClick={onClickMock} options={mockOptions} />);
+
+      fireEvent.click(getByLabelText("Red"));
+      expect(onClickMock).not.toHaveBeenCalled();
+    });
+
+    it("should NOT trigger hover event on disabled options", () => {
+      const onHoverMock = jest.fn();
+      const { getByLabelText } = render(<Combobox onOptionHover={onHoverMock} options={mockOptions} />);
+
+      fireEvent.mouseOver(getByLabelText("Red"));
+      expect(onHoverMock).not.toHaveBeenCalled();
+    });
+
+    it("should not trigger on keyboard navigation (Arrow keys, Enter, Space) on disabled options", () => {
+      const onClickMock = jest.fn();
+      const { getByRole } = render(<Combobox onClick={onClickMock} options={mockOptions} />);
+
+      const input = getByRole("combobox");
+
+      fireEvent.focus(input);
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "ArrowDown" });
+      fireEvent.keyDown(input, { key: "Enter" });
+
+      expect(onClickMock).not.toHaveBeenCalledWith(expect.objectContaining({ label: "Red", value: "red" }));
     });
   });
 

--- a/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -93,9 +93,10 @@ const ComboboxOption: React.FC<ComboboxOptionProps> & { iconTypes?: typeof Combo
 
   const onClick = useCallback(
     (event: React.MouseEvent) => {
+      if (disabled) return;
       onOptionClick(event, index, option, true);
     },
-    [index, option, onOptionClick]
+    [index, option, onOptionClick, disabled]
   );
 
   const onMouseLeave = useCallback(
@@ -116,11 +117,12 @@ const ComboboxOption: React.FC<ComboboxOptionProps> & { iconTypes?: typeof Combo
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
+      if (disabled) return;
       if (event.key === keyCodes.ENTER || event.key === keyCodes.SPACE) {
         onOptionClick(event, index, option, false);
       }
     },
-    [onOptionClick, index, option]
+    [onOptionClick, index, option, disabled]
   );
   if (!tooltipContent) {
     tooltipContent = isOptionOverflowing ? label : null;

--- a/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -117,12 +117,11 @@ const ComboboxOption: React.FC<ComboboxOptionProps> & { iconTypes?: typeof Combo
 
   const onKeyDown = useCallback(
     (event: React.KeyboardEvent) => {
-      if (disabled) return;
       if (event.key === keyCodes.ENTER || event.key === keyCodes.SPACE) {
         onOptionClick(event, index, option, false);
       }
     },
-    [onOptionClick, index, option, disabled]
+    [onOptionClick, index, option]
   );
   if (!tooltipContent) {
     tooltipContent = isOptionOverflowing ? label : null;


### PR DESCRIPTION
### Description
[https://github.com/mondaycom/vibe/issues/2481]: Restricted the onclick of the combobox in case of disabled options


- [x] I have read the [Contribution Guide](https://github.com/mondaycom/vibe/packages/core/CONTRIBUTING.md) for this project.

