### PR TITLE
fix: Dropdown font broken

### DIFF
--- a/packages/core/src/components/Dropdown/Dropdown.styles.js
+++ b/packages/core/src/components/Dropdown/Dropdown.styles.js
@@ -39,7 +39,11 @@ const getColor = () => {
   return { color, backgroundColor };
 };
 
-const getFont = size => ({ fontSize: getSingleValueTextSize(size), lineHeight: getSingleValueTextSize(size) });
+const getFont = size => ({
+  fontSize: getSingleValueTextSize(size),
+  lineHeight: getSingleValueTextSize(size),
+  fontFamily: getCSSVar("font-family")
+});
 
 const disabledContainerStyle = isDisabled => {
   if (!isDisabled) return {};


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->
Resolves #2182

### Issue:
- Font family was not getting applied in dropdown, instead it was getting applied from story body CSS directly
<img width="1438" alt="Screenshot 2024-10-20 at 12 54 29 AM" src="https://github.com/user-attachments/assets/c92220ba-e2f9-4b3b-8771-8b5f9b291707">

### After Fix:
<img width="1438" alt="Screenshot 2024-10-20 at 12 55 47 AM" src="https://github.com/user-attachments/assets/b382a140-688d-495f-9585-94e05e8650e6">

