### PR TITLE
fix(metadata): include components withStaticPropsWithoutForwardRef

### DIFF
--- a/packages/core/src/types/withStaticProps.ts
+++ b/packages/core/src/types/withStaticProps.ts
@@ -1,5 +1,4 @@
-import React, { ForwardRefExoticComponent, RefAttributes } from "react";
-
+import { FC, ForwardRefExoticComponent, RefAttributes } from "react";
 type Required<T> = {
   [P in keyof T]-?: T[P];
 };
@@ -10,6 +9,6 @@ export const withStaticProps = <Props, StaticProps, Ref = HTMLElement>(
 ) => Object.assign(component, staticProps);
 
 export const withStaticPropsWithoutForwardRef = <Props, StaticProps>(
-  component: React.FC<Props>,
+  component: FC<Props>,
   staticProps: Required<StaticProps>
 ) => Object.assign(component, staticProps);


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9308916690

This adds the following components that were missing from the metadata
Counter, SplitButton, Divider, MenuTitle, MenuItemButton, Avatar, Toast, AttentionBox, Skeleton and ThemeProvider
