### PR TITLE
fix: margin causing overflow & uncentered

### DIFF
--- a/packages/core/src/components/EditableTypography/EditableTypography.module.scss
+++ b/packages/core/src/components/EditableTypography/EditableTypography.module.scss
@@ -4,8 +4,6 @@
   display: inline-flex;
   min-width: 0;
   max-width: 100%;
-  // Shifts the component to align the text with the container
-  margin-left: -6px;
   overflow: hidden;
   position: relative;
 


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

## Fix

- Fixes #2471 

## Comment

https://github.com/mondaycom/vibe/blob/52415f4ef0bf8c358f38d620db87ee24f1ba1774/packages/core/src/components/EditableTypography/EditableTypography.module.scss#L7-L8

This doesn't seem to be needed anymore, the text and containers are centered without it but are off center with it.