### PR TITLE
fix: change progress bar transition duration

### DIFF
--- a/packages/core/src/components/ProgressBars/LinearProgressBar/Bar/Bar.module.scss
+++ b/packages/core/src/components/ProgressBars/LinearProgressBar/Bar/Bar.module.scss
@@ -46,5 +46,5 @@
 }
 
 .animate {
-  transition: width var(--motion-productive-medium) var(--motion-timing-transition);
+  transition: width 300ms var(--motion-timing-transition);
 }


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9694174715


___

### **PR Type**
Bug fix


___

### **Description**
- Changed progress bar transition duration from CSS variable to fixed 300ms


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["CSS Variable"] -- "replaced with" --> B["Fixed 300ms Duration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Bar.module.scss</strong><dd><code>Replace CSS variable with fixed transition duration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/ProgressBars/LinearProgressBar/Bar/Bar.module.scss

<ul><li>Replaced CSS variable <code>--motion-productive-medium</code> with fixed <code>300ms</code> <br>value<br> <li> Updated transition duration for <code>.animate</code> class</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3022/files#diff-ee251b1ecf57751f6dd32229c3f7074e27f580a695cbd36b4bd0d9ed542fa811">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

