### PR TITLE
fix(ColorPickerContent): add keyboard tab navigation support to ColorPickerContent's grid

### DIFF
--- a/packages/core/src/components/ColorPicker/__tests__/__snapshots__/ColorPicker.test.tsx.snap
+++ b/packages/core/src/components/ColorPicker/__tests__/__snapshots__/ColorPicker.test.tsx.snap
@@ -24,7 +24,8 @@ exports[`renders correctly with empty props 1`] = `
     <ul
       className="colorsGrid"
       data-testid="color-picker"
-      tabIndex={-1}
+      role="grid"
+      tabIndex={0}
     >
       <li
         className="itemWrapper"

--- a/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.tsx
@@ -78,10 +78,6 @@ export interface ColorPickerColorsGridProps extends VibeComponentProps {
    * If true, displays a tooltip with the color name.
    */
   showColorNameTooltip?: boolean;
-  /**
-   * If true, the grid element will be focusable via keyboard (tab navigation).
-   */
-  enableGridTabNavigation?: boolean;
 }
 
 const ColorPickerColorsGrid = forwardRef(
@@ -100,7 +96,6 @@ const ColorPickerColorsGrid = forwardRef(
       tooltipContentByColor,
       colorShape,
       showColorNameTooltip: showColorNameTooltip,
-      enableGridTabNavigation,
       id,
       "data-testid": dataTestId
     }: ColorPickerColorsGridProps,
@@ -114,19 +109,12 @@ const ColorPickerColorsGrid = forwardRef(
       onItemClicked: onColorClicked,
       itemsCount: colorsToRender.length,
       numberOfItemsInLine: numberOfColorsInLine,
-      entryFocusStrategy: enableGridTabNavigation ? "first" : "directional",
+      entryFocusStrategy: "first",
       getItemByIndex
     });
 
     return (
-      <ul
-        className={styles.colorsGrid}
-        ref={ref}
-        tabIndex={enableGridTabNavigation ? 0 : -1}
-        id={id}
-        data-testid={dataTestId}
-        role="grid"
-      >
+      <ul className={styles.colorsGrid} ref={ref} tabIndex={0} id={id} data-testid={dataTestId} role="grid">
         {colorsToRender.map((color, index) => {
           return (
             <ColorPickerItemComponent

--- a/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerColorsGrid.tsx
@@ -78,6 +78,10 @@ export interface ColorPickerColorsGridProps extends VibeComponentProps {
    * If true, displays a tooltip with the color name.
    */
   showColorNameTooltip?: boolean;
+  /**
+   * If true, the grid element will be focusable via keyboard (tab navigation).
+   */
+  enableGridTabNavigation?: boolean;
 }
 
 const ColorPickerColorsGrid = forwardRef(
@@ -96,6 +100,7 @@ const ColorPickerColorsGrid = forwardRef(
       tooltipContentByColor,
       colorShape,
       showColorNameTooltip: showColorNameTooltip,
+      enableGridTabNavigation,
       id,
       "data-testid": dataTestId
     }: ColorPickerColorsGridProps,
@@ -109,11 +114,19 @@ const ColorPickerColorsGrid = forwardRef(
       onItemClicked: onColorClicked,
       itemsCount: colorsToRender.length,
       numberOfItemsInLine: numberOfColorsInLine,
+      entryFocusStrategy: enableGridTabNavigation ? "first" : "directional",
       getItemByIndex
     });
 
     return (
-      <ul className={styles.colorsGrid} ref={ref} tabIndex={-1} id={id} data-testid={dataTestId}>
+      <ul
+        className={styles.colorsGrid}
+        ref={ref}
+        tabIndex={enableGridTabNavigation ? 0 : -1}
+        id={id}
+        data-testid={dataTestId}
+        role="grid"
+      >
         {colorsToRender.map((color, index) => {
           return (
             <ColorPickerItemComponent

--- a/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
@@ -91,10 +91,6 @@ export interface ColorPickerContentProps extends VibeComponentProps {
    * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
    */
   showColorNameTooltip?: boolean;
-  /**
-   * If true, enables keyboard tab navigation into the colors grid (makes it focusable).
-   */
-  enableTabNavigation?: boolean;
 }
 
 const ColorPickerContent = forwardRef(
@@ -119,7 +115,6 @@ const ColorPickerContent = forwardRef(
       colorShape = "square",
       forceUseRawColorList,
       showColorNameTooltip,
-      enableTabNavigation,
       id,
       "data-testid": dataTestId
     }: ColorPickerContentProps,
@@ -183,7 +178,6 @@ const ColorPickerContent = forwardRef(
             tooltipContentByColor={tooltipContentByColor}
             colorShape={colorShape}
             showColorNameTooltip={showColorNameTooltip}
-            enableGridTabNavigation={enableTabNavigation}
             id={id}
             data-testid={dataTestId}
           />

--- a/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerContent/ColorPickerContent.tsx
@@ -91,6 +91,10 @@ export interface ColorPickerContentProps extends VibeComponentProps {
    * When "tooltipContentByColor" is supplied, it will override the color name tooltip.
    */
   showColorNameTooltip?: boolean;
+  /**
+   * If true, enables keyboard tab navigation into the colors grid (makes it focusable).
+   */
+  enableTabNavigation?: boolean;
 }
 
 const ColorPickerContent = forwardRef(
@@ -115,6 +119,7 @@ const ColorPickerContent = forwardRef(
       colorShape = "square",
       forceUseRawColorList,
       showColorNameTooltip,
+      enableTabNavigation,
       id,
       "data-testid": dataTestId
     }: ColorPickerContentProps,
@@ -178,6 +183,7 @@ const ColorPickerContent = forwardRef(
             tooltipContentByColor={tooltipContentByColor}
             colorShape={colorShape}
             showColorNameTooltip={showColorNameTooltip}
+            enableGridTabNavigation={enableTabNavigation}
             id={id}
             data-testid={dataTestId}
           />


### PR DESCRIPTION
As for today - there's no way to tab into ColorPickerContent

- Introduced `enableGridTabNavigation` prop in `ColorPickerColorsGrid` for focusable grid elements.
- Updated `ColorPickerContent` to accept `enableTabNavigation` prop for enabling keyboard navigation.
- Enhanced `useGridKeyboardNavigation` hook to support entry focus strategy for keyboard navigation.

https://monday.monday.com/boards/8350127532/pulses/8433955776