### PR TITLE
feat(TextArea): Character count and maxLength

### DIFF
--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -24,15 +24,7 @@
     color: var(--secondary-text-color);
 
     .helpText {
-      width: fit-content;
       display: flex;
-      flex-grow: 1;
-    }
-
-    .limitText {
-      width: fit-content;
-      flex-shrink: 0;
-      margin-left: auto;
     }
   }
 

--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -21,10 +21,7 @@
   }
 
   .subTextContainer {
-    display: flex;
-    gap: var(--spacing-xs);
     color: var(--secondary-text-color);
-    align-items: top;
 
     .helpText {
       width: fit-content;

--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -20,8 +20,22 @@
     }
   }
 
-  .helpText {
+  .subTextContainer {
+    display: flex;
+    gap: var(--spacing-xs);
     color: var(--secondary-text-color);
+    align-items: top;
+
+    .helpText {
+      width: fit-content;
+      display: flex;
+      flex-grow: 1;
+    }
+
+    .limitText {
+      width: fit-content;
+      flex-shrink: 0;
+    }
   }
 
   .textArea {
@@ -71,12 +85,14 @@
       border-color: var(--color-error);
     }
 
-    .helpText {
+    .helpText,
+    .limitText {
       color: var(--color-error);
     }
   }
 
   &.disabled {
+
     .textArea,
     .textArea:hover {
       color: var(--disabled-text-color);
@@ -90,6 +106,7 @@
   }
 
   &.readOnly {
+
     .textArea,
     .textArea:hover {
       background-color: var(--allgrey-background-color);

--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -26,6 +26,10 @@
     .helpText {
       display: flex;
     }
+
+    .limitText {
+      margin-left: auto;
+    }
   }
 
   .textArea {

--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -92,7 +92,6 @@
   }
 
   &.disabled {
-
     .textArea,
     .textArea:hover {
       color: var(--disabled-text-color);
@@ -106,7 +105,6 @@
   }
 
   &.readOnly {
-
     .textArea,
     .textArea:hover {
       background-color: var(--allgrey-background-color);

--- a/packages/core/src/components/TextArea/TextArea.module.scss
+++ b/packages/core/src/components/TextArea/TextArea.module.scss
@@ -35,6 +35,7 @@
     .limitText {
       width: fit-content;
       flex-shrink: 0;
+      margin-left: auto;
     }
   }
 

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -5,6 +5,7 @@ import { ComponentDefaultTestId } from "../../tests/constants";
 import styles from "./TextArea.module.scss";
 import { TextAreaProps, TextAreaSize } from "./TextArea.types";
 import Text from "../Text/Text";
+import { Flex } from "../Flex";
 
 const DEFAULT_ROWS: Record<TextAreaSize, number> = {
   small: 3,
@@ -81,19 +82,19 @@ const TextArea = forwardRef(
           aria-describedby={helpTextId ?? undefined}
           onChange={handleOnChange}
         />
-        <div className={cx(styles.subTextContainer)}>
+        <Flex gap={Flex.gaps.XS} className={cx(styles.subTextContainer)}>
           {helpText && (
             <Text className={cx(styles.helpText)} color={Text.colors.INHERIT} id={helpTextId}>
               {helpText}
             </Text>
           )}
           {showCharCount && (
-            <div className={cx(styles.limitText)}>
+            <Flex className={cx(styles.limitText)}>
               {characterCount}
               {maxLength && `/${maxLength}`}
-            </div>
+            </Flex>
           )}
-        </div>
+        </Flex>
       </div>
     );
   }

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useState } from "react";
+import React, { forwardRef, useCallback, useState } from "react";
 import cx from "classnames";
 import { getTestId } from "../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../tests/constants";
@@ -39,18 +39,18 @@ const TextArea = forwardRef(
 
     const [characterCount, setCharacterCount] = useState(rest.value?.length || 0);
 
-    const handleKeyDown = (event: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
       if (!allowExceedingLimit && event.currentTarget.value.length >= characterLimit && !['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
         event.preventDefault();
         event.stopPropagation();
       }
       rest.onKeyDown?.(event);
-    };
+    }, [allowExceedingLimit, characterLimit, rest.onKeyDown]);
 
-    const handleOnChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const handleOnChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
       setCharacterCount(event.target.value.length);
       onChange?.(event);
-    }
+    }, [onChange]);
 
     return (
       <div

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -6,6 +6,7 @@ import styles from "./TextArea.module.scss";
 import { TextAreaProps, TextAreaSize } from "./TextArea.types";
 import Text from "../Text/Text";
 import { Flex } from "../Flex";
+import { HiddenText } from "../HiddenText";
 
 const DEFAULT_ROWS: Record<TextAreaSize, number> = {
   small: 3,
@@ -80,7 +81,7 @@ const TextArea = forwardRef(
           rows={numRows}
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
           aria-invalid={error}
-          aria-describedby={helpTextId ?? undefined}
+          aria-describedby={[helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined}
           onChange={handleOnChange}
         />
         <Flex gap={Flex.gaps.XS} className={cx(styles.subTextContainer)}>
@@ -93,6 +94,7 @@ const TextArea = forwardRef(
             <Flex className={cx(styles.limitText)}>
               {characterCount}
               {maxLength && `/${maxLength}`}
+              <HiddenText id={allowExceedingMaxLengthTextId} text={`Maximum of ${maxLength} characters`} />
             </Flex>
           )}
         </Flex>

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -41,7 +41,7 @@ const TextArea = forwardRef(
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
-    const inErrorState = error || (maxLength && value?.length > maxLength);
+    const isErrorState = error || (maxLength && value?.length > maxLength);
 
     const ariaDescribedby = useMemo(
       () => [helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined,
@@ -63,7 +63,7 @@ const TextArea = forwardRef(
         className={cx(
           styles.textAreaWrapper,
           {
-            [styles.error]: inErrorState,
+            [styles.error]: isErrorState,
             [styles.success]: success,
             [styles.disabled]: disabled,
             [styles.readOnly]: readOnly

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -30,6 +30,7 @@ const TextArea = forwardRef(
       allowExceedingLimit,
       onChange,
       resize = true,
+      showCharCount = false,
       ...rest
     }: TextAreaProps,
     ref: React.ForwardedRef<HTMLTextAreaElement>
@@ -83,7 +84,7 @@ const TextArea = forwardRef(
               {helpText}
             </Text>
           )}
-          {maxLength && <div className={cx(styles.limitText)}>{characterCount}/{maxLength}</div>}
+          {maxLength && showCharCount && <div className={cx(styles.limitText)}>{characterCount}/{maxLength}</div>}
         </div>
       </div>
     );

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -84,7 +84,7 @@ const TextArea = forwardRef(
           aria-describedby={[helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined}
           onChange={handleOnChange}
         />
-        <Flex gap={Flex.gaps.XS} className={cx(styles.subTextContainer)}>
+        <Flex gap={Flex.gaps.XS} justify={Flex.justify.SPACE_BETWEEN} className={cx(styles.subTextContainer)}>
           {helpText && (
             <Text className={cx(styles.helpText)} color={Text.colors.INHERIT} id={helpTextId}>
               {helpText}

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -93,7 +93,7 @@ const TextArea = forwardRef(
           {showCharCount && (
             <Flex className={cx(styles.limitText)}>
               {characterCount}
-              {maxLength && `/${maxLength}`}
+              {typeof maxLength === "number" && `/${maxLength}`}
               <HiddenText id={allowExceedingMaxLengthTextId} text={`Maximum of ${maxLength} characters`} />
             </Flex>
           )}

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -40,10 +40,13 @@ const TextArea = forwardRef(
 
     const [characterCount, setCharacterCount] = useState(rest.value?.length || 0);
 
-    const handleOnChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
-      setCharacterCount(event.target.value.length);
-      onChange?.(event);
-    }, [onChange]);
+    const handleOnChange = useCallback(
+      (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+        setCharacterCount(event.target.value.length);
+        onChange?.(event);
+      },
+      [onChange]
+    );
 
     return (
       <div
@@ -84,7 +87,12 @@ const TextArea = forwardRef(
               {helpText}
             </Text>
           )}
-          {maxLength && showCharCount && <div className={cx(styles.limitText)}>{characterCount}/{maxLength}</div>}
+          {showCharCount && (
+            <div className={cx(styles.limitText)}>
+              {characterCount}
+              {maxLength && `/${maxLength}`}
+            </div>
+          )}
         </div>
       </div>
     );

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -41,6 +41,7 @@ const TextArea = forwardRef(
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
+    const inErrorState = error || (maxLength && value?.length > maxLength);
 
     const [characterCount, setCharacterCount] = useState(value?.length || 0);
 
@@ -57,7 +58,7 @@ const TextArea = forwardRef(
         className={cx(
           styles.textAreaWrapper,
           {
-            [styles.error]: error || (maxLength && characterCount > maxLength),
+            [styles.error]: inErrorState,
             [styles.success]: success,
             [styles.disabled]: disabled,
             [styles.readOnly]: readOnly

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -26,7 +26,7 @@ const TextArea = forwardRef(
       disabled,
       readOnly,
       required,
-      characterLimit,
+      maxLength,
       allowExceedingLimit,
       onChange,
       resize = true,
@@ -39,14 +39,6 @@ const TextArea = forwardRef(
 
     const [characterCount, setCharacterCount] = useState(rest.value?.length || 0);
 
-    const handleKeyDown = useCallback((event: React.KeyboardEvent<HTMLTextAreaElement>) => {
-      if (!allowExceedingLimit && event.currentTarget.value.length >= characterLimit && !['Backspace', 'Delete', 'ArrowLeft', 'ArrowRight'].includes(event.key)) {
-        event.preventDefault();
-        event.stopPropagation();
-      }
-      rest.onKeyDown?.(event);
-    }, [allowExceedingLimit, characterLimit, rest.onKeyDown]);
-
     const handleOnChange = useCallback((event: React.ChangeEvent<HTMLTextAreaElement>) => {
       setCharacterCount(event.target.value.length);
       onChange?.(event);
@@ -57,7 +49,7 @@ const TextArea = forwardRef(
         className={cx(
           styles.textAreaWrapper,
           {
-            [styles.error]: error || (characterLimit && characterCount > characterLimit),
+            [styles.error]: error || (maxLength && characterCount > maxLength),
             [styles.success]: success,
             [styles.disabled]: disabled,
             [styles.readOnly]: readOnly
@@ -74,6 +66,7 @@ const TextArea = forwardRef(
         <textarea
           {...rest}
           id={id}
+          maxLength={maxLength && !allowExceedingLimit ? maxLength : undefined}
           ref={ref}
           disabled={disabled}
           readOnly={readOnly}
@@ -83,7 +76,6 @@ const TextArea = forwardRef(
           aria-invalid={error}
           aria-describedby={helpTextId ?? undefined}
           onChange={handleOnChange}
-          onKeyDown={handleKeyDown}
         />
         <div className={cx(styles.subTextContainer)}>
           {helpText && (
@@ -91,7 +83,7 @@ const TextArea = forwardRef(
               {helpText}
             </Text>
           )}
-          {characterLimit && <div className={cx(styles.limitText)}>{characterCount}/{characterLimit}</div>}
+          {maxLength && <div className={cx(styles.limitText)}>{characterCount}/{maxLength}</div>}
         </div>
       </div>
     );

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useCallback, useState } from "react";
+import React, { forwardRef, useCallback, useMemo, useState } from "react";
 import cx from "classnames";
 import { getTestId } from "../../tests/test-ids-utils";
 import { ComponentDefaultTestId } from "../../tests/constants";
@@ -43,6 +43,11 @@ const TextArea = forwardRef(
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
     const inErrorState = error || (maxLength && value?.length > maxLength);
 
+    const ariaDescribedby = useMemo(
+      () => [helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined,
+      [helpTextId, allowExceedingMaxLengthTextId]
+    );
+
     const [characterCount, setCharacterCount] = useState(value?.length || 0);
 
     const handleOnChange = useCallback(
@@ -84,7 +89,7 @@ const TextArea = forwardRef(
           rows={numRows}
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
           aria-invalid={error}
-          aria-describedby={[helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined}
+          aria-describedby={ariaDescribedby}
           onChange={handleOnChange}
         />
         <Flex gap={Flex.gaps.XS} justify={Flex.justify.SPACE_BETWEEN} className={cx(styles.subTextContainer)}>
@@ -94,11 +99,13 @@ const TextArea = forwardRef(
             </Text>
           )}
           {showCharCount && (
-            <Flex className={cx(styles.limitText)}>
-              {characterCount}
-              {typeof maxLength === "number" && `/${maxLength}`}
+            <>
+              <Text className={styles.limitText}>
+                {characterCount}
+                {typeof maxLength === "number" && `/${maxLength}`}
+              </Text>
               <HiddenText id={allowExceedingMaxLengthTextId} text={`Maximum of ${maxLength} characters`} />
-            </Flex>
+            </>
           )}
         </Flex>
       </div>

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -28,7 +28,7 @@ const TextArea = forwardRef(
       readOnly,
       required,
       maxLength,
-      allowExceedingLimit,
+      allowExceedingMaxLength,
       onChange,
       resize = true,
       showCharCount = false,
@@ -38,6 +38,7 @@ const TextArea = forwardRef(
   ) => {
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
+    const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
 
     const [characterCount, setCharacterCount] = useState(rest.value?.length || 0);
 
@@ -71,7 +72,7 @@ const TextArea = forwardRef(
         <textarea
           {...rest}
           id={id}
-          maxLength={maxLength && !allowExceedingLimit ? maxLength : undefined}
+          maxLength={typeof maxLength === "number" && !allowExceedingMaxLength ? maxLength : undefined}
           ref={ref}
           disabled={disabled}
           readOnly={readOnly}

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -31,6 +31,7 @@ const TextArea = forwardRef(
       maxLength,
       allowExceedingMaxLength,
       onChange,
+      value,
       resize = true,
       showCharCount = false,
       ...rest
@@ -41,7 +42,7 @@ const TextArea = forwardRef(
     const helpTextId = helpText && `${id}-help-text`;
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
 
-    const [characterCount, setCharacterCount] = useState(rest.value?.length || 0);
+    const [characterCount, setCharacterCount] = useState(value?.length || 0);
 
     const handleOnChange = useCallback(
       (event: React.ChangeEvent<HTMLTextAreaElement>) => {
@@ -75,6 +76,7 @@ const TextArea = forwardRef(
           id={id}
           maxLength={typeof maxLength === "number" && !allowExceedingMaxLength ? maxLength : undefined}
           ref={ref}
+          value={value}
           disabled={disabled}
           readOnly={readOnly}
           required={required}

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -58,4 +58,8 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    * If true, the textarea will allow the user to exceed the character limit.
    */
   allowExceedingLimit?: boolean;
+  /**
+   * If true, the character count and limit will be displayed below the textarea.
+   */
+  showCharCount?: boolean;
 }

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -7,7 +7,23 @@ type TextAreaNativeInputProps = Omit<
   "role" | "aria-describedby" | "aria-invalid"
 >;
 
-export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentProps {
+/**
+ * This type ensures that allowExceedingMaxLength is only used when maxLength is provided.
+ */
+type MaxLengthProps =
+  | {
+      /**
+       * The allowed number of characters.
+       */
+      maxLength?: number;
+      /**
+       * If true, the TextArea will allow the user to exceed the character limit.
+       */
+      allowExceedingMaxLength?: false;
+    }
+  | { allowExceedingMaxLength: true; maxLength: number };
+
+interface TextAreaInterface extends TextAreaNativeInputProps, VibeComponentProps {
   /**
    * The current value of the textarea.
    */
@@ -51,15 +67,9 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    */
   placeholder?: string;
   /**
-   * The allowed number of characters.
-   */
-  maxLength?: number;
-  /**
-   * If true, the TextArea will allow the user to exceed the character limit.
-   */
-  allowExceedingMaxLength?: boolean;
-  /**
    * If true, the character count and limit will be displayed below the textarea.
    */
   showCharCount?: boolean;
 }
+
+export type TextAreaProps = TextAreaInterface & MaxLengthProps;

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -55,9 +55,9 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    */
   maxLength?: number;
   /**
-   * If true, the textarea will allow the user to exceed the character limit.
+   * If true, the TextArea will allow the user to exceed the character limit.
    */
-  allowExceedingLimit?: boolean;
+  allowExceedingMaxLength?: boolean;
   /**
    * If true, the character count and limit will be displayed below the textarea.
    */

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -7,23 +7,7 @@ type TextAreaNativeInputProps = Omit<
   "role" | "aria-describedby" | "aria-invalid"
 >;
 
-/**
- * This type ensures that allowExceedingMaxLength is only used when maxLength is provided.
- */
-type MaxLengthProps =
-  | {
-      /**
-       * The allowed number of characters.
-       */
-      maxLength?: number;
-      /**
-       * If true, the TextArea will allow the user to exceed the character limit.
-       */
-      allowExceedingMaxLength?: false;
-    }
-  | { allowExceedingMaxLength: true; maxLength: number };
-
-interface TextAreaInterface extends TextAreaNativeInputProps, VibeComponentProps {
+export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentProps {
   /**
    * The current value of the textarea.
    */
@@ -67,9 +51,15 @@ interface TextAreaInterface extends TextAreaNativeInputProps, VibeComponentProps
    */
   placeholder?: string;
   /**
+   * The allowed number of characters.
+   */
+  maxLength?: number;
+  /**
+   * If true, the TextArea will allow the user to exceed the character limit.
+   */
+  allowExceedingMaxLength?: boolean;
+  /**
    * If true, the character count and limit will be displayed below the textarea.
    */
   showCharCount?: boolean;
 }
-
-export type TextAreaProps = TextAreaInterface & MaxLengthProps;

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -50,4 +50,12 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    * Placeholder text to display when the textarea is empty.
    */
   placeholder?: string;
+  /**
+   * The allowed number of characters.
+   */
+  characterLimit?: number;
+  /**
+   * If true, the textarea will allow the user to exceed the character limit.
+   */
+  allowExceedingLimit?: boolean;
 }

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -55,7 +55,8 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
    */
   maxLength?: number;
   /**
-   * If true, the TextArea will allow the user to exceed the character limit.
+   * If true, the TextArea will allow the user to exceed the character limit set by maxLength.
+   * Note: Using this prop will only make sense alongside the maxLength prop.
    */
   allowExceedingMaxLength?: boolean;
   /**

--- a/packages/core/src/components/TextArea/TextArea.types.ts
+++ b/packages/core/src/components/TextArea/TextArea.types.ts
@@ -53,7 +53,7 @@ export interface TextAreaProps extends TextAreaNativeInputProps, VibeComponentPr
   /**
    * The allowed number of characters.
    */
-  characterLimit?: number;
+  maxLength?: number;
   /**
    * If true, the textarea will allow the user to exceed the character limit.
    */

--- a/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
@@ -42,8 +42,7 @@ export const Overview: Story = {
   render: textAreaTemplate.bind({}),
   args: {
     label: "Text area label",
-    helpText: "Helper text",
-    showCharCount: true,
+    helpText: "Helper text"
   },
   parameters: {
     docs: {

--- a/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
@@ -43,7 +43,6 @@ export const Overview: Story = {
   args: {
     label: "Text area label",
     helpText: "Helper text",
-    maxLength: 2000,
     showCharCount: true,
   },
   parameters: {

--- a/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
+++ b/packages/core/src/components/TextArea/__stories__/TextArea.stories.tsx
@@ -42,7 +42,9 @@ export const Overview: Story = {
   render: textAreaTemplate.bind({}),
   args: {
     label: "Text area label",
-    helpText: "Helper text"
+    helpText: "Helper text",
+    maxLength: 2000,
+    showCharCount: true,
   },
   parameters: {
     docs: {

--- a/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -107,13 +107,17 @@ describe("TextArea", () => {
       expect(screen.queryByText("0/")).not.toBeInTheDocument();
     });
 
+    it("should not show character count when only maxLength is provided", () => {
+      render(<TextArea maxLength={5} />);
+      expect(screen.queryByText("0/5")).not.toBeInTheDocument();
+    });
+
     it("should prevent typing when character limit is reached", () => {
       const handleChange = jest.fn();
-      render(<TextArea maxLength={5} allowExceedingLimit={false} onChange={handleChange} />);
+      render(<TextArea showCharCount maxLength={5} allowExceedingLimit={false} onChange={handleChange} />);
 
       const charCount = screen.getByText("0/5");
       expect(charCount).toBeInTheDocument();
-      
 
       const input = screen.getByRole("textbox");
       userEvent.type(input, "12345a");
@@ -124,7 +128,7 @@ describe("TextArea", () => {
     });
 
     it("should allow typing when limit is allowed to be exceeded", () => {
-      render(<TextArea maxLength={10} allowExceedingLimit={true} />);
+      render(<TextArea showCharCount maxLength={10} allowExceedingLimit={true} />);
 
       const charCount = screen.getByText("0/10");
       expect(charCount).toBeInTheDocument();
@@ -137,7 +141,7 @@ describe("TextArea", () => {
     });
 
     it("should allow text removal when character limit is exceeded", async () => {
-      render(<TextArea maxLength={5} allowExceedingLimit={false} />);
+      render(<TextArea showCharCount maxLength={5} allowExceedingLimit={false} />);
 
       const input = screen.getByRole("textbox");
       userEvent.type(input, "12345");

--- a/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -119,7 +119,7 @@ describe("TextArea", () => {
 
     it("should prevent typing when character limit is reached", () => {
       const handleChange = jest.fn();
-      render(<TextArea showCharCount maxLength={5} allowExceedingLimit={false} onChange={handleChange} />);
+      render(<TextArea showCharCount maxLength={5} allowExceedingMaxLength={false} onChange={handleChange} />);
 
       const charCount = screen.getByText("0/5");
       expect(charCount).toBeInTheDocument();
@@ -133,7 +133,7 @@ describe("TextArea", () => {
     });
 
     it("should allow typing when limit is allowed to be exceeded", () => {
-      render(<TextArea showCharCount maxLength={10} allowExceedingLimit={true} />);
+      render(<TextArea showCharCount maxLength={10} allowExceedingMaxLength={true} />);
 
       const charCount = screen.getByText("0/10");
       expect(charCount).toBeInTheDocument();
@@ -145,8 +145,8 @@ describe("TextArea", () => {
       expect(charCount).toHaveTextContent("11/10");
     });
 
-    it("should allow text removal when character limit is exceeded", async () => {
-      render(<TextArea showCharCount maxLength={5} allowExceedingLimit={false} />);
+    it("should allow text removal when character limit is exceeded", () => {
+      render(<TextArea showCharCount maxLength={5} allowExceedingMaxLength={false} />);
 
       const input = screen.getByRole("textbox");
       userEvent.type(input, "12345");

--- a/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -107,6 +107,11 @@ describe("TextArea", () => {
       expect(screen.queryByText("0/")).not.toBeInTheDocument();
     });
 
+    it("it only shows character count with showCharCount and no MaxLength", () => {
+      render(<TextArea showCharCount />);
+      expect(screen.queryByText("0")).toBeInTheDocument();
+    });
+
     it("should not show character count when only maxLength is provided", () => {
       render(<TextArea maxLength={5} />);
       expect(screen.queryByText("0/5")).not.toBeInTheDocument();


### PR DESCRIPTION
Towards https://monday.monday.com/boards/3709356818/pulses/7684207310
Design [Figma](https://www.figma.com/design/U27gdArnWEFYL7XA9ZId5D/Submission-view?node-id=3919-12955&node-type=section&t=4707WZFZeZnWo4Wj-0)

Currently there is no visual feedback for the user when there is a max length set on the TextArea component. A character count should be displayed when there is a maxLength set to convey this information.

There are two attributes that influence the behaviour, when `allowExceedingLimit` is set the user is able to type more than the maximum allowed characters, but will see the input in an error state (see 2nd screenshot). When a `maxLength` only is set the user is strictly able to type no more than the allowed length.

![image](https://github.com/user-attachments/assets/33d83a22-ffb7-4b34-a07f-7ae8395c4095)
![image](https://github.com/user-attachments/assets/252f2690-da74-422f-a12c-84b04d617e8f)


- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.
