### PR TITLE
fix(Dropdown):  fix size and focus

### DIFF
--- a/packages/core/src/components/DropdownNew/Dropdown.types.ts
+++ b/packages/core/src/components/DropdownNew/Dropdown.types.ts
@@ -181,7 +181,7 @@ export type BaseDropdownProps<Item extends BaseListItemData<Record<string, unkno
   /**
    * Callback fired when the dropdown loses focus.
    */
-  onBlur?: () => void;
+  onBlur?: (event: React.FocusEvent<HTMLDivElement>) => void;
   /**
    * Callback fired when the clear button is clicked.
    */

--- a/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.module.scss
+++ b/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.module.scss
@@ -14,7 +14,8 @@
     --border-color: var(--primary-text-color);
   }
 
-  &.active {
+  &.active,
+  &:focus {
     --border-color: var(--primary-color);
   }
 

--- a/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.tsx
+++ b/packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.tsx
@@ -27,6 +27,7 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
     readOnly,
     error,
     isFocused,
+    isOpen,
     helperText,
     dir,
     tooltipProps
@@ -39,7 +40,7 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
         [styles.disabled]: disabled,
         [styles.readOnly]: readOnly,
         [styles.error]: error,
-        [styles.active]: isFocused
+        [styles.active]: isFocused || isOpen
       })}
       id={id}
       aria-label={ariaLabel}

--- a/packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss
+++ b/packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss
@@ -5,17 +5,18 @@
   display: flex;
   align-items: center;
   cursor: pointer;
+  outline: none;
 
   &.small {
-    min-height: 32px;
+    min-height: 30px;
   }
 
   &.medium {
-    min-height: 40px;
+    min-height: 38px;
   }
 
   &.large {
-    min-height: 48px;
+    min-height: 46px;
   }
 
   .inputWrapper {

--- a/packages/core/src/components/DropdownNew/modes/DropdownComboboxController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownComboboxController.tsx
@@ -99,7 +99,7 @@ const DropdownComboboxController = <Item extends BaseListItemData<Record<string,
         },
         onBlur: (event: React.FocusEvent<HTMLInputElement>) => {
           setIsFocused(false);
-          onBlur?.();
+          onBlur?.(event);
           inputOptions?.onBlur?.(event);
         },
         onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/core/src/components/DropdownNew/modes/DropdownMultiComboboxController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownMultiComboboxController.tsx
@@ -95,7 +95,7 @@ const DropdownMultiComboboxController = <Item extends BaseListItemData<Record<st
         },
         onBlur: (event: React.FocusEvent<HTMLInputElement>) => {
           setIsFocused(false);
-          onBlur?.();
+          onBlur?.(event);
           inputOptions?.onBlur?.(event);
         },
         onKeyDown: (event: React.KeyboardEvent<HTMLInputElement>) => {

--- a/packages/core/src/components/DropdownNew/modes/DropdownMultiSelectController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownMultiSelectController.tsx
@@ -80,9 +80,9 @@ const DropdownMultiSelectController = <Item extends BaseListItemData<Record<stri
           setIsFocused(true);
           onFocus?.(event);
         },
-        onBlur: () => {
+        onBlur: (event: React.FocusEvent<HTMLDivElement>) => {
           setIsFocused(false);
-          onBlur?.();
+          onBlur?.(event);
         }
       });
     },

--- a/packages/core/src/components/DropdownNew/modes/DropdownMultiSelectController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownMultiSelectController.tsx
@@ -24,11 +24,14 @@ const DropdownMultiSelectController = <Item extends BaseListItemData<Record<stri
     dropdownRef,
     onClear,
     onOptionRemove,
+    onFocus,
+    onBlur,
     size = "medium"
   } = props;
 
   const initialMultiSelectedItems = Array.isArray(defaultValue) ? defaultValue : [];
   const [multiSelectedItemsState, setMultiSelectedItemsState] = useState<Item[]>(initialMultiSelectedItems);
+  const [isFocused, setIsFocused] = useState(false);
 
   const {
     isOpen,
@@ -69,10 +72,18 @@ const DropdownMultiSelectController = <Item extends BaseListItemData<Record<stri
     selectedItems: hookSelectedItems || [],
     filteredOptions,
     clearable,
-    getToggleButtonProps: (toggleOptions?: any) => {
+    getToggleButtonProps: (toggleOptions?: Record<string, any>) => {
       return getToggleButtonProps({
         ...(toggleOptions || {}),
-        disabled: props.readOnly || props.disabled
+        disabled: props.readOnly || props.disabled,
+        onFocus: (event: React.FocusEvent<HTMLDivElement>) => {
+          setIsFocused(true);
+          onFocus?.(event);
+        },
+        onBlur: () => {
+          setIsFocused(false);
+          onBlur?.();
+        }
       });
     },
     getLabelProps,
@@ -96,7 +107,8 @@ const DropdownMultiSelectController = <Item extends BaseListItemData<Record<stri
     addSelectedItem: hookAddSelectedItem,
     removeSelectedItem: hookRemoveSelectedItem,
     size,
-    toggleMenu
+    toggleMenu,
+    isFocused
   };
 
   return <DropdownWrapperUI contextValue={contextValue} dropdownRef={dropdownRef} />;

--- a/packages/core/src/components/DropdownNew/modes/DropdownSelectController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownSelectController.tsx
@@ -71,9 +71,9 @@ const DropdownSelectController = <Item extends BaseListItemData<Record<string, u
           setIsFocused(true);
           onFocus?.(event);
         },
-        onBlur: () => {
+        onBlur: (event: React.FocusEvent<HTMLDivElement>) => {
           setIsFocused(false);
-          onBlur?.();
+          onBlur?.(event);
         }
       });
     },

--- a/packages/core/src/components/DropdownNew/modes/DropdownSelectController.tsx
+++ b/packages/core/src/components/DropdownNew/modes/DropdownSelectController.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import React, { useState } from "react";
 import { type DropdownSingleControllerProps } from "../Dropdown.types";
 import useDropdownSelect from "../hooks/useDropdownSelect";
 import { type BaseListItemData } from "../../BaseListItem";
@@ -25,8 +25,12 @@ const DropdownSelectController = <Item extends BaseListItemData<Record<string, u
     multi = false,
     dropdownRef,
     onClear,
+    onFocus,
+    onBlur,
     size = "medium"
   } = props;
+
+  const [isFocused, setIsFocused] = useState(false);
 
   const {
     isOpen,
@@ -59,10 +63,18 @@ const DropdownSelectController = <Item extends BaseListItemData<Record<string, u
     highlightedIndex,
     selectedItem: hookSelectedItem,
     filteredOptions,
-    getToggleButtonProps: (toggleOptions?: any) => {
+    getToggleButtonProps: (toggleOptions?: Record<string, any>) => {
       return getToggleButtonProps({
         ...(toggleOptions || {}),
-        disabled: props.readOnly || props.disabled
+        disabled: props.readOnly || props.disabled,
+        onFocus: (event: React.FocusEvent<HTMLDivElement>) => {
+          setIsFocused(true);
+          onFocus?.(event);
+        },
+        onBlur: () => {
+          setIsFocused(false);
+          onBlur?.();
+        }
       });
     },
     getLabelProps,
@@ -84,7 +96,8 @@ const DropdownSelectController = <Item extends BaseListItemData<Record<string, u
     autoFocus,
     onClear,
     size,
-    toggleMenu
+    toggleMenu,
+    isFocused
   };
 
   return <DropdownWrapperUI contextValue={contextValue} dropdownRef={dropdownRef} />;


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9898647435


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Fix dropdown height sizing for all size variants

- Update onBlur callback to pass focus event parameter

- Add focus state styling and outline management

- Implement focus tracking in select controllers


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dropdown Types"] --> B["onBlur Event Fix"]
  C["SCSS Styling"] --> D["Height Adjustments"]
  C --> E["Focus State Styling"]
  F["Controllers"] --> G["Focus Tracking"]
  F --> H["Event Handling"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dropdown.types.ts</strong><dd><code>Update onBlur callback type signature</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/Dropdown.types.ts

- Update `onBlur` callback type to include React.FocusEvent parameter


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-4df10ef7cece5571ebb762ea73b2829db5064798df60f36263c27973bdc2be61">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Trigger.module.scss</strong><dd><code>Fix trigger sizing and outline</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/components/Trigger/Trigger.module.scss

<ul><li>Reduce min-height for all size variants by 2px<br> <li> Add outline: none to remove default focus outline</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-4aab4f2ee268e972a0ef3798b39823547ce2a9525ede07672a0f5c66b8a6b156">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownComboboxController.tsx</strong><dd><code>Fix onBlur event parameter passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/modes/DropdownComboboxController.tsx

<ul><li>Pass event parameter to <code>onBlur</code> callback instead of calling without <br>arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-100ffa729d17f8996cebb426e1a381b23a557154cbdcc77faafd603ac28dd48f">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownMultiComboboxController.tsx</strong><dd><code>Fix onBlur event parameter passing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/modes/DropdownMultiComboboxController.tsx

<ul><li>Pass event parameter to <code>onBlur</code> callback instead of calling without <br>arguments</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-a98d9b0d65ac81fbdc5304025e3e5b2f995f31bfac62f72a777d375f50e8676e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>DropdownBase.module.scss</strong><dd><code>Add focus state styling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/components/DropdownBase/DropdownBase.module.scss

- Add focus state styling to match active state border color


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-d74b8d68a2d96d7d09325fbb98a401d6c830ddb9af1456d13e5b9e5c2a0750e3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownMultiSelectController.tsx</strong><dd><code>Add focus tracking to multi-select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/modes/DropdownMultiSelectController.tsx

<ul><li>Add focus state tracking with <code>isFocused</code> state<br> <li> Implement onFocus and onBlur handlers in getToggleButtonProps<br> <li> Add focus-related props to context value</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-2e1412e9259bd10cfbe77a32ae4ba2804d80888fb9ddaa0050f1420502ad1bdb">+15/-3</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownSelectController.tsx</strong><dd><code>Add focus tracking to select</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/modes/DropdownSelectController.tsx

<ul><li>Add focus state tracking with <code>isFocused</code> state<br> <li> Implement onFocus and onBlur handlers in getToggleButtonProps<br> <li> Add focus-related props to context value</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3071/files#diff-63e3108f97d1d3dcd66cf9b084cd5322a94b73bda2e18a44e2077f12bcd70ec3">+17/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

