### PR TITLE
fix(Chips): warning color missing hover state

### DIFF
--- a/packages/core/src/types/Colors.ts
+++ b/packages/core/src/types/Colors.ts
@@ -10,7 +10,8 @@ const MapStateSelectedColor = {
 const MapStateSelectedHoverColor = {
   positive: "--positive-color-selected-hover",
   negative: "--negative-color-selected-hover",
-  primary: "--primary-selected-hover-color"
+  primary: "--primary-selected-hover-color",
+  warning: "--warning-color-selected-hover"
 };
 
 type ContentColor = (typeof contentColors)[number];


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9857616053


___

### **PR Type**
Bug fix


___

### **Description**
- Add missing warning color hover state mapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["MapStateSelectedHoverColor"] --> B["Add warning hover state"]
  B --> C["Complete color state mapping"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Colors.ts</strong><dd><code>Add warning color hover state mapping</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/types/Colors.ts

<ul><li>Add missing <code>warning: "--warning-color-selected-hover"</code> entry to <br><code>MapStateSelectedHoverColor</code> object</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3080/files#diff-096f26d638382870eb3c4de129f9882b06fb2b17fea1952984d5dc21b9c76a95">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

