### PR TITLE
ci: do not fail pre-release if not running with a PR open

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   build:
     name: Build
-    if: "contains(github.event.head_commit.message, '[prerelease]')"
+    if: contains(github.event.head_commit.message, '[prerelease]')
     uses: ./.github/workflows/build-and-upload.yml
     secrets:
       npm_token: ${{ secrets.npm_token }}
@@ -56,6 +56,7 @@ jobs:
         uses: 8BitJonny/gh-get-current-pr@3.0.0
         id: PR
       - name: Prepare PR comment
+        if: steps.PR.outputs.pr_found == 'true'
         id: prepare-comment
         env:
           json_data: ${{ steps.generate-versions.outputs.new_versions }}
@@ -69,6 +70,7 @@ jobs:
 
           echo 'EOF' >> $GITHUB_OUTPUT
       - name: Create comment with prerelease version details
+        if: steps.PR.outputs.pr_found == 'true'
         uses: peter-evans/create-or-update-comment@v4
         with:
           issue-number: ${{ steps.PR.outputs.number }}


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/9960526846


___

### **PR Type**
Enhancement


___

### **Description**
- Add conditional checks to prevent PR comment failures

- Only prepare and create PR comments when PR exists

- Remove unnecessary quotes from workflow condition


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Push to branch"] --> B["Check for [prerelease] tag"]
  B --> C["Build and publish"]
  C --> D["Get PR info"]
  D --> E{"PR found?"}
  E -->|Yes| F["Prepare comment"]
  E -->|No| G["Skip comment steps"]
  F --> H["Create PR comment"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>prerelease.yml</strong><dd><code>Add PR existence checks to workflow steps</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/prerelease.yml

<ul><li>Add conditional checks using <code>steps.PR.outputs.pr_found == 'true'</code><br> <li> Apply condition to "Prepare PR comment" and "Create comment" steps<br> <li> Remove unnecessary quotes from build job condition</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3082/files#diff-884bb2e52646d4b226c75e5dd7c196f9d654accb529fef4b6eeb401daa83144e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

