### PR TITLE
feat(ButtonGroup): add blurOnMouseUp to ButtonGroup

### DIFF
--- a/packages/core/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/components/ButtonGroup/ButtonGroup.tsx
@@ -47,6 +47,7 @@ export interface ButtonGroupProps extends VibeComponentProps {
   tooltipMoveBy?: MoveBy;
   children?: React.ReactNode;
   fullWidth?: boolean;
+  blurOnMouseUp?: boolean;
 }
 
 const ButtonGroup: VibeComponent<ButtonGroupProps, HTMLDivElement> & {
@@ -69,6 +70,7 @@ const ButtonGroup: VibeComponent<ButtonGroupProps, HTMLDivElement> & {
       tooltipShowDelay,
       tooltipContainerSelector,
       tooltipMoveBy,
+      blurOnMouseUp = true,
       id,
       "data-testid": dataTestId,
       fullWidth = false
@@ -120,6 +122,7 @@ const ButtonGroup: VibeComponent<ButtonGroupProps, HTMLDivElement> & {
             tooltipShowDelay={tooltipShowDelay}
             tooltipContainerSelector={tooltipContainerSelector}
             tooltipMoveBy={tooltipMoveBy}
+            blurOnMouseUp={blurOnMouseUp}
             className={cx(styles.button, styles.optionText, {
               [styles.selected]: isSelected,
               [styles.disabled]: disabled,
@@ -141,6 +144,7 @@ const ButtonGroup: VibeComponent<ButtonGroupProps, HTMLDivElement> & {
       tooltipShowDelay,
       tooltipContainerSelector,
       tooltipMoveBy,
+      blurOnMouseUp,
       disabled,
       fullWidth,
       onClick


### PR DESCRIPTION
Add blurOnMouseUp to button-group component.
Today we have a control over blurOnMouseUp only for button component- but in button-group it is always `true`. the option to disable it is required for certain use cases