### PR TITLE
docs(Divider): fixed `divider.jsx` and removed the deprecated color names

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/divider.jsx
@@ -12,7 +12,7 @@ export const DividerDescription = () => {
       <div style={{ width: "220px" }}>
         <Menu>
           <MenuItem
-            title="My Item (stuck red)"
+            title="My Item"
             icon={Settings}
             iconType={Icon.type.SVG}
             iconBackgroundColor="var(--sb-negative-color)"
@@ -21,7 +21,7 @@ export const DividerDescription = () => {
         <Divider />
         <Menu>
           <MenuItem
-            title="My Item (indigo)"
+            title="My Item"
             icon={Bolt}
             iconType={Icon.type.SVG}
             iconBackgroundColor="var(--sb-color-purple)"


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

I have removed the deprecated color names

- [ ] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
