### PR TITLE
fix: resolve unexpected click events for disabled options in Combobox #2481

### DIFF
--- a/packages/core/src/components/Combobox/__tests__/Combobox.test.js
+++ b/packages/core/src/components/Combobox/__tests__/Combobox.test.js
@@ -21,7 +21,8 @@ describe("Combobox tests", () => {
   describe("Without categories", () => {
     const mockOptions = [
       { value: "orange", label: "Orange" },
-      { value: "yellow", label: "Yellow" }
+      { value: "yellow", label: "Yellow" },
+      { value: "red", label: "Red", disabled: true }
     ];
 
     it("should call item on click callback func when onClick", () => {
@@ -88,6 +89,22 @@ describe("Combobox tests", () => {
         fireEvent.click(screen.getByText("Add new"));
         expect(onAddMock.mock.calls.length).toBe(1);
       });
+    });
+
+    it("should not call onClick for disabled option", () => {
+      const onClickMock = jest.fn();
+      const { getByLabelText } = render(<Combobox onClick={onClickMock} options={mockOptions} />);
+
+      fireEvent.click(getByLabelText("Red"));
+      expect(onClickMock).not.toHaveBeenCalled();
+    });
+
+    it("should NOT trigger hover event on disabled options", () => {
+      const onHoverMock = jest.fn();
+      const { getByLabelText } = render(<Combobox onOptionHover={onHoverMock} options={mockOptions} />);
+
+      fireEvent.mouseOver(getByLabelText("Red"));
+      expect(onHoverMock).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -93,9 +93,10 @@ const ComboboxOption: React.FC<ComboboxOptionProps> & { iconTypes?: typeof Combo
 
   const onClick = useCallback(
     (event: React.MouseEvent) => {
+      if (disabled) return;
       onOptionClick(event, index, option, true);
     },
-    [index, option, onOptionClick]
+    [index, option, onOptionClick, disabled]
   );
 
   const onMouseLeave = useCallback(


### PR DESCRIPTION
I wanted to let you know that I have fixed the issue with the combo box trigger on disabled options in my pull request for issue #2481.

Please let me know if you have any questions or if there’s anything specific you’d like to discuss regarding this fix!

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

