### PR TITLE
fix(Combobox): Remove default bottom margin to align with Figma spacing

### DIFF
--- a/packages/core/src/components/Combobox/Combobox.module.scss
+++ b/packages/core/src/components/Combobox/Combobox.module.scss
@@ -7,7 +7,7 @@
   display: flex;
   flex-direction: column;
   position: relative;
-  margin-bottom: var(--spacing-small);
+  margin-bottom: 0;
 }
 
 .combobox.stickyCategory .comboboxCategory {
@@ -46,7 +46,7 @@
   height: calc(100% - 20px);
   overflow: hidden;
   position: relative;
-  padding: 0 16px;
+  padding: 0 var(--spacing-medium);
   display: flex;
   flex-direction: column;
 }
@@ -65,7 +65,7 @@
 .comboboxNoResults .addNewButton {
   flex: 0 0 auto;
   width: 100% !important;
-  margin-bottom: 8px;
+  margin-bottom: var(--spacing-small);
 }
 
 .comboboxNoResults .addNewButton .buttonLabel {
@@ -76,6 +76,6 @@
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
-  padding: 0 4px;
+  padding: 0 var(--spacing-xs);
   overflow: hidden;
 }


### PR DESCRIPTION
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [ ] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

<!-- Please add the issue nubmer that this PR closes: -->

Resolves #
