### PR TITLE
fix(docs): docgen can't handle ComponentType

### DIFF
--- a/packages/core/.storybook/main.ts
+++ b/packages/core/.storybook/main.ts
@@ -54,7 +54,8 @@ const config: StorybookConfig = {
     check: true,
     checkOptions: {
       async: false
-    }
+    },
+    reactDocgen: "react-docgen-typescript"
   },
   async webpackFinal(config, { configType }) {
     if (configType === "DEVELOPMENT") {

--- a/packages/core/src/types/withStaticProps.ts
+++ b/packages/core/src/types/withStaticProps.ts
@@ -1,15 +1,12 @@
-import { ForwardRefExoticComponent, RefAttributes, ComponentType } from "react";
+import React, { ForwardRefExoticComponent, RefAttributes } from "react";
 
 type Required<T> = {
   [P in keyof T]-?: T[P];
 };
 
+type Component<P, R> = React.FC<P> | ForwardRefExoticComponent<P & RefAttributes<R>>;
+
 export const withStaticProps = <Props, StaticProps, Ref = HTMLElement>(
-  component: ComponentType<Props> | ForwardRefExoticComponent<Props & RefAttributes<Ref>>,
+  component: Component<Props, Ref>,
   staticProps: Required<StaticProps>
-) =>
-  Object.assign(component, staticProps) as (
-    | ComponentType<Props>
-    | ForwardRefExoticComponent<Props & RefAttributes<Ref>>
-  ) &
-    Required<StaticProps>;
+) => Object.assign(component, staticProps) as Component<Props, Ref> & Required<StaticProps>;


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/pulses/8988817874

Also:
Switched to use react-docgen-typescript in our Storybook default docgen. Check Storybook docs:
<https://storybook.js.org/docs/api/main-config/main-config-typescript#reactdocgen>
> react-docgen-typescript invokes the TypeScript compiler, which makes it slow but generally accurate. react-docgen performs its own analysis, which is much faster but incomplete.