### PR TITLE
fix(Label): fix line kind when using content colors

### DIFF
--- a/packages/core/src/components/Label/Label.tsx
+++ b/packages/core/src/components/Label/Label.tsx
@@ -91,9 +91,12 @@ const Label = forwardRef<HTMLElement, LabelProps>(
 
     const backgroundColorStyle = useMemo(() => {
       if (contentColors.includes(color as ContentColor)) {
+        if (kind === "line") {
+          return { color: `var(--color-${color})` };
+        }
         return { backgroundColor: `var(--color-${color})` };
       }
-    }, [color]);
+    }, [color, kind]);
 
     const onClickCallback = useCallback(
       (event: React.MouseEvent<HTMLSpanElement, MouseEvent>) => {


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9783626373


___

### **PR Type**
Bug fix


___

### **Description**
- Fix line kind styling when using content colors

- Apply text color instead of background color for line labels


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Content Color Check"] --> B["Kind Check Added"]
  B --> C["Line Kind: Text Color"]
  B --> D["Other Kinds: Background Color"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Label.tsx</strong><dd><code>Fix line kind content color styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Label/Label.tsx

<ul><li>Add conditional check for <code>kind === "line"</code> within content colors logic<br> <li> Apply text color instead of background color for line kind labels<br> <li> Include <code>kind</code> in dependency array for <code>backgroundColorStyle</code> memo</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3041/files#diff-1b7c25220a9af71b8233ba37cc8000e8185dd3a55aa59dea9087278945730e36">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

