### PR TITLE
fix(ColorPicker): make forceUseRawColorList and showColorNameTooltip compatible

### DIFF
--- a/packages/core/src/components/ColorPicker/ColorPicker.tsx
+++ b/packages/core/src/components/ColorPicker/ColorPicker.tsx
@@ -40,7 +40,7 @@ export interface ColorPickerProps extends VibeComponentProps {
    */
   forceUseRawColorList?: boolean;
   /**
-   * Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.
+   * Used to enable color name tooltip on each color in the component.
    * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
    *
    */

--- a/packages/core/src/components/ColorPicker/__tests__/ColorPicker.test.tsx
+++ b/packages/core/src/components/ColorPicker/__tests__/ColorPicker.test.tsx
@@ -122,7 +122,7 @@ describe("ColorPicker", () => {
     expect(content).toBeTruthy();
   });
 
-  it("should not render tooltip with the color name if showColorNameTooltip is true and forceUseRawColorList is true", () => {
+  it("should render tooltip with the color name if showColorNameTooltip is true and forceUseRawColorList is true", () => {
     const colorName = "done-green";
     const colorNameTooltip = "Done Green";
     const colorList = [colorName];
@@ -134,7 +134,7 @@ describe("ColorPicker", () => {
     });
     jest.advanceTimersByTime(1000);
     const content = screen.queryByText(colorNameTooltip);
-    expect(content).toBeNull();
+    expect(content).toBeTruthy();
   });
 
   it("should render tooltip with tooltipContentByColor value if tooltipContentByColor of the color exist", () => {

--- a/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
@@ -39,7 +39,7 @@ export interface ColorPickerContentProps extends VibeComponentProps {
    */
   forceUseRawColorList?: boolean;
   /**
-   * Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.
+   * Used to enable color name tooltip on each color in the component.
    * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
    */
   showColorNameTooltip?: boolean;
@@ -134,7 +134,7 @@ const ColorPickerContent: VibeComponent<ColorPickerContentProps, HTMLDivElement>
             colorSize={colorSize}
             tooltipContentByColor={tooltipContentByColor}
             colorShape={colorShape}
-            showColorNameTooltip={showColorNameTooltip && !forceUseRawColorList}
+            showColorNameTooltip={showColorNameTooltip}
             id={id}
             data-testid={dataTestId}
           />

--- a/packages/core/src/storybook/stand-alone-documentaion/playground/react-docgen-output.json
+++ b/packages/core/src/storybook/stand-alone-documentaion/playground/react-docgen-output.json
@@ -19072,7 +19072,7 @@
           "tsType": {
             "name": "boolean"
           },
-          "description": "Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.\nWhen \"tooltipContentByColor\" is supplied, it will override the color name tooltip."
+          "description": "Used to enable color name tooltip on each color in the component.\nWhen \"tooltipContentByColor\" is supplied, it will override the color name tooltip."
         }
       }
     }
@@ -26193,7 +26193,7 @@
           "tsType": {
             "name": "boolean"
           },
-          "description": "Used to enable color name tooltip on each color in the component. it's incompatible with forceUseRawColorList flag.\nWhen \"tooltipContentByColor\" is supplied, it will override the color name tooltip."
+          "description": "Used to enable color name tooltip on each color in the component.\nWhen \"tooltipContentByColor\" is supplied, it will override the color name tooltip."
         }
       }
     }


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->
![image](https://github.com/user-attachments/assets/cca53278-34e9-4e9f-b28d-51248a6ab0be)
make forceUseRawColorList and showColorNameTooltip compatible
- [ ] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->

Resolves #
