### PR TITLE
docs(colors): add color prefix to doc's content colors

### DIFF
--- a/packages/core/src/storybook/stand-alone-documentaion/colors/content-color-row/content-color-row.jsx
+++ b/packages/core/src/storybook/stand-alone-documentaion/colors/content-color-row/content-color-row.jsx
@@ -27,7 +27,7 @@ export const ContentColorRow = ({ colorName }) => {
   return (
     <tr className="content-color-row">
       <ContentColorCell>
-        <Text>{`--${colorName}`}</Text>
+        <Text>{`--color-${colorName}`}</Text>
       </ContentColorCell>
       <ContentColorCell style={regularStyle} />
       <ContentColorCell style={hoverStyle} />


### PR DESCRIPTION
This pr resolves an issue where var name of the colors in the color foundation name was incorrect 
https://vibe.monday.com/?path=/docs/foundations-colors--colors

Resolves #2664 