### PR TITLE
feat(Modal): control autofocus and keyboard navigation focus

### DIFF
--- a/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
+++ b/packages/core/src/components/ModalNew/ModalContent/ModalContent.tsx
@@ -16,6 +16,7 @@ const ModalContent = forwardRef(
         className={cx(styles.content, className)}
         id={id}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL_NEXT_CONTENT, id)}
+        data-autofocus-inside={true}
       >
         {children}
       </div>

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.module.scss
@@ -1,4 +1,6 @@
 .actions {
+  display: flex;
+  align-items: center;
   position: absolute;
   right: var(--spacing-large);
   top: var(--spacing-large);

--- a/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
+++ b/packages/core/src/components/ModalNew/ModalTopActions/ModalTopActions.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import styles from "./ModalTopActions.module.scss";
 import { ModalTopActionsButtonColor, ModalTopActionsColor, ModalTopActionsProps } from "./ModalTopActions.types";
-import Flex from "../../Flex/Flex";
 import IconButton from "../../IconButton/IconButton";
 import { CloseMedium } from "../../Icon/Icons";
 import { ButtonColor } from "../../Button/ButtonConstants";
@@ -15,7 +14,7 @@ const ModalTopActions = ({ renderAction, color, closeButtonAriaLabel, onClose }:
   const buttonColor = colorToButtonColor[color] || ButtonColor.PRIMARY;
 
   return (
-    <Flex className={styles.actions}>
+    <div className={styles.actions} data-no-autofocus={true}>
       {typeof renderAction === "function" ? renderAction(buttonColor) : renderAction}
       <IconButton
         icon={CloseMedium}
@@ -25,7 +24,7 @@ const ModalTopActions = ({ renderAction, color, closeButtonAriaLabel, onClose }:
         color={buttonColor}
         ariaLabel={closeButtonAriaLabel}
       />
-    </Flex>
+    </div>
   );
 };
 


### PR DESCRIPTION
- Always start autofocus cycle on content
- Skip top actions (close button + render action) from autofocusing on first focus cycle of modal

https://monday.monday.com/boards/3532714909/pulses/7360929204