### PR TITLE
docs(Clickable): related component should use Text instead of inline string

### DIFF
--- a/packages/core/src/storybook/components/related-components/descriptions/clickable-description/clickable-description.jsx
+++ b/packages/core/src/storybook/components/related-components/descriptions/clickable-description/clickable-description.jsx
@@ -3,12 +3,13 @@ import React, { useMemo } from "react";
 import { RelatedComponent } from "vibe-storybook-components";
 import Clickable from "../../../../../components/Clickable/Clickable";
 import classes from "./clickable-description.stories.module.scss";
+import { Text } from "../../../../../components";
 
 export const ClickableDescription = () => {
   const component = useMemo(() => {
     return (
       <Clickable className={classes["clickable-description"]} onClick={() => alert("clicked")}>
-        <div>Button with custom appearance</div>
+        <Text ellipsis={false}>Button with custom appearance</Text>
       </Clickable>
     );
   }, []);


### PR DESCRIPTION
We do not currently use Vibe's `Text` component, but instead use inline string.

This PR fix this, `Text` component is now properly used.

Resolves #2507
