### PR TITLE
fix(Tipseen): prevent double delay when using showDelay

### DIFF
--- a/packages/core/src/components/Tipseen/Tipseen.tsx
+++ b/packages/core/src/components/Tipseen/Tipseen.tsx
@@ -240,7 +240,7 @@ const Tipseen: VibeComponent<TipseenProps> & {
           position={position}
           animationType={animationType}
           hideDelay={hideDelay}
-          showDelay={showDelay}
+          showDelay={0}
           hideTrigger={hideTrigger}
           showTrigger={showTrigger}
           showOnDialogEnter={false}


### PR DESCRIPTION
The Tipseen component was experiencing a "double delay" issue where the content would take twice the specified showDelay time to become interactive. This was caused by both the Tipseen component and the underlying Tooltip component applying the same delay.

This fix passes a showDelay of 0 to the Tooltip while maintaining the original delay logic in the Tipseen component, ensuring the content appears and becomes interactive after exactly the specified delay time.

https://monday.monday.com/boards/3532714909/pulses/8301809774