### PR TITLE
fix(Table): fix loading state handling in TableVirtualizedBody

### DIFF
--- a/packages/core/src/components/Table/Table/__tests__/Table.test.tsx
+++ b/packages/core/src/components/Table/Table/__tests__/Table.test.tsx
@@ -9,6 +9,7 @@ import TableHeaderCell, { TableHeaderCellProps } from "../../TableHeaderCell/Tab
 import TableHeader from "../../TableHeader/TableHeader";
 import TableCellSkeleton from "../../TableCellSkeleton/TableCellSkeleton";
 import { mockUseTable, mockUseTableRowMenu } from "./tableTestUtils";
+import TableVirtualizedBody from "../../TableVirtualizedBody/TableVirtualizedBody";
 
 interface TableNode {
   role: string;
@@ -108,6 +109,47 @@ describe("Table", () => {
 
       const tableBodyElement = getByRole("rowgroup");
       expect(tableBodyElement.children.length).toBe(5);
+    });
+  });
+
+  describe("Virtualized table loading state", () => {
+    it("should render header when virtualized table has headerRenderer and is in loading state", () => {
+      const headerText = "Test Header Column";
+      const columns = [{ id: "test", title: headerText, loadingStateType: "long-text" as const }];
+
+      const HeaderRenderer = (columns: any[]) => (
+        <div role="rowgroup" data-testid="table-header">
+          {columns.map(col => (
+            <div key={col.id}>{col.title}</div>
+          ))}
+        </div>
+      );
+
+      const RowRenderer = (item: any) => <div role="row">{item.name}</div>;
+
+      const { getByTestId, getByText } = render(
+        <Table
+          columns={columns}
+          dataState={{ isLoading: true }}
+          errorState={<div>Error</div>}
+          emptyState={<div>Empty</div>}
+        >
+          <TableVirtualizedBody
+            items={[{ id: "1", name: "Test Item" }]}
+            rowRenderer={RowRenderer}
+            headerRenderer={HeaderRenderer}
+            columns={columns}
+          />
+        </Table>
+      );
+
+      // Header should be visible even when loading
+      expect(getByTestId("table-header")).toBeInTheDocument();
+      expect(getByText(headerText)).toBeInTheDocument();
+
+      // Should also render skeleton rows
+      const skeletonElements = document.querySelectorAll('[data-testid="skeleton"]');
+      expect(skeletonElements.length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
+++ b/packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx
@@ -75,9 +75,10 @@ const TableVirtualizedBody = forwardRef(
     }: TableVirtualizedBodyProps<T>,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
-    const { size, virtualizedListRef, onVirtualizedListScroll, markTableAsVirtualized } = useTable();
+    const { size, virtualizedListRef, onVirtualizedListScroll, markTableAsVirtualized, dataState } = useTable();
     const { resetHoveredRow } = useTableRowMenu();
     const virtualizedWithHeader = !!columns && !!headerRenderer;
+    const { isLoading } = dataState || {};
 
     const handleOuterScroll = useCallback(
       (e: Event) => {
@@ -147,6 +148,21 @@ const TableVirtualizedBody = forwardRef(
           : undefined,
       [virtualizedWithHeader, headerRenderer, columns]
     );
+
+    // When in loading state and we have a header renderer, render header separately
+    if (isLoading && virtualizedWithHeader) {
+      return (
+        <div
+          ref={ref}
+          id={id}
+          className={cx(styles.tableBody, styles.withHeader, className)}
+          data-testid={dataTestId || getTestId(ComponentDefaultTestId.TABLE_VIRTUALIZED_BODY, id)}
+        >
+          {headerRenderer!(columns!)}
+          <TableBody />
+        </div>
+      );
+    }
 
     return (
       <TableBody


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9629012734


___

### **PR Type**
Bug fix


___

### **Description**
- Fix loading state handling in virtualized table components

- Ensure header renders correctly during loading state

- Add comprehensive test coverage for virtualized table loading


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["TableVirtualizedBody"] --> B["Extract dataState from useTable"]
  B --> C["Check isLoading state"]
  C --> D["Render header separately when loading"]
  D --> E["Return early with header + TableBody"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Table.test.tsx</strong><dd><code>Add virtualized table loading state tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Table/Table/__tests__/Table.test.tsx

<ul><li>Import <code>TableVirtualizedBody</code> component for testing<br> <li> Add new test suite for virtualized table loading state<br> <li> Test header rendering during loading with <code>headerRenderer</code><br> <li> Verify skeleton elements are rendered during loading</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/2992/files#diff-fecdec6a0d6aadd3a1c468d80a6f4814bbf26dc287a2baab9f3fb00a263d8251">+42/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>TableVirtualizedBody.tsx</strong><dd><code>Fix loading state header rendering logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Table/TableVirtualizedBody/TableVirtualizedBody.tsx

<ul><li>Extract <code>dataState</code> from <code>useTable</code> hook<br> <li> Add early return for loading state with header renderer<br> <li> Render header separately when <code>isLoading</code> and <code>virtualizedWithHeader</code><br> <li> Maintain existing functionality for non-loading states</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/2992/files#diff-4cc2e9ac3543607f8250d4fb1a3cb32cca68149aabd70be69be750ca43f5717f">+17/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

