### PR TITLE
fix(Modal): avoid breaking changes due to specificity

### DIFF
--- a/packages/core/src/components/Modal/Modal/Modal.module.scss
+++ b/packages/core/src/components/Modal/Modal/Modal.module.scss
@@ -2,49 +2,49 @@
   position: fixed;
   inset: 0;
   z-index: var(--monday-modal-z-index, 10000);
+}
 
-  .overlay {
-    position: fixed;
-    inset: 0;
-    height: 100%;
-    background-color: var(--color-surface);
+.overlay {
+  position: fixed;
+  inset: 0;
+  height: 100%;
+  background-color: var(--color-surface);
+}
+
+.modal {
+  --top-actions-spacing: var(--spacing-large);
+  --top-actions-width: var(--spacing-xl);
+  --modal-inline-padding: var(--spacing-xl);
+
+  position: relative;
+  top: 50%;
+  left: 50%;
+
+  display: flex;
+  flex-direction: column;
+  width: var(--modal-width);
+  max-height: var(--modal-max-height);
+  background-color: var(--primary-background-color);
+  overflow: hidden;
+  border-radius: var(--border-radius-big);
+  box-shadow: var(--box-shadow-large);
+
+  &.withHeaderAction {
+    --top-actions-width: calc(var(--spacing-xl) * 2);
   }
 
-  .modal {
-    --top-actions-spacing: var(--spacing-large);
-    --top-actions-width: var(--spacing-xl);
-    --modal-inline-padding: var(--spacing-xl);
+  &.sizeSmall {
+    --modal-max-height: 50%;
+    --modal-width: 480px;
+  }
 
-    position: relative;
-    top: 50%;
-    left: 50%;
+  &.sizeMedium {
+    --modal-max-height: 80%;
+    --modal-width: 580px;
+  }
 
-    display: flex;
-    flex-direction: column;
-    width: var(--modal-width);
-    max-height: var(--modal-max-height);
-    background-color: var(--primary-background-color);
-    overflow: hidden;
-    border-radius: var(--border-radius-big);
-    box-shadow: var(--box-shadow-large);
-
-    &.withHeaderAction {
-      --top-actions-width: calc(var(--spacing-xl) * 2);
-    }
-
-    &.sizeSmall {
-      --modal-max-height: 50%;
-      --modal-width: 480px;
-    }
-
-    &.sizeMedium {
-      --modal-max-height: 80%;
-      --modal-width: 580px;
-    }
-
-    &.sizeLarge {
-      --modal-max-height: 80%;
-      --modal-width: 840px;
-    }
+  &.sizeLarge {
+    --modal-max-height: 80%;
+    --modal-width: 840px;
   }
 }


### PR DESCRIPTION
the previous commit caused `.modal` to have `(0, 2, 0)`, which caused it to override user-defined `className`.
it wasn't released yet though

https://monday.monday.com/boards/3532714909/pulses/8165813476