### PR TITLE
docs(Box): related Box should use Text instead of inline string

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/box-description.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/box-description.jsx
@@ -1,18 +1,18 @@
 import React, { useMemo } from "react";
 import { RelatedComponent } from "vibe-storybook-components";
 import Box from "../../../../components/Box/Box";
+import Text from "../../../../components/Text/Text";
 
 export const BoxDescription = () => {
   const component = useMemo(
     () => (
       <div
         style={{
-          width: "80%",
-          textAlign: "center"
+          width: "80%"
         }}
       >
         <Box border={Box.borders.DEFAULT} rounded={Box.roundeds.MEDIUM}>
-          Box
+          <Text align={Text.align.CENTER}>Box</Text>
         </Box>
       </div>
     ),


### PR DESCRIPTION
# Purpose

The aim of this pull request is to make the sample Box in the BoxDescription component use a Text component for its content instead of an inline string.

The changes are implemented by replicating the suggestion in the related issue.

# Checklist

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

# Related issue

Fixes #2506 