### PR TITLE
feat(Link): add `style` prop for inline styling

### DIFF
--- a/packages/core/src/components/Link/Link.tsx
+++ b/packages/core/src/components/Link/Link.tsx
@@ -69,6 +69,10 @@ export interface LinkProps extends VibeComponentProps {
   inlineText?: boolean;
   /** The link's color style */
   color?: LinkColor;
+  /**
+   * Inline style object applied to the link element.
+   */
+  style?: React.CSSProperties;
 }
 
 const Link = forwardRef(
@@ -91,6 +95,7 @@ const Link = forwardRef(
       disableNavigation = false,
       inheritFontSize = false,
       inlineText = false,
+      style,
       "data-testid": dataTestId
     }: LinkProps,
     ref: React.ForwardedRef<HTMLAnchorElement>
@@ -116,6 +121,7 @@ const Link = forwardRef(
         ref={ref}
         onClick={onClickWrapper}
         target={target}
+        style={style}
         className={cx(styles.link, className, getStyle(styles, camelCase("color-" + color)), {
           [styles.inheritFontSize]: inheritFontSize,
           [styles.inlineText]: inlineText


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9854959969


___

### **PR Type**
Enhancement


___

### **Description**
- Add `style` prop to Link component for inline styling

- Enable custom CSS properties on link elements


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Link Component"] --> B["Add style prop"]
  B --> C["Apply inline styles"]
  C --> D["Enhanced customization"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Link.tsx</strong><dd><code>Add style prop for inline styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Link/Link.tsx

<ul><li>Add <code>style</code> prop of type <code>React.CSSProperties</code> to LinkProps interface<br> <li> Extract <code>style</code> prop in component destructuring<br> <li> Apply <code>style</code> prop to anchor element for inline styling</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3063/files#diff-da900ddc28909b29904c867d0dfbceeedcd4673e846ac573e33739c5faa40ed6">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

