### PR TITLE
fix(Dropdown): when disabled chip has extra class

### DIFF
--- a/packages/core/src/components/Dropdown/hooks/useHiddenOptionsData.js
+++ b/packages/core/src/components/Dropdown/hooks/useHiddenOptionsData.js
@@ -19,7 +19,11 @@ export function useHiddenOptionsData({
 
       while (childIndex < ref.children.length && optionIndex < selectedOptionsCount) {
         const child = ref.children[childIndex];
-        const isOption = child.classList.contains(chipClassName) || child.classList.contains(chipWrapperClassName);
+        const chipClasses = chipClassName.split(" ");
+
+        const isOption =
+          child.classList.contains(chipWrapperClassName) ||
+          chipClasses.some(className => child.classList.contains(className));
 
         if (isOption) {
           const { bottom: childBottom } = child.getBoundingClientRect();


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/8041715569

Explanation about the solution:
We had a few issues.
The `isCounterShown` dependency in the `useHiddenOptionsData` caused infinite loop, as two `useEffect`s were called infinitely.
It is in the dependency array as the Dropdown calculates what chips should be hidden.
But when calculated, the counter of "+X" chip at the end isn't shown (yet), so in some scenarios you could have pushed another chip to the width of the Dropdown (let's say 4 out of 5), but then when the counter appeared (to show "+1") as it should, the whole logic got messed up (cause chip number 4 did not had space anymore as the "+1" counter, which should now show "+2", caused it to be pushed out of boundaries), and we got caught up in an infinite loop.

I solved it, a temporary solution, by fixing the disabled state classes (which was buggy anyway - we probably never calculated the counter correctly for disabled state (!!)). It helped with solving the infinite loop, but there might be very specific and very edgy scenarios where the infinite loop would happen again because of the counter dependency.

On the new Dropdown design we should take this kind of stuff into consideration and build it better future-proof @rivka-ungar.

P.S. neither Claude or GPT correctly understood what's going on there, which means this logic is really messed up 🙃.

code that fails on previous version:
```jsx
() => {
  const options = [
    {
      value: 1,
      label: 'Option 1',
    },
    {
      value: 2,
      label: 'Option 2',
    },
    {
      value: 3,
      label: 'Option 3',
    },
    {
      value: 4,
      label: 'Option 4',
    },
    {
      value: 5,
      label: 'Option 5',
    },
  ]

  const selected = [...options]; 

  return (
    <Flex direction="column" align="start" gap="medium">
      <div style={{ width: 434 }}>
        <Dropdown
          multi
          options={options}
          value={selected}
          disabled
        >
        </Dropdown>
      </did>
    </Flex>
  );
}
```

Try it in the [Playground](https://vibe.monday.com/?path=/story/playground--playground).
while changing the width to 435px shows everything correct, having 434px fails.
in compare to this PR, where the [Playground with the changes from the PR](https://62037c72e0e4d6004a9a450f-kbewaczfkl.chromatic.com/?path=/story/playground--playground) shows everything correct.