### PR TITLE
fix: add missing deps

### DIFF
--- a/packages/style/package.json
+++ b/packages/style/package.json
@@ -35,6 +35,12 @@
     "stylelint:fix": "stylelint \"**/*.scss\" --fix",
     "fix-lint": "prettier --write \"{,!(node_modules)/**/}*.{js,jsx,ts,tsx,scss}\""
   },
+  "dependencies": {
+    "postcss": "8.4.31",
+    "postcss-scss": "^4.0.9",
+    "postcss-value-parser": "4.2.0",
+    "stylelint": "^14.16.1"
+  },
   "devDependencies": {
     "@babel/preset-env": "^7.22.9",
     "@babel/preset-typescript": "^7.22.5",
@@ -42,13 +48,9 @@
     "clean-css-cli": "^4.3.0",
     "execa": "^5.1.1",
     "jest": "^27.5.1",
-    "postcss": "8.4.31",
     "postcss-custom-properties": "^14.0.6",
-    "postcss-scss": "^4.0.9",
-    "postcss-value-parser": "4.2.0",
     "prettier": "^2.0.5",
     "sass": "^1.70.0",
-    "stylelint": "^14.16.1",
     "stylelint-config-recommended-scss": "^6.0.0",
     "ts-node": "^10.9.2",
     "typescript-plugin-css-modules": "^5.0.1"


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9651727237


___

### **PR Type**
Other


___

### **Description**
- Move PostCSS and Stylelint dependencies from devDependencies to dependencies

- Ensure proper runtime availability of styling tools


___

### Diagram Walkthrough


```mermaid
flowchart LR
  devDeps["devDependencies"] -- "move" --> deps["dependencies"]
  deps --> postcss["postcss"]
  deps --> stylelint["stylelint"]
  deps --> postcssScss["postcss-scss"]
  deps --> postcssParser["postcss-value-parser"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Restructure package dependencies classification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/style/package.json

<ul><li>Added new <code>dependencies</code> section with 4 packages<br> <li> Moved <code>postcss</code>, <code>postcss-scss</code>, <code>postcss-value-parser</code>, and <code>stylelint</code> from <br><code>devDependencies</code><br> <li> Removed these packages from <code>devDependencies</code> section</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3010/files#diff-632bbe6a638ba6961ea8562bb7e59706168e923044c6f4737f80dc138409bc26">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

