### PR TITLE
fix(Chips): allow ariaLabel to be explicitly set to null for dropdown multi - DONT MERGE

### DIFF
--- a/packages/core/src/components/Chips/Chips.tsx
+++ b/packages/core/src/components/Chips/Chips.tsx
@@ -104,8 +104,9 @@ export interface ChipsProps extends VibeComponentProps {
   onClick?: (event: React.MouseEvent<HTMLDivElement, MouseEvent>) => void;
   /**
    * The label of the chip for accessibility.
+   * Pass null to explicitly prevent aria-label from being rendered.
    */
-  ariaLabel?: string;
+  ariaLabel?: string | null;
   /**
    * If true, disables all click behaviors.
    */
@@ -161,7 +162,7 @@ const Chips = forwardRef(
     const componentDataTestId = dataTestId || getTestId(ComponentDefaultTestId.CHIP, id);
     const hasClickableWrapper = (!!onClick || !!onMouseDown) && !disableClickableBehavior;
     const hasCloseButton = !readOnly && !disabled;
-    const overrideAriaLabel = ariaLabel || (typeof label === "string" && label) || "";
+    const overrideAriaLabel = ariaLabel === null ? undefined : ariaLabel || (typeof label === "string" && label) || "";
 
     const iconButtonRef = useRef(null);
     const componentRef = useRef(null);
@@ -242,7 +243,7 @@ const Chips = forwardRef(
         }
       : {
           className: overrideClassName,
-          "aria-label": overrideAriaLabel,
+          ...(overrideAriaLabel !== undefined && { "aria-label": overrideAriaLabel }),
           style: backgroundColorStyle,
           ref: mergedRef,
           onClick: onClickCallback,

--- a/packages/core/src/components/DropdownNew/components/Trigger/DropdownChip.tsx
+++ b/packages/core/src/components/DropdownNew/components/Trigger/DropdownChip.tsx
@@ -55,6 +55,7 @@ const DropdownChip = <Item extends BaseListItemData<Record<string, unknown>>>({
   return (
     <Chips
       label={item.label}
+      ariaLabel={null}
       closeButtonAriaLabel={`Remove ${item.label}`}
       onDelete={onDelete}
       disabled={disabled}


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/9965537836


___

### **PR Type**
Bug fix


___

### **Description**
- Allow `ariaLabel` to be explicitly set to `null` in Chips component

- Prevent redundant aria-label rendering in dropdown multi-select chips

- Fix screen reader accessibility for dropdown chip components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Chips component"] --> B["ariaLabel prop type change"]
  B --> C["Conditional aria-label rendering"]
  C --> D["DropdownChip implementation"]
  D --> E["Screen reader accessibility fix"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Chips.tsx</strong><dd><code>Enhanced ariaLabel prop handling for accessibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Chips/Chips.tsx

<ul><li>Updated <code>ariaLabel</code> prop type to accept <code>string | null</code><br> <li> Modified logic to handle explicit <code>null</code> values<br> <li> Added conditional rendering of aria-label attribute<br> <li> Updated JSDoc comment for clarity</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3083/files#diff-e5eb673c48ef5bd2244e67e68720a3a4e862d34fb0527aacbada7bc736fc39d9">+4/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownChip.tsx</strong><dd><code>Disabled default aria-label for dropdown chips</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/components/Trigger/DropdownChip.tsx

<ul><li>Set <code>ariaLabel={null}</code> to prevent redundant aria-label rendering<br> <li> Relies on <code>closeButtonAriaLabel</code> for screen reader accessibility</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3083/files#diff-6c4ff8afe23691bb1505c95957fad18fc1e88edb8cba01006d666454cb6365bd">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

