### PR TITLE
docs(LiveEdit): remember last known valid code for better DX

### DIFF
--- a/packages/core/src/storybook/components/live-preview/LivePreview.module.scss
+++ b/packages/core/src/storybook/components/live-preview/LivePreview.module.scss
@@ -1,0 +1,28 @@
+.wrapper {
+  position: relative;
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  color: #fff;
+  background-color: rgba(0, 0, 0, 0.7);
+  padding: 16px;
+  margin: 0;
+  z-index: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.errorTitle {
+  font-size: 14px;
+  font-weight: bold;
+  margin-bottom: 8px;
+}
+
+.errorMessage {
+  font-size: 12px;
+  white-space: pre-wrap;
+  word-break: break-all;
+}

--- a/packages/core/src/storybook/components/live-preview/LivePreview.tsx
+++ b/packages/core/src/storybook/components/live-preview/LivePreview.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState, useEffect } from "react";
 import { withLive } from "react-live";
+import styles from "./LivePreview.module.scss";
 
 interface LivePreview {
   live?: {
@@ -11,6 +12,25 @@ interface LivePreview {
 
 const LivePreview: React.FC<LivePreview> = ({ live = {} }) => {
   const { error, element: Element } = live;
-  return <>{error ?? (Element && <Element />)}</>;
+  const [lastGoodElement, setLastGoodElement] = useState<typeof Element | null>(null);
+
+  useEffect(() => {
+    if (Element && !error) {
+      setLastGoodElement(() => Element);
+    }
+  }, [Element, error]);
+
+  const ElementToRender = lastGoodElement || Element;
+
+  return (
+    <>
+      {ElementToRender && <ElementToRender />}
+      {error && (
+        <div className={styles.overlay}>
+          <pre className={styles.errorMessage}>{error}</pre>
+        </div>
+      )}
+    </>
+  );
 };
 export default withLive(LivePreview);


### PR DESCRIPTION
How it looks now:
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/23381c26-b6e3-4cd5-b3ff-d56621c54174" />

It helps avoid "jumping" in the page when editing. it always remember the last known valid code.

https://monday.monday.com/boards/3532714909/pulses/6495484558