### PR TITLE
fix(MenuButton): fix tab focus when menu is closing

### DIFF
--- a/packages/core/src/components/MenuButton/MenuButton.tsx
+++ b/packages/core/src/components/MenuButton/MenuButton.tsx
@@ -251,9 +251,9 @@ const MenuButton = forwardRef(
 
     const onDialogDidHide = useCallback(
       (event: DialogEvent, hideEvent: string) => {
-        handleMenuClose(CLOSE_KEYS.includes(hideEvent as DialogTriggerEventEnum));
+        handleMenuClose(isOpen && CLOSE_KEYS.includes(hideEvent as DialogTriggerEventEnum));
       },
-      [handleMenuClose]
+      [handleMenuClose, isOpen]
     );
 
     const onDialogDidShow = useCallback(() => {


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

Fixing menu button tab action

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->

https://github.com/user-attachments/assets/1b11866c-bb4d-4e69-b674-797e8d4d0560

The issue is that onDialogDidHide is called when the menu is closed, returning the focus to the menu button when tabbing to the next element. Checking if the menu is open allows tabbing to the next element

