### PR TITLE
Fix/jonathanad/allow japanese ime composition

### DIFF
--- a/packages/core/src/components/EditableTypography/EditableTypography.tsx
+++ b/packages/core/src/components/EditableTypography/EditableTypography.tsx
@@ -113,6 +113,7 @@ const EditableTypography = forwardRef(
 
     const [isEditing, setIsEditing] = useState(isEditMode || false);
     const [inputValue, setInputValue] = useState(value);
+    const [onIMEComposing, setOnIMEComposing] = useState(false);
 
     const prevValue = usePrevious(value);
 
@@ -163,11 +164,23 @@ const EditableTypography = forwardRef(
       onChange?.(inputValue);
     }
 
+    function handleIMECompositionStart() {
+      setOnIMEComposing(true);
+    }
+
+    function handleIMECompositionEnd() {
+      setOnIMEComposing(false);
+    }
+
     function handleBlur() {
       handleInputValueChange();
     }
 
     function handleKeyDown(event: React.KeyboardEvent<HTMLInputElement | HTMLTextAreaElement>) {
+      if (onIMEComposing) {
+        return;
+      }
+
       if (event.key === keyCodes.ENTER) {
         if (multiline && event.shiftKey) {
           return;
@@ -252,6 +265,8 @@ const EditableTypography = forwardRef(
               placeholder={placeholder}
               role="textbox"
               rows={1}
+              onCompositionStart={handleIMECompositionStart}
+              onCompositionEnd={handleIMECompositionEnd}
             />
           ) : (
             <input
@@ -264,6 +279,8 @@ const EditableTypography = forwardRef(
               aria-label={ariaLabel}
               placeholder={placeholder}
               role="input"
+              onCompositionStart={handleIMECompositionStart}
+              onCompositionEnd={handleIMECompositionEnd}
             />
           ))}
         <TypographyComponent

--- a/packages/core/src/components/EditableTypography/__tests__/EditableTypography.test.tsx
+++ b/packages/core/src/components/EditableTypography/__tests__/EditableTypography.test.tsx
@@ -1,0 +1,94 @@
+import { vi, afterEach, describe, it, expect } from "vitest";
+import React from "react";
+import { fireEvent, render, cleanup, screen, within } from "@testing-library/react";
+import EditableTypography from "../EditableTypography";
+import Text from "../../Text/Text";
+
+describe("EditableTypography - IME composition with onKeyDown", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("should ignore Enter keydown while composing (single-line) and commit after composition ends", () => {
+    const onChange = vi.fn();
+    render(
+      <EditableTypography value="Editable text" onChange={onChange} component={Text} typographyClassName="typography" />
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    const input = screen.getByRole("input");
+    fireEvent.change(input, { target: { value: "新しい" } });
+    fireEvent.compositionStart(input);
+
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(screen.getByRole("input")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: "Enter" });
+
+    expect(within(screen.getByRole("button")).getByText("新しい")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("新しい");
+  });
+
+  it("should ignore Escape keydown while composing (single-line) and cancel after composition ends", () => {
+    const onChange = vi.fn();
+    render(
+      <EditableTypography value="Editable text" onChange={onChange} component={Text} typographyClassName="typography" />
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    const input = screen.getByRole("input");
+    fireEvent.change(input, { target: { value: "中" } });
+    fireEvent.compositionStart(input);
+
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(screen.getByRole("input")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(input);
+    fireEvent.keyDown(input, { key: "Escape" });
+
+    expect(within(screen.getByRole("button")).getByText("Editable text")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+  });
+
+  it("should ignore Enter keydown while composing (multiline) and commit after composition ends", () => {
+    const onChange = vi.fn();
+    render(
+      <EditableTypography
+        value="Editable text"
+        onChange={onChange}
+        component={Text}
+        typographyClassName="typography"
+        multiline
+      />
+    );
+
+    const button = screen.getByRole("button");
+    fireEvent.click(button);
+
+    const textarea = screen.getByRole("textbox");
+    fireEvent.change(textarea, { target: { value: "新しい" } });
+    fireEvent.compositionStart(textarea);
+
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(screen.getByRole("textbox")).toBeInTheDocument();
+    expect(onChange).not.toHaveBeenCalled();
+
+    fireEvent.compositionEnd(textarea);
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(within(screen.getByRole("button")).getByText("新しい")).toBeInTheDocument();
+    expect(onChange).toHaveBeenCalledTimes(1);
+    expect(onChange).toHaveBeenCalledWith("新しい");
+  });
+});


### PR DESCRIPTION
This PR fixes `EditableText` and `EditableHeading` for Japanese users, by adding event listeners to the `onCompositionStart` and `onCompositionEnd` events, and disables submitting the text on "enter" press, while being in composition mode.



https://github.com/user-attachments/assets/a572b62b-86eb-4b62-8601-c155cd09b471

