### PR TITLE
feat(FieldLabel): add htmlFor prop and id support for improved accessibility

### DIFF
--- a/packages/core/src/components/FieldLabel/FieldLabel.tsx
+++ b/packages/core/src/components/FieldLabel/FieldLabel.tsx
@@ -29,11 +29,24 @@ export interface FieldLabelProps extends VibeComponentProps {
    * If true, displays an asterisk to indicate a required field.
    */
   required?: boolean;
+  /**
+   * The HTML for attribute of the associated input element.
+   */
+  htmlFor?: string;
 }
 
 const FieldLabel: FC<FieldLabelProps> = forwardRef(
   (
-    { icon = "", labelText = "", labelFor = "", iconClassName = "", labelClassName = "", required = false },
+    {
+      icon = "",
+      labelText = "",
+      labelFor = "",
+      iconClassName = "",
+      labelClassName = "",
+      required = false,
+      id = "",
+      htmlFor = ""
+    },
     ref: ForwardedRef<HTMLLabelElement>
   ) => {
     if (!labelText) {
@@ -43,7 +56,12 @@ const FieldLabel: FC<FieldLabelProps> = forwardRef(
     return (
       <section className={cx(styles.labelComponentWrapper)}>
         <Icon icon={icon} className={cx(styles.labelComponentIcon, iconClassName)} id={labelFor} iconType="font" />
-        <label htmlFor={labelFor} ref={ref} className={cx(styles.labelComponentText, labelClassName)}>
+        <label
+          id={id}
+          htmlFor={labelFor || htmlFor}
+          ref={ref}
+          className={cx(styles.labelComponentText, labelClassName)}
+        >
           {labelText}
           {required && <span className={styles.required}> *</span>}
         </label>


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9476741730


___

### **PR Type**
Enhancement


___

### **Description**
- Add `htmlFor` prop to FieldLabel component for accessibility

- Support `id` prop for label element identification

- Improve form control association with proper HTML attributes

- Maintain backward compatibility with existing `labelFor` prop


___

### **Changes diagram**

```mermaid
flowchart LR
  A["FieldLabel Component"] --> B["Add htmlFor prop"]
  A --> C["Add id prop"]
  B --> D["Enhanced accessibility"]
  C --> D
  D --> E["Better form control association"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>FieldLabel.tsx</strong><dd><code>Add accessibility props to FieldLabel component</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/FieldLabel/FieldLabel.tsx

<li>Add <code>htmlFor</code> prop to component interface for HTML for attribute<br> <li> Add <code>id</code> prop support for label element identification<br> <li> Update label element to use <code>htmlFor</code> or fallback to <code>labelFor</code><br> <li> Maintain backward compatibility with existing props


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/2958/files#diff-6aad21bda6a3ca302c572a98a3a15ee93955d0fa7e60aa5e91a4584ae3b2ca8d">+20/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>