### PR TITLE
fix(tooltip): fix text with line breaks

### DIFF
--- a/packages/core/src/components/Tooltip/Tooltip.module.scss
+++ b/packages/core/src/components/Tooltip/Tooltip.module.scss
@@ -11,6 +11,7 @@
   background-color: var(--inverted-color-background);
   color: var(--text-color-on-inverted);
   --tooltip-max-width: 240px;
+  white-space: pre-wrap;
 
   .image {
     display: block;


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/8138323310

Following this [pr](https://github.com/mondaycom/vibe/pull/2383), since the containerSelector is no longer `tooltips-container` which provided the `white-space: pre-wrap;` style, we need to add it directly to the component.
