### PR TITLE
fix(Tipseen): setting width more than max-width in tooltip default width has no effect

### DIFF
--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -175,6 +175,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
             [styles.tipseenWrapperWithoutCustomWidth]: !width,
             [styles.floating]: floating
           })}
+          maxWidth={width}
           arrowClassName={tooltipArrowClassName}
           style={width ? { width } : undefined}
           shouldShowOnMount={!defaultDelayOpen}


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/113184182/pulses/8516533100