### PR TITLE
fix #2501: remove deprecated color names from Divider catalog component

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
@@ -21,7 +21,7 @@ export const DividerDescription = () => {
         <Divider />
         <Menu>
           <MenuItem
-            title="My Item "
+            title="My Item"
             icon={Bolt}
             iconType={Icon.type.SVG}
             iconBackgroundColor="var(--sb-color-purple)"

--- a/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
@@ -12,7 +12,7 @@ export const DividerDescription = () => {
       <div style={{ width: "220px" }}>
         <Menu>
           <MenuItem
-            title="My Item (stuck red)"
+            title="My Item"
             icon={Settings}
             iconType={Icon.type.SVG}
             iconBackgroundColor="var(--sb-negative-color)"
@@ -21,7 +21,7 @@ export const DividerDescription = () => {
         <Divider />
         <Menu>
           <MenuItem
-            title="My Item (indigo)"
+            title="My Item "
             icon={Bolt}
             iconType={Icon.type.SVG}
             iconBackgroundColor="var(--sb-color-purple)"


### PR DESCRIPTION
fix #2501 
Removed the deprecated color names from the "Divider" catalog component 

Screenshot after changes: 
<img width="318" alt="Screenshot 2024-10-13 at 2 15 05 PM" src="https://github.com/user-attachments/assets/03a965a9-706b-4536-89f6-4de7dd285053">

- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
