### PR TITLE
docs(Colors): migrate "Story of" to "Canvas of"

### DIFF
--- a/packages/core/src/storybook/stand-alone-documentaion/colors/Colors.mdx
+++ b/packages/core/src/storybook/stand-alone-documentaion/colors/Colors.mdx
@@ -8,9 +8,10 @@ import { BorderColors } from "./border-colors/border-colors";
 import { ContentColors } from "./content-colors/content-colors";
 import { cardColorsExample, menuColorsExample } from "./assets";
 import { ComponentNameDecorator } from "../../components";
+import * as ColorsStories from "./colors.stories.tsx"
 import styles from "./colors.module.scss";
 
-<Meta title="Foundations/Colors" />
+<Meta of={ColorsStories} />
 
 <ComponentNameDecorator withFoundationBackground>Colors</ComponentNameDecorator>
 
@@ -30,35 +31,19 @@ The colors are designed to be clear and accessible. They come in three color the
 
 ### Semantic colors
 
-<Canvas>
-  <Story name="Semantic Colors">
-    <SemanticColors />
-  </Story>
-</Canvas>
+<Canvas of={ColorsStories.Semantic} sourceState="none" />
 
 ### Background colors
 
-<Canvas>
-  <Story name="Background Colors">
-    <BackgroundColors />
-  </Story>
-</Canvas>
+<Canvas of={ColorsStories.Background} sourceState="none" />
 
 ### Text colors
 
-<Canvas>
-  <Story name="Text Colors">
-    <TextColors />
-  </Story>
-</Canvas>
+<Canvas of={ColorsStories.Text} sourceState="none" />
 
 ### Border colors
 
-<Canvas>
-  <Story name="Border Colors">
-    <BorderColors />
-  </Story>
-</Canvas>
+<Canvas of={ColorsStories.Border} sourceState="none" />
 
 ### Content colors
 
@@ -66,11 +51,7 @@ These colors are used only for color coding purposes like groups colors, statuse
 this gives understanding and indication of orientation and belonging.
 The board's main strength is its simple and visual appearance. That's why the status colors should appear on the board and nowhere else in the UI.
 
-<Canvas>
-  <Story name="Content Colors">
-    <ContentColors />
-  </Story>
-</Canvas>
+<Canvas of={ColorsStories.Content} sourceState="none" />
 
 ## Usage and examples
 

--- a/packages/core/src/storybook/stand-alone-documentaion/colors/colors.stories.tsx
+++ b/packages/core/src/storybook/stand-alone-documentaion/colors/colors.stories.tsx
@@ -1,0 +1,33 @@
+import { Meta, StoryObj } from "@storybook/react";
+import { SemanticColors } from "./semantic-colors/semantic-colors";
+import { BackgroundColors } from "./background-colors/background-colors";
+import TextColors from "./text-colors/text-colors";
+import { BorderColors } from "./border-colors/border-colors";
+import { ContentColors } from "./content-colors/content-colors";
+
+const meta: Meta = {
+  title: "Foundations/Colors"
+};
+export default meta;
+
+type Story = StoryObj;
+
+export const Semantic: Story = {
+  render: SemanticColors
+};
+
+export const Background: Story = {
+  render: BackgroundColors
+};
+
+export const Text: Story = {
+  render: TextColors
+};
+
+export const Border: Story = {
+  render: BorderColors
+};
+
+export const Content: Story = {
+  render: ContentColors
+};


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->
Resolves #2499

* Implemented `colors.stories.tsx` to follow [CSF 3.0](https://storybook.js.org/docs/api/csf)
* Changed `colors.stories.mdx` to `Colors.mdx`
* Updated `Meta` to use `of` attr instead of `title`
