### PR TITLE
docs: change the AttentionBox container size

### DIFF
--- a/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.scss
+++ b/packages/core/src/components/AttentionBox/__stories__/AttentionBox.stories.scss
@@ -2,7 +2,7 @@
 
 .monday-storybook-attention-box {
   &--fixed-width {
-    width: 430px;
+    width: 350px;
   }
 
   &_column-wrapper {
@@ -53,7 +53,7 @@
   }
 
   &_box {
-    width: 340px;
+    width: 274px;
   }
 
   &_search {


### PR DESCRIPTION
docs: #2483 

This PR changes the size of the ```<AttentionBox/>``` container. Below are the screenshots after the changes have been made.

<img width="522" alt="Screenshot 2024-10-12 at 3 10 03 PM" src="https://github.com/user-attachments/assets/4546dd70-dfab-47a3-887b-1d1c3f932ef9">

<img width="792" alt="Screenshot 2024-10-12 at 3 09 50 PM" src="https://github.com/user-attachments/assets/009c82ca-83aa-49bb-9a86-6b7a34ca1c2d">

- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
