### PR TITLE
feat(TextField): improved maxLength with exceeding limit UI

### DIFF
--- a/packages/core/src/components/LegacySearch/__tests__/__snapshots__/Search.snapshot.test.tsx.snap
+++ b/packages/core/src/components/LegacySearch/__tests__/__snapshots__/Search.snapshot.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`Search renders correctly when disabled 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -23,7 +24,6 @@ exports[`Search renders correctly when disabled 1`] = `
         data-testid="search_search"
         disabled={true}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -115,6 +115,7 @@ exports[`Search renders correctly with className 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -124,7 +125,6 @@ exports[`Search renders correctly with className 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -216,6 +216,7 @@ exports[`Search renders correctly with icon 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -225,7 +226,6 @@ exports[`Search renders correctly with icon 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -307,6 +307,7 @@ exports[`Search renders correctly with id 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -316,7 +317,6 @@ exports[`Search renders correctly with id 1`] = `
         data-testid="search_testId"
         disabled={false}
         id="testId"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -408,6 +408,7 @@ exports[`Search renders correctly with loading 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -417,7 +418,6 @@ exports[`Search renders correctly with loading 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -538,6 +538,7 @@ exports[`Search renders correctly with placeholder 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label="placeholder"
         aria-owns=""
@@ -547,7 +548,6 @@ exports[`Search renders correctly with placeholder 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -639,6 +639,7 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -648,7 +649,6 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -730,6 +730,7 @@ exports[`Search renders correctly with underline type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -739,7 +740,6 @@ exports[`Search renders correctly with underline type 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -831,6 +831,7 @@ exports[`Search renders correctly with validation 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={true}
         aria-label=""
         aria-owns=""
@@ -840,7 +841,6 @@ exports[`Search renders correctly with validation 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -942,6 +942,7 @@ exports[`Search renders correctly with value 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -951,7 +952,6 @@ exports[`Search renders correctly with value 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1043,6 +1043,7 @@ exports[`Search renders correctly with wrapperClassName 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1052,7 +1053,6 @@ exports[`Search renders correctly with wrapperClassName 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1144,6 +1144,7 @@ exports[`Search renders correctly without props 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1153,7 +1154,6 @@ exports[`Search renders correctly without props 1`] = `
         data-testid="search_search"
         disabled={false}
         id="search"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}

--- a/packages/core/src/components/LegacySearch/__tests__/__snapshots__/Search.snapshot.test.tsx.snap
+++ b/packages/core/src/components/LegacySearch/__tests__/__snapshots__/Search.snapshot.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`Search renders correctly when disabled 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -115,7 +114,6 @@ exports[`Search renders correctly with className 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -216,7 +214,6 @@ exports[`Search renders correctly with icon 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -307,7 +304,6 @@ exports[`Search renders correctly with id 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -408,7 +404,6 @@ exports[`Search renders correctly with loading 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -538,7 +533,6 @@ exports[`Search renders correctly with placeholder 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label="placeholder"
         aria-owns=""
@@ -639,7 +633,6 @@ exports[`Search renders correctly with secondaryIconName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -730,7 +723,6 @@ exports[`Search renders correctly with underline type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -831,7 +823,6 @@ exports[`Search renders correctly with validation 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={true}
         aria-label=""
         aria-owns=""
@@ -942,7 +933,6 @@ exports[`Search renders correctly with value 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1043,7 +1033,6 @@ exports[`Search renders correctly with wrapperClassName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1144,7 +1133,6 @@ exports[`Search renders correctly without props 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""

--- a/packages/core/src/components/TextField/TextField.module.scss
+++ b/packages/core/src/components/TextField/TextField.module.scss
@@ -206,9 +206,11 @@
   color: var(--negative-color);
 }
 
-.textField .inputWrapper.inputErrorValidation + .subTextContainer .subTextContainerStatus,
-.textField .inputWrapper.inputErrorValidation + .subTextContainer .counter {
-  color: var(--negative-color);
+.textField .inputWrapper.inputErrorValidation + .subTextContainer {
+  .subTextContainerStatus,
+  .counter {
+    color: var(--negative-color);
+  }
 }
 
 .textField .inputWrapper.inputSuccessValidation:hover .input {

--- a/packages/core/src/components/TextField/TextField.module.scss
+++ b/packages/core/src/components/TextField/TextField.module.scss
@@ -206,7 +206,8 @@
   color: var(--negative-color);
 }
 
-.textField .inputWrapper.inputErrorValidation + .subTextContainer .subTextContainerStatus {
+.textField .inputWrapper.inputErrorValidation + .subTextContainer .subTextContainerStatus,
+.textField .inputWrapper.inputErrorValidation + .subTextContainer .counter {
   color: var(--negative-color);
 }
 

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -262,7 +262,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
     const shouldFocusOnPrimaryIcon =
       (onIconClick !== NOOP || iconsNames.primary || iconTooltipContent) && inputValue && iconName.length && isPrimary;
     const shouldFocusOnSecondaryIcon = (secondaryIconName || secondaryTooltipContent) && isSecondary && !!inputValue;
-    const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length-text`;
+    const allowExceedingMaxLengthTextId = allowExceedingMaxLength ? `${id}-allow-exceeding-max-length-text` : undefined;
 
     useEffect(() => {
       if (!inputRef?.current || !autoFocus) {
@@ -321,7 +321,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               aria-owns={searchResultsContainerId}
               aria-activedescendant={activeDescendant}
               aria-required={required}
-              aria-describedby={allowExceedingMaxLengthTextId ?? undefined}
+              aria-describedby={allowExceedingMaxLengthTextId}
               required={required}
               tabIndex={tabIndex}
             />

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -79,7 +79,7 @@ export interface TextFieldProps extends VibeComponentProps {
   /** TEXT_TYPES is exposed on the component itself */
   type?: TextFieldTextType;
   maxLength?: number;
-  allowExceedingLimit?: boolean;
+  allowExceedingMaxLength?: boolean;
   trim?: boolean;
   /** ARIA role for container landmark */
   role?: string;
@@ -147,7 +147,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
       iconsNames = EMPTY_OBJECT,
       type = TextFieldTextType.TEXT,
       maxLength = null,
-      allowExceedingLimit = false,
+      allowExceedingMaxLength = false,
       trim = false,
       role = "",
       required = false,
@@ -312,7 +312,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               onFocus={onFocus}
               onKeyDown={onKeyDown}
               onWheel={onWheel}
-              maxLength={maxLength && !allowExceedingLimit ? maxLength : undefined}
+              maxLength={typeof maxLength === "number" && !allowExceedingMaxLength ? maxLength : undefined}
               role={searchResultsContainerId && "combobox"} // For voice reader
               aria-label={inputAriaLabel || placeholder}
               aria-invalid={(validation && validation.status === "error") || isRequiredAndEmpty}

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -243,7 +243,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
     }, [disabled, clearOnIconClick, onIconClick, currentStateIconName, controlled, onChangeCallback, clearValue]);
 
     const validationClass = useMemo(() => {
-      if (maxLength && inputValue.length > maxLength) {
+      if (maxLength !== undefined && inputValue.length > maxLength) {
         return FEEDBACK_CLASSES.error;
       }
 
@@ -392,7 +392,8 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               )}
               {showCharCount && (
                 <span className={cx(styles.counter)} aria-label={TextFieldAriaLabel.CHAR}>
-                  {(inputValue && inputValue.length) || 0}{maxLength && `/${maxLength}`}
+                  {(inputValue && inputValue.length) || 0}
+                  {maxLength && `/${maxLength}`}
                 </span>
               )}
             </Text>

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -243,7 +243,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
     }, [disabled, clearOnIconClick, onIconClick, currentStateIconName, controlled, onChangeCallback, clearValue]);
 
     const validationClass = useMemo(() => {
-      if (maxLength !== undefined && inputValue.length > maxLength) {
+      if (typeof maxLength === "number" && inputValue.length > maxLength) {
         return FEEDBACK_CLASSES.error;
       }
 
@@ -393,7 +393,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               {showCharCount && (
                 <span className={cx(styles.counter)} aria-label={TextFieldAriaLabel.CHAR}>
                   {(inputValue && inputValue.length) || 0}
-                  {maxLength && `/${maxLength}`}
+                  {typeof maxLength === "number" && `/${maxLength}`}
                 </span>
               )}
             </Text>

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -79,6 +79,7 @@ export interface TextFieldProps extends VibeComponentProps {
   /** TEXT_TYPES is exposed on the component itself */
   type?: TextFieldTextType;
   maxLength?: number;
+  allowExceedingLimit?: boolean;
   trim?: boolean;
   /** ARIA role for container landmark */
   role?: string;
@@ -146,6 +147,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
       iconsNames = EMPTY_OBJECT,
       type = TextFieldTextType.TEXT,
       maxLength = null,
+      allowExceedingLimit = false,
       trim = false,
       role = "",
       required = false,
@@ -241,12 +243,16 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
     }, [disabled, clearOnIconClick, onIconClick, currentStateIconName, controlled, onChangeCallback, clearValue]);
 
     const validationClass = useMemo(() => {
+      if (maxLength && inputValue.length > maxLength) {
+        return FEEDBACK_CLASSES.error;
+      }
+
       if ((!validation || !validation.status) && !isRequiredAndEmpty) {
         return "";
       }
       const status = isRequiredAndEmpty ? "error" : validation.status;
       return FEEDBACK_CLASSES[status];
-    }, [validation, isRequiredAndEmpty]);
+    }, [validation, isRequiredAndEmpty, inputValue]);
 
     const hasIcon = iconName || secondaryIconName;
     const shouldShowExtraText = showCharCount || (validation && validation.text) || isRequiredAndEmpty;
@@ -306,7 +312,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               onFocus={onFocus}
               onKeyDown={onKeyDown}
               onWheel={onWheel}
-              maxLength={maxLength}
+              maxLength={maxLength && !allowExceedingLimit ? maxLength : undefined}
               role={searchResultsContainerId && "combobox"} // For voice reader
               aria-label={inputAriaLabel || placeholder}
               aria-invalid={(validation && validation.status === "error") || isRequiredAndEmpty}
@@ -386,7 +392,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               )}
               {showCharCount && (
                 <span className={cx(styles.counter)} aria-label={TextFieldAriaLabel.CHAR}>
-                  {(inputValue && inputValue.length) || 0}
+                  {(inputValue && inputValue.length) || 0}{maxLength && `/${maxLength}`}
                 </span>
               )}
             </Text>

--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -33,6 +33,7 @@ import { ComponentDefaultTestId } from "../../tests/constants";
 import { VibeComponentProps, VibeComponent, withStaticProps } from "../../types";
 import styles from "./TextField.module.scss";
 import { Tooltip } from "../Tooltip";
+import { HiddenText } from "../HiddenText";
 
 const EMPTY_OBJECT = { primary: "", secondary: "", layout: "" };
 
@@ -261,6 +262,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
     const shouldFocusOnPrimaryIcon =
       (onIconClick !== NOOP || iconsNames.primary || iconTooltipContent) && inputValue && iconName.length && isPrimary;
     const shouldFocusOnSecondaryIcon = (secondaryIconName || secondaryTooltipContent) && isSecondary && !!inputValue;
+    const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length-text`;
 
     useEffect(() => {
       if (!inputRef?.current || !autoFocus) {
@@ -319,6 +321,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
               aria-owns={searchResultsContainerId}
               aria-activedescendant={activeDescendant}
               aria-required={required}
+              aria-describedby={allowExceedingMaxLengthTextId ?? undefined}
               required={required}
               tabIndex={tabIndex}
             />
@@ -394,6 +397,7 @@ const TextField: VibeComponent<TextFieldProps, unknown> & {
                 <span className={cx(styles.counter)} aria-label={TextFieldAriaLabel.CHAR}>
                   {(inputValue && inputValue.length) || 0}
                   {typeof maxLength === "number" && `/${maxLength}`}
+                  <HiddenText id={allowExceedingMaxLengthTextId} text={`Maximum of ${maxLength} characters`} />
                 </span>
               )}
             </Text>

--- a/packages/core/src/components/TextField/__tests__/TextField.test.js
+++ b/packages/core/src/components/TextField/__tests__/TextField.test.js
@@ -216,11 +216,11 @@ describe("TextField Tests", () => {
       expect(parseInt(charCount.innerHTML, 10)).toEqual(value.length);
     });
 
-    it("should prevent typing when character limit is reached and allowExceedingLimit is false", () => {
+    it("should prevent typing when character limit is reached and allowExceedingMaxLength is false", () => {
       const { rerender } = inputComponent;
       act(() => {
         rerender(
-          <TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingLimit={false} />
+          <TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingMaxLength={false} />
         );
       });
 
@@ -231,10 +231,10 @@ describe("TextField Tests", () => {
       expect(input).toHaveAttribute("maxlength", "5");
     });
 
-    it("should allow typing beyond character limit when allowExceedingLimit is true", () => {
-      const { rerender, queryByLabelText } = inputComponent;
+    it("should allow typing beyond character limit when allowExceedingMaxLength is true", () => {
+      const { rerender, queryByLabelText, getByText } = inputComponent;
       act(() => {
-        rerender(<TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingLimit={true} />);
+        rerender(<TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingMaxLength={true} />);
       });
 
       const input = screen.getByPlaceholderText(defaultPlaceHolder);

--- a/packages/core/src/components/TextField/__tests__/TextField.test.js
+++ b/packages/core/src/components/TextField/__tests__/TextField.test.js
@@ -233,7 +233,9 @@ describe("TextField Tests", () => {
     it("should allow typing beyond character limit when allowExceedingMaxLength is true", () => {
       const { rerender, getByText } = inputComponent;
       act(() => {
-        rerender(<TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingMaxLength={true} />);
+        rerender(
+          <TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingMaxLength={true} />
+        );
       });
 
       const input = screen.getByPlaceholderText(defaultPlaceHolder);

--- a/packages/core/src/components/TextField/__tests__/TextField.test.js
+++ b/packages/core/src/components/TextField/__tests__/TextField.test.js
@@ -172,7 +172,7 @@ describe("TextField Tests", () => {
     });
 
     it("should display char count and max length on initial", () => {
-      const { rerender, queryByLabelText } = inputComponent;
+      const { rerender, getByText } = inputComponent;
       const value = "hello";
       act(() => {
         rerender(
@@ -187,8 +187,7 @@ describe("TextField Tests", () => {
         );
       });
 
-      const charCount = queryByLabelText(TextFieldAriaLabel.CHAR);
-      expect(charCount.innerHTML).toBe(`${value.length}/10`);
+      expect(getByText(`${value.length}/10`)).toBeTruthy();
     });
 
     it("char count should display correctly after changing value", () => {
@@ -232,7 +231,7 @@ describe("TextField Tests", () => {
     });
 
     it("should allow typing beyond character limit when allowExceedingMaxLength is true", () => {
-      const { rerender, queryByLabelText, getByText } = inputComponent;
+      const { rerender, getByText } = inputComponent;
       act(() => {
         rerender(<TextField placeholder={defaultPlaceHolder} showCharCount maxLength={5} allowExceedingMaxLength={true} />);
       });
@@ -245,8 +244,7 @@ describe("TextField Tests", () => {
       expect(input).toHaveValue("123456");
       expect(input).not.toHaveAttribute("maxlength");
 
-      const charCount = queryByLabelText(TextFieldAriaLabel.CHAR);
-      expect(charCount.innerHTML).toBe("6/5");
+      expect(getByText("6/5")).toBeTruthy();
     });
   });
 

--- a/packages/core/src/components/TextField/__tests__/TextField.test.js
+++ b/packages/core/src/components/TextField/__tests__/TextField.test.js
@@ -2,7 +2,6 @@ import React from "react";
 import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 import TextField from "../TextField";
 import { TextFieldAriaLabel } from "../TextFieldConstants";
-import userEvent from "@testing-library/user-event";
 
 describe("TextField Tests", () => {
   let inputComponent;

--- a/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
+++ b/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
@@ -14,7 +14,7 @@ exports[`TextField renders correctly when disabled 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -77,7 +77,7 @@ exports[`TextField renders correctly when loading 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -169,7 +169,7 @@ exports[`TextField renders correctly when readonly 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -232,7 +232,7 @@ exports[`TextField renders correctly when required 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -295,7 +295,7 @@ exports[`TextField renders correctly with another type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -358,7 +358,7 @@ exports[`TextField renders correctly with className 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -421,7 +421,7 @@ exports[`TextField renders correctly with className 2`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -484,7 +484,7 @@ exports[`TextField renders correctly with date type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -547,7 +547,7 @@ exports[`TextField renders correctly with date-time type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -610,7 +610,7 @@ exports[`TextField renders correctly with email type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -673,7 +673,7 @@ exports[`TextField renders correctly with icon 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -744,7 +744,7 @@ exports[`TextField renders correctly with iconsNames 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -809,7 +809,7 @@ exports[`TextField renders correctly with id 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -872,7 +872,7 @@ exports[`TextField renders correctly with labelIconName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -935,7 +935,7 @@ exports[`TextField renders correctly with large size 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -998,7 +998,7 @@ exports[`TextField renders correctly with placeholder 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label="placeholder"
         aria-owns=""
@@ -1061,7 +1061,7 @@ exports[`TextField renders correctly with role 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1124,7 +1124,7 @@ exports[`TextField renders correctly with secondaryIconName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1195,7 +1195,7 @@ exports[`TextField renders correctly with showCharCount 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1251,8 +1251,8 @@ exports[`TextField renders correctly with showCharCount 1`] = `
         0
         <span
           className="hiddenTextWrapper"
-          data-testid="hidden-text_false"
-          id={false}
+          data-testid="hidden-text_maximum-text"
+          id="maximum-text"
         >
           Maximum of null characters
         </span>
@@ -1276,7 +1276,7 @@ exports[`TextField renders correctly with tel type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1339,7 +1339,7 @@ exports[`TextField renders correctly with url type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1402,7 +1402,7 @@ exports[`TextField renders correctly with validation 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={true}
         aria-label=""
         aria-owns=""
@@ -1475,7 +1475,7 @@ exports[`TextField renders correctly with value 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1538,7 +1538,7 @@ exports[`TextField renders correctly with wrapperClassName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={false}
+        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""

--- a/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
+++ b/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
@@ -14,7 +14,6 @@ exports[`TextField renders correctly when disabled 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -77,7 +76,6 @@ exports[`TextField renders correctly when loading 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -169,7 +167,6 @@ exports[`TextField renders correctly when readonly 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -232,7 +229,6 @@ exports[`TextField renders correctly when required 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -295,7 +291,6 @@ exports[`TextField renders correctly with another type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -358,7 +353,6 @@ exports[`TextField renders correctly with className 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -421,7 +415,6 @@ exports[`TextField renders correctly with className 2`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -484,7 +477,6 @@ exports[`TextField renders correctly with date type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -547,7 +539,6 @@ exports[`TextField renders correctly with date-time type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -610,7 +601,6 @@ exports[`TextField renders correctly with email type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -673,7 +663,6 @@ exports[`TextField renders correctly with icon 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -744,7 +733,6 @@ exports[`TextField renders correctly with iconsNames 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -809,7 +797,6 @@ exports[`TextField renders correctly with id 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -872,7 +859,6 @@ exports[`TextField renders correctly with labelIconName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -935,7 +921,6 @@ exports[`TextField renders correctly with large size 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -998,7 +983,6 @@ exports[`TextField renders correctly with placeholder 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label="placeholder"
         aria-owns=""
@@ -1061,7 +1045,6 @@ exports[`TextField renders correctly with role 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1124,7 +1107,6 @@ exports[`TextField renders correctly with secondaryIconName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1195,7 +1177,6 @@ exports[`TextField renders correctly with showCharCount 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1251,8 +1232,8 @@ exports[`TextField renders correctly with showCharCount 1`] = `
         0
         <span
           className="hiddenTextWrapper"
-          data-testid="hidden-text_maximum-text"
-          id="maximum-text"
+          data-testid="hidden-text_hiddenText"
+          id="hiddenText"
         >
           Maximum of null characters
         </span>
@@ -1276,7 +1257,6 @@ exports[`TextField renders correctly with tel type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1339,7 +1319,6 @@ exports[`TextField renders correctly with url type 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1402,7 +1381,6 @@ exports[`TextField renders correctly with validation 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={true}
         aria-label=""
         aria-owns=""
@@ -1475,7 +1453,6 @@ exports[`TextField renders correctly with value 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1538,7 +1515,6 @@ exports[`TextField renders correctly with wrapperClassName 1`] = `
     >
       <input
         aria-activedescendant=""
-        aria-describedby={undefined}
         aria-invalid={false}
         aria-label=""
         aria-owns=""

--- a/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
+++ b/packages/core/src/components/TextField/__tests__/__snapshots__/TextField.snapshot.test.tsx.snap
@@ -14,6 +14,7 @@ exports[`TextField renders correctly when disabled 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -23,7 +24,6 @@ exports[`TextField renders correctly when disabled 1`] = `
         data-testid="text-field_input"
         disabled={true}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -77,6 +77,7 @@ exports[`TextField renders correctly when loading 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -86,7 +87,6 @@ exports[`TextField renders correctly when loading 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -169,6 +169,7 @@ exports[`TextField renders correctly when readonly 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -178,7 +179,6 @@ exports[`TextField renders correctly when readonly 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -232,6 +232,7 @@ exports[`TextField renders correctly when required 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -241,7 +242,6 @@ exports[`TextField renders correctly when required 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -295,6 +295,7 @@ exports[`TextField renders correctly with another type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -304,7 +305,6 @@ exports[`TextField renders correctly with another type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -358,6 +358,7 @@ exports[`TextField renders correctly with className 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -367,7 +368,6 @@ exports[`TextField renders correctly with className 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -421,6 +421,7 @@ exports[`TextField renders correctly with className 2`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -430,7 +431,6 @@ exports[`TextField renders correctly with className 2`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -484,6 +484,7 @@ exports[`TextField renders correctly with date type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -493,7 +494,6 @@ exports[`TextField renders correctly with date type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -547,6 +547,7 @@ exports[`TextField renders correctly with date-time type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -556,7 +557,6 @@ exports[`TextField renders correctly with date-time type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -610,6 +610,7 @@ exports[`TextField renders correctly with email type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -619,7 +620,6 @@ exports[`TextField renders correctly with email type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -673,6 +673,7 @@ exports[`TextField renders correctly with icon 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -682,7 +683,6 @@ exports[`TextField renders correctly with icon 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -744,6 +744,7 @@ exports[`TextField renders correctly with iconsNames 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -753,7 +754,6 @@ exports[`TextField renders correctly with iconsNames 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -809,6 +809,7 @@ exports[`TextField renders correctly with id 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -818,7 +819,6 @@ exports[`TextField renders correctly with id 1`] = `
         data-testid="text-field_testId"
         disabled={false}
         id="testId"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -872,6 +872,7 @@ exports[`TextField renders correctly with labelIconName 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -881,7 +882,6 @@ exports[`TextField renders correctly with labelIconName 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -935,6 +935,7 @@ exports[`TextField renders correctly with large size 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -944,7 +945,6 @@ exports[`TextField renders correctly with large size 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -998,6 +998,7 @@ exports[`TextField renders correctly with placeholder 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label="placeholder"
         aria-owns=""
@@ -1007,7 +1008,6 @@ exports[`TextField renders correctly with placeholder 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1061,6 +1061,7 @@ exports[`TextField renders correctly with role 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1070,7 +1071,6 @@ exports[`TextField renders correctly with role 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1124,6 +1124,7 @@ exports[`TextField renders correctly with secondaryIconName 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1133,7 +1134,6 @@ exports[`TextField renders correctly with secondaryIconName 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1195,6 +1195,7 @@ exports[`TextField renders correctly with showCharCount 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1204,7 +1205,6 @@ exports[`TextField renders correctly with showCharCount 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1249,6 +1249,13 @@ exports[`TextField renders correctly with showCharCount 1`] = `
         className="counter"
       >
         0
+        <span
+          className="hiddenTextWrapper"
+          data-testid="hidden-text_false"
+          id={false}
+        >
+          Maximum of null characters
+        </span>
       </span>
     </div>
   </div>
@@ -1269,6 +1276,7 @@ exports[`TextField renders correctly with tel type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1278,7 +1286,6 @@ exports[`TextField renders correctly with tel type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1332,6 +1339,7 @@ exports[`TextField renders correctly with url type 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1341,7 +1349,6 @@ exports[`TextField renders correctly with url type 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1395,6 +1402,7 @@ exports[`TextField renders correctly with validation 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={true}
         aria-label=""
         aria-owns=""
@@ -1404,7 +1412,6 @@ exports[`TextField renders correctly with validation 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1468,6 +1475,7 @@ exports[`TextField renders correctly with value 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1477,7 +1485,6 @@ exports[`TextField renders correctly with value 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}
@@ -1531,6 +1538,7 @@ exports[`TextField renders correctly with wrapperClassName 1`] = `
     >
       <input
         aria-activedescendant=""
+        aria-describedby={false}
         aria-invalid={false}
         aria-label=""
         aria-owns=""
@@ -1540,7 +1548,6 @@ exports[`TextField renders correctly with wrapperClassName 1`] = `
         data-testid="text-field_input"
         disabled={false}
         id="input"
-        maxLength={null}
         onBlur={[Function]}
         onChange={[Function]}
         onFocus={[Function]}


### PR DESCRIPTION
Towards https://monday.monday.com/boards/3709356818/pulses/7684207310
Design [Figma](https://www.figma.com/design/U27gdArnWEFYL7XA9ZId5D/Submission-view?node-id=3919-12955&node-type=section&t=4707WZFZeZnWo4Wj-0)
Related PR https://github.com/mondaycom/vibe/pull/2574

Introduces new behaviour around the maxLength of the TextField component. A new `allowExceedingLimit` flag in combination with the `maxLength` field will give the user a visual marker that they have exceeded the limit without disabling typing in the input field.

The input will display an error state once the maxLength has been exceeded (while allowing it).

![image](https://github.com/user-attachments/assets/805cceb6-4d25-44bb-a0b7-98a2cbc5d8bb)
![image](https://github.com/user-attachments/assets/6e7882c9-d9a5-432e-a4ba-3fa6b5ef2b3a)


- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

