### PR TITLE
fix: EditableText and EditableHeading overflowing in the catalog

### DIFF
--- a/packages/core/src/components/EditableTypography/EditableTypography.module.scss
+++ b/packages/core/src/components/EditableTypography/EditableTypography.module.scss
@@ -1,7 +1,7 @@
 @import "~monday-ui-style/dist/mixins";
 
 .editableTypography {
-  display: inline-flex;
+  display: contents;
   min-width: 0;
   max-width: 100%;
   // Shifts the component to align the text with the container

--- a/packages/core/src/components/EditableTypography/EditableTypography.module.scss
+++ b/packages/core/src/components/EditableTypography/EditableTypography.module.scss
@@ -1,11 +1,12 @@
 @import "~monday-ui-style/dist/mixins";
 
 .editableTypography {
-  display: contents;
+  display: block;
   min-width: 0;
-  max-width: 100%;
   // Shifts the component to align the text with the container
   margin-left: -6px;
+  // Adds 6 px removed above to the element width to avoid unnecessary overflow
+  max-width: calc(100% + 6px);
   overflow: hidden;
   position: relative;
 

--- a/packages/core/src/components/EditableTypography/EditableTypography.module.scss
+++ b/packages/core/src/components/EditableTypography/EditableTypography.module.scss
@@ -1,7 +1,7 @@
 @import "~monday-ui-style/dist/mixins";
 
 .editableTypography {
-  display: block;
+  display: inline-flex;
   min-width: 0;
   // Shifts the component to align the text with the container
   margin-left: -6px;


### PR DESCRIPTION
- [X] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

Resolves #2471

### Details

Based on [this tip](https://github.com/mondaycom/vibe/issues/2471#issuecomment-2409017206) I updated editableTypography style. 

The following checks pass locally:
- [X] tests 
- [X] linter 

To verify that changes work, I checked catalog locally and it looks like overflow works correctly (see screenshots below)
![image](https://github.com/user-attachments/assets/7f9b673c-4408-4ba5-824c-b69a7723995b)
![image](https://github.com/user-attachments/assets/a5f67656-ed00-4e6e-8ab1-5d5e9a235eb3)

Questions:
- Are there other scenarios that I should test?
- In the component description of <Heading> there is information about overflow behavior, while there is no such info in the description for <EditableHeading>. Should it be added?