### PR TITLE
docs(DialogContentContainer): replace inline strings with Vibe's Text component

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/dialog-content-container.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/dialog-content-container.jsx
@@ -1,13 +1,14 @@
 import React, { useMemo } from "react";
 import { RelatedComponent } from "vibe-storybook-components";
 import DialogContentContainer from "../../../../components/DialogContentContainer/DialogContentContainer";
+import Text from "../../../../components/Text/Text"; 
 
 export const DialogContentContainerDescription = () => {
   const component = useMemo(() => {
     return (
       <div style={{ width: "200px" }}>
         <DialogContentContainer>
-          <p>A content section within an elevated dialog content container</p>
+          <Text ellipsis={false}>A content section within an elevated dialog content container</Text>
         </DialogContentContainer>
       </div>
     );

--- a/packages/core/src/storybook/components/related-components/descriptions/dialog-content-container.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/dialog-content-container.jsx
@@ -1,7 +1,7 @@
 import React, { useMemo } from "react";
 import { RelatedComponent } from "vibe-storybook-components";
 import DialogContentContainer from "../../../../components/DialogContentContainer/DialogContentContainer";
-import Text from "../../../../components/Text/Text"; 
+import Text from "../../../../components/Text/Text";
 
 export const DialogContentContainerDescription = () => {
   const component = useMemo(() => {


### PR DESCRIPTION
**What changes are you making?**
This PR replaces the inline string in the DialogContentContainer located in `packages/core/src/storybook/components/related-components/descriptions/dialog-content-container.jsx `with Vibe's Text component.

**Motivation for these changes:**
Currently, the DialogContentContainer uses inline strings, which leads to theme inconsistencies, particularly in dark mode. By implementing the Text component, we can ensure proper styling and a consistent appearance across different themes.

**Impact on the project:**
This update resolves the styling issues related to dark themes and aligns with Vibe's design specifications, enhancing the user experience.

[Link to the issue](https://github.com/mondaycom/vibe/issues/2508#issue-2583857804)
I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
