### PR TITLE
fix(DropdownNew): onInputChange return null instead of empty string

### DIFF
--- a/packages/core/src/components/DropdownNew/hooks/useDropdownCombobox.ts
+++ b/packages/core/src/components/DropdownNew/hooks/useDropdownCombobox.ts
@@ -13,7 +13,7 @@ function useDropdownCombobox<T extends BaseListItemData<Record<string, unknown>>
   value?: T,
   inputValueProp?: string,
   onChange?: (option: T | T[] | null) => void,
-  onInputChange?: (value: string) => void,
+  onInputChange?: (value: string | null) => void,
   onMenuOpen?: () => void,
   onMenuClose?: () => void,
   onOptionSelect?: (option: T) => void,
@@ -65,7 +65,7 @@ function useDropdownCombobox<T extends BaseListItemData<Record<string, unknown>>
     onInputValueChange: useCallback(
       ({ inputValue }) => {
         filterOptions(inputValue || "");
-        onInputChange?.(inputValue || "");
+        onInputChange?.(inputValue);
       },
       [onInputChange, filterOptions]
     ),
@@ -89,9 +89,9 @@ function useDropdownCombobox<T extends BaseListItemData<Record<string, unknown>>
       switch (actionAndChanges.type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-          return { ...actionAndChanges.changes, inputValue: "", isOpen: !closeMenuOnSelect };
+          return { ...actionAndChanges.changes, inputValue: null, isOpen: !closeMenuOnSelect };
         case useCombobox.stateChangeTypes.InputBlur:
-          return { ...actionAndChanges.changes, inputValue: "" };
+          return { ...actionAndChanges.changes, inputValue: null };
 
         default:
           return actionAndChanges.changes;

--- a/packages/core/src/components/DropdownNew/hooks/useDropdownMultiCombobox.ts
+++ b/packages/core/src/components/DropdownNew/hooks/useDropdownMultiCombobox.ts
@@ -14,7 +14,7 @@ function useDropdownMultiCombobox<T extends BaseListItemData<Record<string, unkn
   value?: T[],
   inputValueProp?: string,
   onChange?: (options: T[]) => void,
-  onInputChange?: (value: string) => void,
+  onInputChange?: (value: string | null) => void,
   onMenuOpen?: () => void,
   onMenuClose?: () => void,
   onOptionSelect?: (option: T) => void,
@@ -67,7 +67,7 @@ function useDropdownMultiCombobox<T extends BaseListItemData<Record<string, unkn
     },
     onInputValueChange: ({ inputValue }) => {
       filterOptions(inputValue || "");
-      onInputChange?.(inputValue || "");
+      onInputChange?.(inputValue);
     },
     onSelectedItemChange: ({ selectedItem: newSelectedItem }) => {
       if (!newSelectedItem) return;
@@ -84,9 +84,9 @@ function useDropdownMultiCombobox<T extends BaseListItemData<Record<string, unkn
       switch (actionAndChanges.type) {
         case useCombobox.stateChangeTypes.InputKeyDownEnter:
         case useCombobox.stateChangeTypes.ItemClick:
-          return { ...actionAndChanges.changes, inputValue: "", isOpen: true };
+          return { ...actionAndChanges.changes, inputValue: null, isOpen: true };
         case useCombobox.stateChangeTypes.InputBlur:
-          return { ...actionAndChanges.changes, inputValue: "" };
+          return { ...actionAndChanges.changes, inputValue: null };
         default:
           return actionAndChanges.changes;
       }


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/10069205016?userId=59970142


___

### **PR Type**
Bug fix


___

### **Description**
- Change `onInputChange` callback to return `null` instead of empty string

- Update type signature to accept `string | null` parameter

- Modify state reducer to use `null` for cleared input values


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["onInputChange callback"] --> B["Type signature updated"]
  B --> C["Return null instead of empty string"]
  C --> D["State reducer updated"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDropdownCombobox.ts</strong><dd><code>Update combobox to use null for cleared input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/hooks/useDropdownCombobox.ts

<ul><li>Updated <code>onInputChange</code> type signature to accept <code>string | null</code><br> <li> Modified callback to pass <code>inputValue</code> directly instead of fallback to <br>empty string<br> <li> Changed state reducer to return <code>null</code> for <code>inputValue</code> in specific cases</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3109/files#diff-70fa2f24574dcc90237e56003c0d0ad932a7ed9e34f6594d266b8fe0f7eeef3f">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>useDropdownMultiCombobox.ts</strong><dd><code>Update multi-combobox to use null for cleared input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/DropdownNew/hooks/useDropdownMultiCombobox.ts

<ul><li>Updated <code>onInputChange</code> type signature to accept <code>string | null</code><br> <li> Modified callback to pass <code>inputValue</code> directly instead of fallback to <br>empty string<br> <li> Changed state reducer to return <code>null</code> for <code>inputValue</code> in specific cases</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3109/files#diff-514ed8d29a328a87c0a61895c1cadf8d1d03c797e78f3ea10dc652f641768f7d">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

