### PR TITLE
chore: build icons after install for initial monorepo setup

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "lerna run lint",
     "test": "lerna run test",
     "storybook": "lerna run storybook --parallel --stream",
-    "postinstall": "lerna run build --scope=vibe-storybook-components"
+    "postinstall": "lerna run build --scope={vibe-storybook-components,@vibe/icons}"
   },
   "devDependencies": {
     "lerna": "^8.1.2",


### PR DESCRIPTION
If we'd not ignore the built icons component we wouldn't need it (it takes about extra ~30s)
Worth re-considering keeping the icon components IMO
https://monday.monday.com/boards/3532714909/pulses/8030088094