### PR TITLE
feat(Tipseen): allow referenceWrapperClassName prop for component

### DIFF
--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -43,6 +43,7 @@ export interface TipseenProps extends VibeComponentProps {
   width?: number;
   moveBy?: MoveBy;
   hideWhenReferenceHidden?: boolean;
+  referenceWrapperClassName?: string;
   /**
    * when false, the arrow of the tooltip is hidden
    */
@@ -97,6 +98,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
       width,
       moveBy,
       hideWhenReferenceHidden = false,
+      referenceWrapperClassName,
       tip = true,
       tooltipArrowClassName,
       modifiers = [],
@@ -188,6 +190,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
           disableDialogSlide={false}
           moveBy={moveBy}
           hideWhenReferenceHidden={hideWhenReferenceHidden}
+          referenceWrapperClassName={referenceWrapperClassName}
           tip={tip && !floating}
           modifiers={modifiers}
           open={defaultDelayOpen ? delayedOpen : undefined}


### PR DESCRIPTION
Wrapping the element with a Tipseen wraps it in an empty span, which interferes with the CSS. Passing the missing property to the inner component ensures the correct styling is applied.

https://monday.monday.com/boards/5703104356/pulses/8039110583

![image](https://github.com/user-attachments/assets/32e527f1-ef8a-4fb5-b623-d2dbeddf0b40)

**another** way to go would be to add a default class name here: https://github.com/stasshw/vibe/blob/24828d7f2ffec00084775f56322518cc04c9a2b8/packages/core/src/components/Dialog/Dialog.tsx#L519

