### PR TITLE
docs: add a quick-add deeplink button for Add to Cursor

### DIFF
--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -12,7 +12,7 @@ Connect your AI client to the MCP server by following the instructions below.
 
 [![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=vibe&config=eyJjb21tYW5kIjoibnB4IC15IEB2aWJlL21jcCJ9)
 
-Or manually update your Cursor configuration file at `~/.cursor/mcp.json` (create it if it doesn't exist):
+Or manually update your Cursor MCP configuration file at `~/.cursor/mcp.json` (create it if it doesn't exist):
 
 ```json
 {
@@ -27,7 +27,11 @@ Or manually update your Cursor configuration file at `~/.cursor/mcp.json` (creat
 
 #### VSCode
 
-Create or update your VSCode MCP configuration file at `.vscode/mcp.json` in your project:
+Paste this in your browser:
+```cli
+vscode://mcp-server/add?config=%7B%22name%22%3A%22vibe%22%2C%22command%22%3A%22npx%22%2C%22args%22%3A%5B%22-y%22%2C%22%40vibe%2Fmcp%22%5D%7D
+```
+or manually update your VSCode MCP configuration file at `.vscode/mcp.json` (create it if it doesn't exist):
 
 ```json
 {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,7 +10,7 @@ Connect your AI client to the MCP server by following the instructions below.
 
 #### Cursor
 
-[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=vibe&config=eyJjb21tYW5kIjoibnB4IC15IEB2aWJlL21jcCJ9)
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=vibe&config=eyJjb21tYW5kIjoibnB4IEB2aWJlL21jcCJ9)
 
 Or manually update your Cursor MCP configuration file at `~/.cursor/mcp.json` (create it if it doesn't exist):
 
@@ -19,7 +19,7 @@ Or manually update your Cursor MCP configuration file at `~/.cursor/mcp.json` (c
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "@vibe/mcp"]
+      "args": ["@vibe/mcp"]
     }
   }
 }
@@ -38,7 +38,7 @@ or manually update your VSCode MCP configuration file at `.vscode/mcp.json` (cre
   "servers": {
     "vibe": {
       "command": "npx",
-      "args": ["-y", "@vibe/mcp"]
+      "args": ["@vibe/mcp"]
     }
   }
 }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -10,12 +10,14 @@ Connect your AI client to the MCP server by following the instructions below.
 
 #### Cursor
 
-Update your Cursor configuration file at `~/.cursor/mcp.json` (create it if it doesn't exist):
+[![Install MCP Server](https://cursor.com/deeplink/mcp-install-light.svg)](https://cursor.com/install-mcp?name=vibe&config=eyJjb21tYW5kIjoibnB4IC15IEB2aWJlL21jcCJ9)
+
+Or manually update your Cursor configuration file at `~/.cursor/mcp.json` (create it if it doesn't exist):
 
 ```json
 {
   "mcpServers": {
-    "vibe-mcp": {
+    "vibe": {
       "command": "npx",
       "args": ["@vibe/mcp"]
     }
@@ -30,7 +32,7 @@ Create or update your VSCode MCP configuration file at `.vscode/mcp.json` in you
 ```json
 {
   "servers": {
-    "vibe-mcp": {
+    "vibe": {
       "command": "npx",
       "args": ["@vibe/mcp"]
     }

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,7 +19,7 @@ Or manually update your Cursor configuration file at `~/.cursor/mcp.json` (creat
   "mcpServers": {
     "vibe": {
       "command": "npx",
-      "args": ["@vibe/mcp"]
+      "args": ["-y", "@vibe/mcp"]
     }
   }
 }
@@ -34,7 +34,7 @@ Create or update your VSCode MCP configuration file at `.vscode/mcp.json` in you
   "servers": {
     "vibe": {
       "command": "npx",
-      "args": ["@vibe/mcp"]
+      "args": ["-y", "@vibe/mcp"]
     }
   }
 }


### PR DESCRIPTION
Cursor now supports deeplinks:
https://docs.cursor.com/deeplinks#markdown

https://monday.monday.com/boards/3532714909/pulses/9308682782