### PR TITLE
feat(Dropdown): add inputValue and blurInputOnSelect properties to allow editing options

### DIFF
--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -117,7 +117,9 @@ const Dropdown: VibeComponent<DropdownComponentProps, HTMLElement> & {
       filterOption,
       menuPosition = Dropdown.menuPositions.ABSOLUTE,
       "data-testid": dataTestId,
-      withGroupDivider = false
+      withGroupDivider = false,
+      inputValue,
+      blurInputOnSelect
     }: DropdownComponentProps,
     ref: React.ForwardedRef<HTMLElement>
   ) => {
@@ -458,6 +460,8 @@ const Dropdown: VibeComponent<DropdownComponentProps, HTMLElement> & {
         loadingMessage={loadingMessage}
         tabSelectsValue={tabSelectsValue}
         filterOption={filterOption}
+        inputValue={inputValue}
+        blurInputOnSelect={blurInputOnSelect}
         {...asyncAdditions}
         {...additions}
       />

--- a/packages/core/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/core/src/components/Dropdown/Dropdown.types.ts
@@ -279,7 +279,14 @@ export interface DropdownComponentProps extends CustomMenuBaseProps, CustomOptio
    * createFilter function is available at Dropdown.createFilter
    */
   filterOption?: (option: DropdownOption, inputValue: string) => boolean;
-
+  /**
+   * The current value of the input field, used to control the current value of the input field programmatically
+   */
+  inputValue?: string;
+  /**
+   * If true, the input field will lose focus when an option is selected
+   */
+  blurInputOnSelect?: boolean;
   withReadOnlyStyle?: boolean;
   OptionRenderer?: React.ReactNode;
   menuIsOpen?: boolean;


### PR DESCRIPTION
In this PR, I added two properties to the React Select component:  
1. inputValue
2. blurInputOnSelect
These properties allow the user to edit their search term after they have already performed a search. Currently, when the input field gains focus, the latest search is cleared, and the user can only start a new search. With these two properties, the user will have the option to edit their existing search term.
Properties added:
1. inputValue: Controls the current value of the input field programmatically, allowing the user to modify their search term.
2. blurInputOnSelect: If true, the input field will lose focus when an option is selected, providing better control over the input behavior.

- [x] I have read the [Contribution Guide](../packages/core/CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->
Resolves #
