### PR TITLE
feat(useIsOverflowing): allow width tolerance

### DIFF
--- a/packages/core/src/hooks/useIsOverflowing/useIsOverflowing.ts
+++ b/packages/core/src/hooks/useIsOverflowing/useIsOverflowing.ts
@@ -1,34 +1,48 @@
 import { RefObject, useCallback, useState } from "react";
 import useResizeObserver from "../useResizeObserver";
 
-function checkOverflow(element: HTMLElement, ignoreHeightOverflow: boolean, tolerance = 0) {
+function checkOverflow(element: HTMLElement, ignoreHeightOverflow: boolean, heightTolerance = 0, widthTolerance = 0) {
   if (!element) {
     return false;
   }
-  const isOverflowingWidth = element.clientWidth < element.scrollWidth;
-  const isOverflowingHeight = !ignoreHeightOverflow && element.clientHeight + tolerance < element.scrollHeight;
+  const isOverflowingWidth = element.clientWidth + widthTolerance < element.scrollWidth;
+  const isOverflowingHeight = !ignoreHeightOverflow && element.clientHeight + heightTolerance < element.scrollHeight;
   return isOverflowingWidth || isOverflowingHeight;
 }
 
 export default function useIsOverflowing({
   ref,
   ignoreHeightOverflow = false,
-  tolerance
+  tolerance: heightTolerance,
+  widthTolerance
 }: {
+  /**
+   * The ref of the element to check for overflow.
+   */
   ref: RefObject<HTMLElement>;
+  /**
+   * Whether to ignore height overflow.
+   */
   ignoreHeightOverflow?: boolean;
+  /**
+   * The tolerance value to consider the element as overflowing (height overflow).
+   */
   tolerance?: number;
+  /**
+   * The tolerance value to consider the element as overflowing (width overflow).
+   */
+  widthTolerance?: number;
 }) {
   const [isOverflowing, setIsOverflowing] = useState<boolean>(() =>
-    checkOverflow(ref?.current, ignoreHeightOverflow, tolerance)
+    checkOverflow(ref?.current, ignoreHeightOverflow, heightTolerance, widthTolerance)
   );
   const callback = useCallback(() => {
     const element = ref?.current;
     if (!element) return;
 
-    const newOverflowState = checkOverflow(element, ignoreHeightOverflow, tolerance);
+    const newOverflowState = checkOverflow(element, ignoreHeightOverflow, heightTolerance, widthTolerance);
     setIsOverflowing(prevState => (prevState !== newOverflowState ? newOverflowState : prevState));
-  }, [ignoreHeightOverflow, ref, tolerance]);
+  }, [ignoreHeightOverflow, ref, heightTolerance, widthTolerance]);
 
   useResizeObserver({
     ref,


### PR DESCRIPTION
we need it to support weird browser's behaviors, such as Safari with 125% zoom, which causes 1 pixel diff (in clientWidth vs scrollWidth), as Chromium and Safari treat rounding floating pixel differently (round up vs round down)

https://monday.monday.com/boards/3532714909/pulses/8350809092