### PR TITLE
docs(VirtualizedGrid): should use Text instead of inline string

### DIFF
--- a/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.stories.helpers.js
+++ b/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.stories.helpers.js
@@ -1,5 +1,5 @@
 import React from "react";
-import { Text } from "src/components/Text";
+import { Text } from "../../Text";
 
 export const generateItems = (height = 30, width = "100%", itemsCount) => {
   const items = [];

--- a/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.stories.helpers.js
+++ b/packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.stories.helpers.js
@@ -1,4 +1,5 @@
 import React from "react";
+import { Text } from "src/components/Text";
 
 export const generateItems = (height = 30, width = "100%", itemsCount) => {
   const items = [];
@@ -13,7 +14,8 @@ export const itemRenderer = (item, index, style) => {
     const backgroundColor = index % 2 === 0 ? "#e1e1e1" : "#f8f8f0";
     return (
       <div key={index} style={style}>
-        <div
+        <Text
+          color={Text.colors.FIXED_DARK}
           style={{
             backgroundColor,
             height: item.height,
@@ -24,7 +26,7 @@ export const itemRenderer = (item, index, style) => {
           }}
         >
           {item.value}
-        </div>
+        </Text>
       </div>
     );
   }


### PR DESCRIPTION
Changes made:
Replaced the `div` with the `Text` component in the `packages/core/src/components/VirtualizedGrid/__stories__/VirtualizedGrid.stories.helpers.js` file.

- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

Resolves #2505
