### PR TITLE
feat(Tabs): add support for Home and End key navigation

### DIFF
--- a/packages/core/src/hooks/useFullKeyboardListeners.ts
+++ b/packages/core/src/hooks/useFullKeyboardListeners.ts
@@ -25,6 +25,8 @@ export default function useFullKeyboardListeners({
   onSelectionKey = noop,
   onArrowNavigation = noop,
   onEscape = noop,
+  onHome = noop,
+  onEnd = noop,
   useDocumentEventListeners = false,
   focusOnMount = false
 }: {
@@ -32,6 +34,8 @@ export default function useFullKeyboardListeners({
   onSelectionKey: KeyboardEventCallback;
   onArrowNavigation: (type: NavDirections) => void;
   onEscape: KeyboardEventCallback;
+  onHome?: KeyboardEventCallback;
+  onEnd?: KeyboardEventCallback;
   useDocumentEventListeners?: boolean;
   focusOnMount: boolean;
 }) {
@@ -83,6 +87,18 @@ export default function useFullKeyboardListeners({
   useKeyEvent({
     keys: ESCAPE_KEYS,
     callback: onEscape,
+    ...listenerOptions
+  });
+
+  useKeyEvent({
+    keys: HOME_KEYS,
+    callback: onHome,
+    ...listenerOptions
+  });
+
+  useKeyEvent({
+    keys: END_KEYS,
+    callback: onEnd,
     ...listenerOptions
   });
 

--- a/packages/core/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.ts
+++ b/packages/core/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.ts
@@ -88,6 +88,27 @@ export default function useGridKeyboardNavigation({
     }
   };
 
+  const onHomeNavigation = useCallback(() => {
+    setIsUsingKeyboardNav(true);
+    const firstEnabledIndex = disabledIndexes.includes(0)
+      ? disabledIndexes.length < itemsCount
+        ? Array.from({ length: itemsCount }, (_, i) => i).find(i => !disabledIndexes.includes(i)) ?? 0
+        : 0
+      : 0;
+    setActiveIndex(firstEnabledIndex);
+  }, [disabledIndexes, itemsCount]);
+
+  const onEndNavigation = useCallback(() => {
+    setIsUsingKeyboardNav(true);
+    const lastEnabledIndex = disabledIndexes.includes(itemsCount - 1)
+      ? disabledIndexes.length < itemsCount
+        ? Array.from({ length: itemsCount }, (_, i) => itemsCount - 1 - i).find(i => !disabledIndexes.includes(i)) ??
+          itemsCount - 1
+        : itemsCount - 1
+      : itemsCount - 1;
+    setActiveIndex(lastEnabledIndex);
+  }, [disabledIndexes, itemsCount]);
+
   useEffect(() => {
     if (!skippedInitialActiveIndexChange.current) {
       skippedInitialActiveIndexChange.current = true;
@@ -167,6 +188,8 @@ export default function useGridKeyboardNavigation({
     onSelectionKey: onKeyboardSelection,
     onArrowNavigation,
     onEscape: blurTargetElement,
+    onHome: onHomeNavigation,
+    onEnd: onEndNavigation,
     focusOnMount
   });
 


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9678436288

### **PR Type**
Enhancement


___

### **Description**
- Add Home and End key navigation support to keyboard listeners

- Implement first/last enabled item navigation in grid components

- Extend useFullKeyboardListeners hook with new key handlers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["useFullKeyboardListeners"] -- "adds onHome/onEnd callbacks" --> B["useGridKeyboardNavigation"]
  B -- "implements navigation logic" --> C["First/Last Item Navigation"]
  A -- "listens for HOME_KEYS/END_KEYS" --> D["Key Event Handlers"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useFullKeyboardListeners.ts</strong><dd><code>Add Home/End key event listeners</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/hooks/useFullKeyboardListeners.ts

<ul><li>Add <code>onHome</code> and <code>onEnd</code> optional callback parameters<br> <li> Register key event listeners for HOME_KEYS and END_KEYS<br> <li> Extend hook interface to support new navigation callbacks</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3031/files#diff-ddf7852415a3ab72a239a45b3f19c30f110b43ff10fbb4190bf02e27516461c0">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useGridKeyboardNavigation.ts</strong><dd><code>Implement Home/End navigation logic for grid</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/hooks/useGridKeyboardNavigation/useGridKeyboardNavigation.ts

<ul><li>Implement <code>onHomeNavigation</code> to jump to first enabled item<br> <li> Implement <code>onEndNavigation</code> to jump to last enabled item<br> <li> Handle disabled indexes when finding first/last navigable items<br> <li> Connect new navigation handlers to useFullKeyboardListeners</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3031/files#diff-f1390db2ab80839bf8626357a1d86e1d5a286bca471a443e54397c62f89d8380">+23/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

