### PR TITLE
chore(TextField): Narrow types for Events on TextField

### DIFF
--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -44,10 +44,10 @@ export interface TextFieldProps extends VibeComponentProps {
     value: string,
     event: React.ChangeEvent<HTMLInputElement> | Pick<React.ChangeEvent<HTMLInputElement>, "target">
   ) => void;
-  onBlur?: (event: React.FocusEvent) => void;
-  onFocus?: (event: React.FocusEvent) => void;
-  onKeyDown?: (event: React.KeyboardEvent) => void;
-  onWheel?: (event: React.WheelEvent) => void;
+  onBlur?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onFocus?: (event: React.FocusEvent<HTMLInputElement>) => void;
+  onKeyDown?: (event: React.KeyboardEvent<HTMLInputElement>) => void;
+  onWheel?: (event: React.WheelEvent<HTMLInputElement>) => void;
   debounceRate?: number;
   autoFocus?: boolean;
   disabled?: boolean;


### PR DESCRIPTION
Noticed that we can narrow the types of the event parameters on the `on..` props for the TextField. This makes it trivial to access the `value` of the input element instead of having to cast it first.

- [ ] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.
