### PR TITLE
ci: commitlint the squashed commit that's about to be merged to master

### DIFF
--- a/.github/workflows/merge-queue.yml
+++ b/.github/workflows/merge-queue.yml
@@ -1,0 +1,17 @@
+name: Merge Queue Checks
+
+on:
+  merge_group:
+    types:
+      - checks_requested
+
+jobs:
+  commitlint:
+    name: Commit Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}
+
+      - uses: YossiSaadi/commitlint-github-action@vibe-fork/support-merge_group-event

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -18,3 +18,13 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets:
       npm_token: ${{ secrets.npm_token }}
+
+  commitlint:
+    name: Commit Lint
+    needs: build
+    if: false
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.sha }}


### PR DESCRIPTION
(using merge queue).
the "fake" commitlint on pr.yml is because of GitHub's requirements to run merge_group workflow