### PR TITLE
fix(Dropdown): stretch selected value

### DIFF
--- a/packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss
+++ b/packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss
@@ -46,6 +46,7 @@
     pointer-events: none;
     inset: 0;
     padding-inline-start: var(--spacing-xs);
+    width: 100%;
 
     &.small {
       padding-inline-start: var(--spacing-small);


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9652455269


___

### **PR Type**
Bug fix


___

### **Description**
- Fix dropdown selected value to stretch full width


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dropdown Trigger"] --> B["Selected Item"] 
  B --> C["Add width: 100%"]
  C --> D["Full Width Stretch"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Trigger.module.scss</strong><dd><code>Add full width styling to selected item</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss

<ul><li>Added <code>width: 100%</code> to <code>.selectedItem</code> class to ensure full width <br>stretching</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3007/files#diff-4aab4f2ee268e972a0ef3798b39823547ce2a9525ede07672a0f5c66b8a6b156">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

