### PR TITLE
feat(Combobox): add className for sticky header

### DIFF
--- a/packages/core/src/components/Combobox/Combobox.tsx
+++ b/packages/core/src/components/Combobox/Combobox.tsx
@@ -33,6 +33,10 @@ export interface ComboboxProps extends VibeComponentProps {
   optionClassName?: string;
   searchWrapperClassName?: string;
   /**
+   * Class name for sticky category header
+   */
+  stickyCategoryClassName?: string;
+  /**
    * Placeholder to show when no value was selected
    */
   placeholder?: string;
@@ -137,6 +141,7 @@ const Combobox: React.FC<ComboboxProps> & {
       className = "",
       optionClassName = "",
       searchWrapperClassName,
+      stickyCategoryClassName,
       searchIcon,
       id = "",
       placeholder = "",
@@ -337,7 +342,13 @@ const Combobox: React.FC<ComboboxProps> & {
             renderAction={RenderAction}
             hideRenderActionOnInput={hideRenderActionOnInput}
           />
-          {stickyCategories && <StickyCategoryHeader label={activeCategory?.label} color={activeCategory?.color} />}
+          {stickyCategories && (
+            <StickyCategoryHeader
+              label={activeCategory?.label}
+              color={activeCategory?.color}
+              className={stickyCategoryClassName}
+            />
+          )}
           {hasResults && (
             <ComboboxItems
               stickyCategories={stickyCategories}

--- a/packages/core/src/components/Combobox/components/StickyCategoryHeader/StickyCategoryHeader.tsx
+++ b/packages/core/src/components/Combobox/components/StickyCategoryHeader/StickyCategoryHeader.tsx
@@ -4,13 +4,22 @@ import styles from "./StickyCategoryHeader.module.scss";
 import comboboxStyles from "../../Combobox.module.scss";
 import comboboxCategoryStyles from "../ComboboxCategory/ComboboxCategory.module.scss";
 
-export const StickyCategoryHeader = ({ label, color }: { label: string; color?: string }) => {
+export const StickyCategoryHeader = ({
+  label,
+  color,
+  className
+}: {
+  label: string;
+  color?: string;
+  className?: string;
+}) => {
   return label === undefined ? null : (
     <div
       className={cx(
         styles.stickyCategoryHeader,
         comboboxStyles.comboboxCategory,
-        comboboxCategoryStyles.comboboxCategory
+        comboboxCategoryStyles.comboboxCategory,
+        className
       )}
       style={color && { color }}
       aria-hidden


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/8451157596

Currently the sticky header has a background color, in order to change it we need to add a className
![Screenshot 2025-02-11 at 13 13 44](https://github.com/user-attachments/assets/6cecb8ee-cbc8-44b4-ab2d-9b435d657aec)
