### PR TITLE
docs: add dropdown options in the catalog

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/dropdown-description.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/dropdown-description.jsx
@@ -7,9 +7,14 @@ export const DropdownDescription = () => {
     const style = {
       width: "60%"
     };
+    const option = [
+      { id: "1", label: "Option 1" },
+      { id: "2", label: "Option 2" },
+      { id: "3", label: "Option 3" }
+    ];
     return (
       <div style={style}>
-        <Dropdown placeholder="Placeholder text here" size={Dropdown.sizes.MEDIUM} />
+        <Dropdown placeholder="Placeholder text here" size={Dropdown.sizes.MEDIUM} options={option} />
       </div>
     );
   }, []);


### PR DESCRIPTION
Docs #2482

Add options to the dropdown in the catalog. 
Also, below is the screenshot of the change that has been made.

<img width="322" alt="dropdown" src="https://github.com/user-attachments/assets/35538b9c-f5a2-4ca1-bed5-42048fdf017a">


- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
