### PR TITLE
fix(TextArea): Error state not correctly set when maxlength is exceeded

### DIFF
--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -41,14 +41,14 @@ const TextArea = forwardRef(
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
-    const isErrorState = error || (maxLength && value?.length > maxLength);
-
+    
     const ariaDescribedby = useMemo(
       () => [helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined,
       [helpTextId, allowExceedingMaxLengthTextId]
     );
-
+    
     const [characterCount, setCharacterCount] = useState(value?.length || 0);
+    const isErrorState = error || (typeof maxLength === "number" && characterCount > maxLength);
 
     const handleOnChange = useCallback(
       (event: React.ChangeEvent<HTMLTextAreaElement>) => {

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -41,12 +41,12 @@ const TextArea = forwardRef(
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
     const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
-    
+
     const ariaDescribedby = useMemo(
       () => [helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined,
       [helpTextId, allowExceedingMaxLengthTextId]
     );
-    
+
     const [characterCount, setCharacterCount] = useState(value?.length || 0);
     const isErrorState = error || (typeof maxLength === "number" && characterCount > maxLength);
 

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -88,7 +88,7 @@ const TextArea = forwardRef(
           required={required}
           rows={numRows}
           className={cx(styles.textArea, [styles[size]], { [styles.resize]: resize })}
-          aria-invalid={error}
+          aria-invalid={isErrorState}
           aria-describedby={ariaDescribedby}
           onChange={handleOnChange}
         />

--- a/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
+++ b/packages/core/src/components/TextArea/__tests__/TextArea.test.tsx
@@ -143,6 +143,7 @@ describe("TextArea", () => {
 
       expect(input).toHaveValue("12345678910");
       expect(charCount).toHaveTextContent("11/10");
+      expect(input).toHaveAttribute("aria-invalid", "true");
     });
 
     it("should allow text removal when character limit is exceeded", () => {


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

Follow up on https://github.com/mondaycom/vibe/pull/2574

Somewhere in the process of implementing the above PR the error state wasn't triggering anymore once the max length was exceeded (when it is allowed to do so).

Before:
<img width="359" alt="image" src="https://github.com/user-attachments/assets/76134a88-7ebc-4294-9523-65205c99a3e9">

After:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/b0bfc565-34db-45e0-b84e-cd949859c4da">

This PR fixes the conditional logic and uses the `characterCount`  state variable to more reliably check against the `maxLength` prop.

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

