### PR TITLE
fix(Tipseen): pass onShow/onHide properties from tipseen

### DIFF
--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -115,6 +115,7 @@ export interface DialogProps extends VibeComponentProps {
   /**
    * callback to be called when the dialog is shown
    */
+  onShowHide?: (params: { isVisible: boolean }) => void;
   onDialogDidShow?: (event?: DialogEvent, eventName?: DialogTriggerEvent | string) => void;
   /**
    * callback to be called when the dialog is hidden
@@ -158,6 +159,7 @@ export interface DialogProps extends VibeComponentProps {
 
 export interface DialogState {
   isOpen?: boolean;
+  isReferenceHidden?: boolean;
   shouldUseDerivedStateFromProps?: boolean;
   preventAnimation?: boolean;
 }
@@ -184,6 +186,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
     preventAnimationOnMount: false,
     tooltip: false,
     onDialogDidShow: NOOP,
+    onShowHide: NOOP,
     onDialogDidHide: NOOP,
     onClickOutside: NOOP,
     onContentClick: NOOP,
@@ -498,6 +501,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
       hideWhenReferenceHidden,
       disableContainerScroll,
       containerSelector,
+      onShowHide,
       id,
       "data-testid": dataTestId
     } = this.props;
@@ -510,6 +514,9 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
     if (!contentRendered) {
       return children;
     }
+
+    let self = this;
+
     return (
       <Manager>
         <Reference>
@@ -571,6 +578,20 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
                     //   res[1]}% ${100 - res[2]}%`;
                     state.styles.arrow.transform = `${state.styles.arrow.transform} rotate(45deg)`;
                     return state;
+                  }
+                },
+                {
+                  name: "my-test",
+                  enabled: true,
+                  phase: "main",
+                  fn({ state }) {
+                    const referenceHidden = state.modifiersData.hide.isReferenceHidden;
+
+                    if (self.state.isReferenceHidden !== referenceHidden) {
+                      // console.log('AAAAAAAAAAAA isReferenceHidden', isReferenceHidden);
+                      self.setState({ isReferenceHidden: referenceHidden });
+                      onShowHide({isVisible: !referenceHidden});
+                    }
                   }
                 },
                 ...modifiers

--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -308,7 +308,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
   }
 
   onShowDialog(event: DialogEvent, eventName: DialogTriggerEvent | string) {
-    if (this.isShown()) return;
+    if (this.state.isOpen) return;
     const { onDialogDidShow } = this.props;
     onDialogDidShow(event, eventName);
   }
@@ -581,9 +581,14 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
                   return null;
                 }
 
-                if (hideWhenReferenceHidden && isReferenceHidden) {
-                  const event = new CustomEvent("onReferenceHidden");
-                  this.hideDialog(event, "onReferenceHidden");
+                if (hideWhenReferenceHidden) {
+                  if (isReferenceHidden) {
+                    const event = new CustomEvent("onReferenceHidden");
+                    this.hideDialogIfNeeded(event, "onReferenceHidden");
+                  } else {
+                    const event = new CustomEvent("onReferenceShown");
+                    this.showDialogIfNeeded(event, "onReferenceShown");
+                  }
                 }
 
                 return (

--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -56,6 +56,10 @@ export interface TipseenProps extends VibeComponentProps {
   modifiers?: Array<Modifier<unknown>>;
   closeAriaLabel?: string;
   onClose?: () => void;
+  /** Callback function triggered when the tooltip becomes visible */
+  onShow?: () => void;
+  /** Callback function triggered when the tooltip becomes hidden */
+  onHide?: () => void;
   content: ElementContent;
   /**
    * Control the color of the Tipseen close button. Dark theme can be useful while presenting bright images under the tipseen image
@@ -88,6 +92,8 @@ const Tipseen: VibeComponent<TipseenProps> & {
       hideCloseButton,
       closeButtonTheme = "light",
       onClose,
+      onShow,
+      onHide,
       closeAriaLabel,
       children = null,
       content,
@@ -191,6 +197,8 @@ const Tipseen: VibeComponent<TipseenProps> & {
           tip={tip && !floating}
           modifiers={modifiers}
           open={defaultDelayOpen ? delayedOpen : undefined}
+          onTooltipShow={onShow}
+          onTooltipHide={onHide}
           forceRenderWithoutChildren={floating}
         >
           {children}

--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -61,6 +61,7 @@ export interface TipseenProps extends VibeComponentProps {
   onShow?: () => void;
   /** Callback function triggered when the tooltip becomes hidden */
   onHide?: () => void;
+  onShowHide?: () => void;
   content: ElementContent;
   /**
    * Control the color of the Tipseen close button. Dark theme can be useful while presenting bright images under the tipseen image
@@ -93,6 +94,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
       hideCloseButton,
       closeButtonTheme = "light",
       onClose,
+      onShowHide,
       onShow,
       onHide,
       closeAriaLabel,
@@ -201,6 +203,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
           modifiers={modifiers}
           open={defaultDelayOpen ? delayedOpen : undefined}
           onTooltipShow={onShow}
+          onShowHide={onShowHide}
           onTooltipHide={onHide}
           forceRenderWithoutChildren={floating}
         >

--- a/packages/core/src/components/Tooltip/Tooltip.tsx
+++ b/packages/core/src/components/Tooltip/Tooltip.tsx
@@ -79,6 +79,7 @@ interface TooltipBaseProps extends VibeComponentProps {
   hideWhenReferenceHidden?: boolean;
   onTooltipHide?: () => void;
   onTooltipShow?: () => void;
+  onShowHide?: () => void;
   /**
    * PopperJS Modifiers type
    * https://popper.js.org/docs/v2/modifiers/


### PR DESCRIPTION
I am passing hideWhenReferenceHidden = true because my element is not immediately visible. I need an indication when the tipseen actually appears for my custom logic. also it seems like the dialog itself had a bug in reporting onShow/onHide

https://monday.monday.com/boards/5703104356/pulses/8039110583
