### PR TITLE
fix(Table): Memoized row for optimized row rendering

### DIFF
--- a/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -36,6 +36,10 @@ export interface TableVirtualizedBodyProps<T extends TableVirtualizedRow = Table
    * Function to render the table header.
    */
   headerRenderer?: (columns: TableColumn[]) => JSX.Element;
+  /**
+   * Number of rows to render above/below the visible area.
+   */
+  overscanCount?: number;
 }
 
 const MemoizedRow = React.memo(
@@ -66,7 +70,8 @@ const TableVirtualizedBody = forwardRef(
       headerRenderer,
       id,
       className,
-      "data-testid": dataTestId
+      "data-testid": dataTestId,
+      overscanCount = 1
     }: TableVirtualizedBodyProps<T>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
@@ -164,6 +169,7 @@ const TableVirtualizedBody = forwardRef(
                 height={height}
                 itemCount={virtualizedWithHeader ? items.length + 1 : items.length}
                 width={width}
+                overscanCount={overscanCount}
                 onScroll={handleVirtualizedVerticalScroll}
                 outerRef={element => {
                   virtualizedListRef.current = element;


### PR DESCRIPTION
Addresses performance issues in TableVirtualizedBody, particularly noticeable during fast scrolling with many columns or complex cell content. This often resulted in excessive re-renders, blank spaces appearing, and compatibility problems with sticky columns.
Changes:
- Internal Row Memoization: Implements React.memo internally for rendered rows. This significantly reduces unnecessary re-renders when scrolling, as rows only update if their data changes, not just their position.
Before
<img width="985" alt="Screenshot 2025-05-03 at 22 33 20" src="https://github.com/user-attachments/assets/8fbea38f-9731-4c0a-a81a-7e1ee4741090" />

After
<img width="997" alt="Screenshot 2025-05-03 at 22 32 47" src="https://github.com/user-attachments/assets/c8615d29-aae0-4036-bc58-9112294f64ab" />


- Configurable Overscanning: Adds an optional overscanCount prop (defaulting to 1). Consumers can increase this value to render more rows outside the viewport, potentially smoothing out fast scrolls at the cost of rendering more items.