### PR TITLE
fix(DropdownBase): update active state to include isOpen condition

### DIFF
--- a/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.tsx
+++ b/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.tsx
@@ -27,6 +27,7 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
     readOnly,
     error,
     isFocused,
+    isOpen,
     helperText,
     dir,
     tooltipProps
@@ -39,7 +40,7 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
         [styles.disabled]: disabled,
         [styles.readOnly]: readOnly,
         [styles.error]: error,
-        [styles.active]: isFocused
+        [styles.active]: isFocused || isOpen
       })}
       id={id}
       aria-label={ariaLabel}


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9890899920


___

### **PR Type**
Bug fix


___

### **Description**
- Update dropdown active state to include `isOpen` condition

- Fix visual state for non-searchable dropdowns when opened


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["DropdownBase Component"] --> B["Extract isOpen from context"]
  B --> C["Update active state logic"]
  C --> D["Apply active styles when focused OR open"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DropdownBase.tsx</strong><dd><code>Update active state logic for dropdown styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.tsx

<ul><li>Extract <code>isOpen</code> property from dropdown context<br> <li> Update active state condition from <code>isFocused</code> to <code>isFocused || isOpen</code><br> <li> Apply active styling when dropdown is either focused or open</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3070/files#diff-8c2bd1cf7a49040d99bcdfaa5aaa6d291f581458503893e597a8116f8cb97cf8">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

