### PR TITLE
fix(Dropdown): Fix ESM - use .default if available

### DIFF
--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -376,7 +376,10 @@ const Dropdown: VibeComponent<DropdownComponentProps, HTMLElement> & {
       }
     };
 
-    const DropDownComponent: React.ElementType = asyncOptions ? AsyncSelect : Select;
+    let DropDownComponent: React.ElementType = asyncOptions ? AsyncSelect : Select;
+
+    // @ts-expect-error - We need to check if the default export is available
+    DropDownComponent = DropDownComponent.default || DropDownComponent;
 
     const asyncAdditions = {
       ...(asyncOptions && {


### PR DESCRIPTION
Same fix as the one we did for `react-windowed-select` and `react-inlinesvg`.