### PR TITLE
fix(Tipseen): resolve invalid HTML structure and ref/id prop issues

### DIFF
--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -142,6 +142,8 @@ const Tipseen: VibeComponent<TipseenProps> & {
     }, [color, closeButtonTheme]);
 
     const TipseenWrapper = ref || id ? "div" : Fragment;
+    const wrapperProps = TipseenWrapper === "div" ? { ref: mergedRef, id, "data-testid": dataTestId || getTestId(ComponentDefaultTestId.TIPSEEN, id) } : {};
+
     const tooltipContent = (
       <div>
         <div className={cx(styles.tipseenHeader)}>
@@ -162,14 +164,14 @@ const Tipseen: VibeComponent<TipseenProps> & {
           )}
           <TipseenTitle text={title} className={cx(styles.tipseenTitle, titleClassName)} />
         </div>
-        <Text color={textColor} type="text2" element="p" className={cx(styles.tipseenContent)}>
+        <Text color={textColor} type="text2" element="div" ellipsis={false} className={cx(styles.tipseenContent)}>
           <TipseenContext.Provider value={color}>{content}</TipseenContext.Provider>
         </Text>
       </div>
     );
 
     return (
-      <TipseenWrapper ref={mergedRef} id={id} data-testid={dataTestId || getTestId(ComponentDefaultTestId.TIPSEEN, id)}>
+      <TipseenWrapper {...wrapperProps}>
         <Tooltip
           className={cx(styles.tipseenWrapper, className, {
             [styles.tipseenWrapperWithoutCustomWidth]: !width,


### PR DESCRIPTION
### ✨ Summary
This PR fixes two issues in the `Tipseen` component:
1. Replaces the `<Text>` element’s `element="p"` with `element="div"` to resolve invalid HTML structure when rendering nested `<div>`s inside `<p>`.
2. Fixes improper usage of `id` and `ref` props on `React.Fragment` by conditionally rendering a `<div>` wrapper when necessary.

### ✅ Changes
- `element` prop in `Text` changed from `"p"` to `"div"` to comply with HTML standards.
- Conditionally render a `<div>` instead of `React.Fragment` when `id` or `ref` is passed, avoiding React warnings.
- No changes in component behavior or appearance (verified in Storybook).

### 🧪 How I tested it
- Ran `yarn storybook` and verified no console warnings in the Tipseen stories.
- Confirmed component behavior is consistent.
- Ran `yarn test` and `yarn lint` with no issues related to my changes.

---
### Error Messages Before Fix
![image](https://github.com/user-attachments/assets/0960337d-5327-474b-bac5-d5f6602fc011)
![image](https://github.com/user-attachments/assets/77b60243-5148-4182-be19-e611392afb0e)
