### PR TITLE
docs(Modal): migrate "Story of" to "Canvas of" in "Sizes" story

### DIFF
--- a/packages/core/src/components/Modal/__stories__/Modal.mdx
+++ b/packages/core/src/components/Modal/__stories__/Modal.mdx
@@ -53,11 +53,7 @@ Use modal for short and non-frequent tasks. For common tasks consider using the 
 
 ### Sizes
 
-<Canvas>
-  <Story of={ModalStories.WidthVariantsNormal} />
-  <Story of={ModalStories.WidthVariantsFull} />
-  <Story of={ModalStories.WidthVariantsCustom} />
-</Canvas>
+<Canvas of={ModalStories.Sizes} />
 
 ### Modal header with an icon
 

--- a/packages/core/src/components/Modal/__stories__/Modal.mdx
+++ b/packages/core/src/components/Modal/__stories__/Modal.mdx
@@ -53,7 +53,9 @@ Use modal for short and non-frequent tasks. For common tasks consider using the 
 
 ### Sizes
 
-<Canvas of={ModalStories.Sizes} />
+<Canvas of={ModalStories.WidthVariantsNormal}/>
+<Canvas of={ModalStories.WidthVariantsFull}/>
+<Canvas of={ModalStories.WidthVariantsCustom} />
 
 ### Modal header with an icon
 


### PR DESCRIPTION
Changes made: 
- Added the `Canvas` to replace the deprecated `Story` usage in Modal's docs page.

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

Resolves #2500 
