### PR TITLE
feat(Tipseen): allow referenceWrapperClassName prop for component

### DIFF
--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -45,6 +45,7 @@ export interface TipseenProps extends VibeComponentProps {
   width?: number;
   moveBy?: MoveBy;
   hideWhenReferenceHidden?: boolean;
+  referenceWrapperClassName?: string;
   /**
    * when false, the arrow of the tooltip is hidden
    */
@@ -104,6 +105,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
       width,
       moveBy,
       hideWhenReferenceHidden = false,
+      referenceWrapperClassName,
       tip = true,
       tooltipArrowClassName,
       modifiers = EMPTY_ARR,
@@ -206,6 +208,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
           disableDialogSlide={false}
           moveBy={moveBy}
           hideWhenReferenceHidden={hideWhenReferenceHidden}
+          referenceWrapperClassName={referenceWrapperClassName}
           tip={tip && !floating}
           modifiers={modifiers}
           open={defaultDelayOpen ? delayedOpen : undefined}


### PR DESCRIPTION
same as https://github.com/mondaycom/vibe/pull/2652

(cherry picked from commit 9d6fcc295965abc12e05d786c1d98f5a5080cfd1)