### PR TITLE
docs: update useVibeMediaQuery docs to fix wrong mediaQuery value

### DIFF
--- a/packages/core/src/hooks/useVibeMediaQuery/__stories__/useVibeMediaQuery.stories.helpers.tsx
+++ b/packages/core/src/hooks/useVibeMediaQuery/__stories__/useVibeMediaQuery.stories.helpers.tsx
@@ -17,7 +17,7 @@ export const TableMediaQuery = () => {
       id: "3",
       items: ["3", "screen and (max-width: 1279px) and (min-width: 1024px)"]
     },
-    { id: "4", items: ["4", "screen and (max-width: 1439px) and (min-width: 1278px)"] },
+    { id: "4", items: ["4", "screen and (max-width: 1439px) and (min-width: 1280px)"] },
     { id: "5", items: ["5", "screen and (max-width: 1919px) and (min-width: 1440px)"] },
     { id: "6", items: ["6", "screen and (min-width: 1920px)"] }
   ];


### PR DESCRIPTION
### **User description**
Update documentation of useVibeMediaQuery docs: fix invalid mediaquery  for "4" value:

<img width="869" height="447" alt="Screenshot 2025-08-14 at 10 32 25" src="https://github.com/user-attachments/assets/e49b8a16-8e94-454b-bfc0-829b71ff3593" />

Vs actual definition in code:

https://github.com/mondaycom/vibe/blob/9d075a71ef3376180bc16098f646a1c605ac8ba5/packages/core/src/utils/media-query-utils.ts#L12

Resolves #


___

### **PR Type**
Documentation


___

### **Description**
- Fix incorrect media query breakpoint value in documentation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Documentation"] -- "fix breakpoint" --> B["Media Query Value"]
  B -- "1278px → 1280px" --> C["Corrected Documentation"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useVibeMediaQuery.stories.helpers.tsx</strong><dd><code>Fix media query breakpoint value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/hooks/useVibeMediaQuery/__stories__/useVibeMediaQuery.stories.helpers.tsx

<ul><li>Corrected media query breakpoint from <code>1278px</code> to <code>1280px</code> for breakpoint <br>"4"</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3057/files#diff-ca50cd66f1ff21e6e6b026f51b3b6d20667ae4ac654a8a49ed2f8a7668e362b3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

