### PR TITLE
fix(DatePicker): add default value for onPickDate prop

### DIFF
--- a/packages/core/src/components/DatePicker/DatePicker.tsx
+++ b/packages/core/src/components/DatePicker/DatePicker.tsx
@@ -96,7 +96,7 @@ const DatePicker = forwardRef(
       hideNavigationKeys = false,
       date,
       endDate,
-      onPickDate,
+      onPickDate = NOOP,
       enableOutsideDays = false,
       showWeekNumber = false,
       shouldBlockRange,

--- a/packages/core/src/components/DatePicker/__tests__/DatePicker.test.tsx
+++ b/packages/core/src/components/DatePicker/__tests__/DatePicker.test.tsx
@@ -116,4 +116,22 @@ describe("DatePicker", () => {
     expect(newDay).toBeInTheDocument();
     expect(newDay.getAttribute("aria-label")).toContain(newYear.innerHTML);
   });
+
+  it("should not crash when onPickDate is not provided and a date is clicked", () => {
+    const { container } = render(<DatePicker />);
+
+    const element = container.querySelector(".CalendarDay");
+    expect(() => {
+      fireEvent.click(element);
+    }).not.toThrow();
+  });
+
+  it("should not crash when onPickDate is not provided in range mode and a date is clicked", () => {
+    const { container } = render(<DatePicker range />);
+
+    const element = container.querySelector(".CalendarDay");
+    expect(() => {
+      fireEvent.click(element);
+    }).not.toThrow();
+  });
 });


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/6381326498


___

### **PR Type**
Bug fix


___

### **Description**
- Add default NOOP value for `onPickDate` prop

- Prevent crashes when callback not provided

- Add tests for both single and range modes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DatePicker Component"] --> B["onPickDate prop"]
  B --> C["Default NOOP value"]
  C --> D["No crash on click"]
  E["Test Coverage"] --> F["Single mode test"]
  E --> G["Range mode test"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatePicker.tsx</strong><dd><code>Add default callback to prevent crashes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DatePicker/DatePicker.tsx

- Add default NOOP value to `onPickDate` prop parameter


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3024/files#diff-5733ea7f9ee570d8548038d727c22130ae4a667b82d641126683a0b56c59797a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DatePicker.test.tsx</strong><dd><code>Add tests for missing callback scenarios</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DatePicker/__tests__/DatePicker.test.tsx

<ul><li>Add test for single mode without <code>onPickDate</code> callback<br> <li> Add test for range mode without <code>onPickDate</code> callback<br> <li> Verify no crashes occur when clicking dates</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3024/files#diff-c87bdf255c736ef57a14082a83d71757fa072f2c7842252457374a055ab301a2">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

