### PR TITLE
Support menu item icon size

### DIFF
--- a/packages/core/src/components/Menu/MenuItem/MenuItem.tsx
+++ b/packages/core/src/components/Menu/MenuItem/MenuItem.tsx
@@ -27,6 +27,10 @@ export interface MenuItemProps extends VibeComponentProps {
    */
   icon?: SubIcon;
   /**
+   * The size of the icon.
+   */
+  iconSize?: number;
+  /**
    * The type of icon.
    */
   iconType?: IconType;
@@ -166,6 +170,7 @@ const MenuItem = forwardRef(
       title = "",
       label = "",
       icon = "",
+      iconSize,
       iconType,
       iconBackgroundColor,
       disabled = false,
@@ -231,6 +236,7 @@ const MenuItem = forwardRef(
               selected={selected}
               backgroundColor={iconBackgroundColor}
               wrapperClassName={iconWrapperClassName}
+              iconSize={iconSize}
             />
           )}
           <div ref={titleRef} className={styles.title}>

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx
@@ -13,7 +13,8 @@ const MenuItemIcon = ({
   disabled,
   selected,
   backgroundColor,
-  wrapperClassName
+  wrapperClassName,
+  iconSize
 }: MenuItemIconProps) => (
   <Flex
     justify="center"
@@ -32,7 +33,7 @@ const MenuItemIcon = ({
       icon={icon}
       className={cx(styles.icon, { [styles.selected]: !disabled && selected })}
       ignoreFocusStyle
-      iconSize={18}
+      iconSize={iconSize || 18}
     />
   </Flex>
 );

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.types.ts
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.types.ts
@@ -32,4 +32,8 @@ export interface MenuItemIconProps {
    * Additional class name for styling the icon wrapper.
    */
   wrapperClassName?: string;
+  /**
+   * The size of the icon.
+   */
+  iconSize?: number;
 }


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

<!-- Please add the issue number that this PR closes: -->

Resolves #


___

### **PR Type**
Enhancement


___

### **Description**
- Add `iconSize` prop to MenuItem component

- Support customizable icon size in MenuItemIcon

- Default icon size remains 18px for backward compatibility


___

### Diagram Walkthrough


```mermaid
flowchart LR
  MenuItem["MenuItem Component"] -- "passes iconSize prop" --> MenuItemIcon["MenuItemIcon Component"]
  MenuItemIcon -- "applies size to" --> Icon["Icon Element"]
  Icon -- "defaults to 18px if not specified" --> Default["18px Default Size"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>MenuItemIcon.types.ts</strong><dd><code>Add iconSize type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.types.ts

<ul><li>Add optional <code>iconSize</code> property to MenuItemIconProps interface<br> <li> Include JSDoc documentation for the new property</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3019/files#diff-105dcf3e293ad87b8c51dd330766711a58b52803c1198353f68f9fac9b1e58ac">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MenuItem.tsx</strong><dd><code>Add iconSize prop to MenuItem</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Menu/MenuItem/MenuItem.tsx

<ul><li>Add optional <code>iconSize</code> prop to MenuItemProps interface<br> <li> Pass <code>iconSize</code> prop to MenuItemIcon component<br> <li> Include JSDoc documentation for new property</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3019/files#diff-1bd12fe45b9dffcab300957bd898d68418819e82481eee2ba4d18927d6f56ca4">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MenuItemIcon.tsx</strong><dd><code>Implement iconSize functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx

<ul><li>Accept <code>iconSize</code> parameter in component props<br> <li> Apply <code>iconSize</code> to Icon component with 18px fallback<br> <li> Maintain backward compatibility with default size</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3019/files#diff-fead8bf76d7cc7985c236b8db0cdfa280cecda68a86cabf5cebcfac8d797ce21">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

