### PR TITLE
fix(MenuItem): remove 2nd tooltip (already has tooltip on the MenuItem wrapper)

### DIFF
--- a/packages/core/src/components/Menu/MenuItem/components/BaseMenuItem/BaseMenuItem.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/BaseMenuItem/BaseMenuItem.tsx
@@ -138,6 +138,7 @@ const BaseMenuItem = forwardRef(
         onMouseLeave={onMouseLeave}
         onMouseEnter={onMouseEnter}
         tabIndex={TAB_INDEX_FOCUS_WITH_JS_ONLY}
+        withoutTooltip
       >
         {children}
         {Boolean(subMenu) && (


### PR DESCRIPTION
This causes a weird behavior of showing two tooltips, one with icon and one without, and the menu items to be uninteractable

https://monday.monday.com/boards/3532714909/pulses/8775344190