### PR TITLE
fix(Table): make row hover state immediate, robust and more reliable

### DIFF
--- a/packages/core/src/components/Table/TableContainer/TableContainer.module.scss
+++ b/packages/core/src/components/Table/TableContainer/TableContainer.module.scss
@@ -7,7 +7,7 @@
     --cell-width: 40px;
     position: absolute;
     overflow: hidden;
-    left: calc(calc(var(--cell-width) * -1) + 1px);
+    left: calc(1px - var(--cell-width));
     width: var(--cell-width);
     height: 100%;
   }

--- a/packages/core/src/components/Table/TableContainer/TableContainer.module.scss
+++ b/packages/core/src/components/Table/TableContainer/TableContainer.module.scss
@@ -7,7 +7,7 @@
     --cell-width: 40px;
     position: absolute;
     overflow: hidden;
-    left: calc(var(--cell-width) * -1);
+    left: calc(calc(var(--cell-width) * -1) + 1px);
     width: var(--cell-width);
     height: 100%;
   }

--- a/packages/core/src/components/Table/TableRowMenu/TableRowMenu.tsx
+++ b/packages/core/src/components/Table/TableRowMenu/TableRowMenu.tsx
@@ -47,7 +47,6 @@ const TableRowMenu = forwardRef(
             style={{ top: menuButtonPosition }}
             onMouseEnter={onMouseOverRowMenu}
             onMouseLeave={onMouseLeaveRowMenu}
-            data-row-menu-id={rowId}
           >
             <MenuButton
               id={id}

--- a/packages/core/src/components/Table/context/TableRowMenuContext/TableRowMenuContext.tsx
+++ b/packages/core/src/components/Table/context/TableRowMenuContext/TableRowMenuContext.tsx
@@ -5,49 +5,46 @@ const TableRowMenuContext = createContext<ITableRowMenuContext | undefined>(unde
 
 export const TableRowMenuProvider = ({ value, children }: TableRowMenuProviderProps) => {
   const { tableRootRef, hoveredRowRef, isMenuOpen, resetHoveredRow, setHoveredRowRef, setIsMenuOpen } = value;
-  const rowMouseLeaveTimeoutId = useRef<ReturnType<typeof setTimeout>>(null);
   const [menuButtonPosition, setMenuButtonPosition] = useState(0);
-  const hasMenuRef = useRef<boolean | null>(null);
-
-  const resetTimeout = useCallback(() => {
-    clearTimeout(rowMouseLeaveTimeoutId.current);
-    rowMouseLeaveTimeoutId.current = null;
-  }, []);
+  const isMenuHovered = useRef(false);
 
   const onMouseOverRow = useCallback(
     (rowRef: React.RefObject<HTMLDivElement>) => {
-      if (hasMenuRef.current === false || isMenuOpen || hoveredRowRef?.current === rowRef.current) return;
+      if (isMenuOpen) return;
 
-      resetTimeout();
       setHoveredRowRef(rowRef);
       const tableRootTop = tableRootRef.current.getBoundingClientRect().top;
       const rowTop = rowRef.current.getBoundingClientRect().top;
       setMenuButtonPosition(rowTop - tableRootTop);
-      if (hasMenuRef.current === null) {
-        setTimeout(() => {
-          hasMenuRef.current = !!document?.querySelector(`[data-row-menu-id]`);
-        });
-      }
     },
-    [isMenuOpen, hoveredRowRef, resetTimeout, setHoveredRowRef, tableRootRef]
+    [isMenuOpen, setHoveredRowRef, tableRootRef]
   );
 
   const onMouseLeaveRow = useCallback(() => {
-    if (isMenuOpen) return;
-    rowMouseLeaveTimeoutId.current = setTimeout(() => {
-      setHoveredRowRef(null);
-    }, 400);
+    if (isMenuOpen || isMenuHovered.current) return;
+    setHoveredRowRef(null);
   }, [isMenuOpen, setHoveredRowRef]);
 
   const onMouseOverRowMenu = useCallback(() => {
-    if (isMenuOpen) return;
-    resetTimeout();
-  }, [isMenuOpen, resetTimeout]);
+    isMenuHovered.current = true;
+  }, []);
 
   const onMouseLeaveRowMenu = useCallback(() => {
+    isMenuHovered.current = false;
     if (isMenuOpen) return;
-    setHoveredRowRef(null);
-  }, [isMenuOpen, setHoveredRowRef]);
+
+    if (!hoveredRowRef?.current) {
+      setHoveredRowRef(null);
+    }
+  }, [isMenuOpen, hoveredRowRef, setHoveredRowRef]);
+
+  const setTableMenuShown = useCallback(() => {
+    setIsMenuOpen(true);
+  }, [setIsMenuOpen]);
+
+  const setTableMenuHidden = useCallback(() => {
+    setIsMenuOpen(false);
+  }, [setIsMenuOpen]);
 
   const contextValue = useMemo<ITableRowMenuContext>(
     () => ({
@@ -58,8 +55,8 @@ export const TableRowMenuProvider = ({ value, children }: TableRowMenuProviderPr
       onMouseLeaveRow,
       onMouseOverRowMenu,
       onMouseLeaveRowMenu,
-      setTableMenuShown: () => setIsMenuOpen(true),
-      setTableMenuHidden: () => setIsMenuOpen(false)
+      setTableMenuShown,
+      setTableMenuHidden
     }),
     [
       hoveredRowRef,
@@ -69,7 +66,8 @@ export const TableRowMenuProvider = ({ value, children }: TableRowMenuProviderPr
       onMouseLeaveRowMenu,
       onMouseOverRow,
       onMouseOverRowMenu,
-      setIsMenuOpen
+      setTableMenuShown,
+      setTableMenuHidden
     ]
   );
 


### PR DESCRIPTION
this was changed because on some scenarios, when moving from menu button to row and back, the menu disappeared - especially in edge cases involving rapid mouse movement

https://monday.monday.com/boards/3532714909/pulses/9173208813

### Key Changes

#### 1. **Immediate Hover State Management**
- **Removed all setTimeouts** for hover state transitions between row and menu.
- Hover state (`hoveredRowRef`) is now updated immediately on mouse events, resulting in a more responsive and predictable UI.
- The code now uses a simple `isMenuHovered` ref to track when the mouse is over the menu, ensuring the menu remains visible when moving between row and menu.

#### 2. **Simplified Mouse Event Logic**
- `onMouseOverRow` and `onMouseOverRowMenu` now always immediately set the hover state and cancel any pending state clears.
- `onMouseLeaveRow` and `onMouseLeaveRowMenu` immediately clear the hover state if appropriate, without delay.
- This eliminates race conditions and flickering that could occur with delayed state changes.