### PR TITLE
ci: force inner tasks to report "skip", to prevent ci stuck on "waiting for status..."

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -17,7 +17,6 @@ jobs:
   publish-chromatic:
     name: Publish Chromatic
     needs: build
-    if: ${{ needs.build.outputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -36,3 +35,4 @@ jobs:
           workingDir: packages/core
           exitOnceUploaded: true
           onlyChanged: false
+          skip: ${{ needs.build.outputs.has_changes == 'false' }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -14,8 +14,9 @@ jobs:
   test:
     name: Test
     needs: build
-    if: ${{ needs.build.outputs.has_changes == 'true' }}
     uses: ./.github/workflows/test.yml
+    with:
+      has_changes: ${{ needs.build.outputs.has_changes }}
     secrets:
       npm_token: ${{ secrets.npm_token }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,12 +5,18 @@ name: Test & Lint
 
 on:
   workflow_call:
+    inputs:
+      has_changes:
+        description: Whether there are any changes in the monorepo.
+        type: string
+        required: true
     secrets:
       npm_token:
         required: true
 
 jobs:
   checks:
+    if: ${{ inputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
@@ -41,6 +47,7 @@ jobs:
         run: yarn lerna run ${{ matrix.command }} $SINCE_FLAG
 
   e2e:
+    if: ${{ inputs.has_changes == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This should prevent this behavior:
![image](https://github.com/user-attachments/assets/78699057-27e5-4fbc-8139-099f5d37f38d)

Where if we're changing something in the root, without changes to "packages" folder, the CI is stuck and we need to force merge

https://monday.monday.com/boards/3532714909/pulses/9449860055