### PR TITLE
feat(RadioButton): add ariaLabel & ariaDescribedBy

### DIFF
--- a/packages/core/src/components/Chips/Chips.tsx
+++ b/packages/core/src/components/Chips/Chips.tsx
@@ -107,6 +107,10 @@ export interface ChipsProps extends VibeComponentProps {
    */
   ariaLabel?: string;
   /**
+   * If true, indicates that the chip has a popup.
+   */
+  ariaHasPopup?: boolean;
+  /**
    * If true, disables all click behaviors.
    */
   disableClickableBehavior?: boolean;
@@ -146,6 +150,7 @@ const Chips = forwardRef(
       onClick,
       noAnimation = true,
       ariaLabel,
+      ariaHasPopup = false,
       "data-testid": dataTestId,
       disableClickableBehavior = false,
       leftAvatarType = "img",
@@ -226,7 +231,7 @@ const Chips = forwardRef(
         "data-testid": componentDataTestId,
         ariaLabel: overrideAriaLabel,
         ariaHidden: false,
-        ariaHasPopup: false,
+        ariaHasPopup,
         ariaExpanded: false
       },
       mergedRef

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -77,7 +77,7 @@ export interface RadioButtonProps extends VibeComponentProps {
   /**
    * ID of element that describe this radio button.
    */
-  "aria-describedby"?: string;
+  ariaDescribedby?: string;
 }
 
 const RadioButton = forwardRef(
@@ -106,7 +106,7 @@ const RadioButton = forwardRef(
       childrenTabIndex = "0",
       noLabelAnimation = false,
       ariaLabel,
-      "aria-describedby": ariaDescribedBy,
+      ariaDescribedby,
       id,
       "data-testid": dataTestId
     }: RadioButtonProps,
@@ -154,7 +154,7 @@ const RadioButton = forwardRef(
               disabled={disabled}
               {...checkedProps}
               aria-label={ariaLabel}
-              aria-describedby={ariaDescribedBy}
+              aria-describedby={ariaDescribedby}
               onChange={onSelect}
               ref={mergedRef}
             />

--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -70,6 +70,14 @@ export interface RadioButtonProps extends VibeComponentProps {
    * If true, disables the label animation.
    */
   noLabelAnimation?: boolean;
+  /**
+   * ARIA label for accessibility when no text is provided.
+   */
+  ariaLabel?: string;
+  /**
+   * ID of element that describe this radio button.
+   */
+  "aria-describedby"?: string;
 }
 
 const RadioButton = forwardRef(
@@ -97,6 +105,8 @@ const RadioButton = forwardRef(
       retainChildClick = true,
       childrenTabIndex = "0",
       noLabelAnimation = false,
+      ariaLabel,
+      "aria-describedby": ariaDescribedBy,
       id,
       "data-testid": dataTestId
     }: RadioButtonProps,
@@ -143,6 +153,8 @@ const RadioButton = forwardRef(
               autoFocus={autoFocus}
               disabled={disabled}
               {...checkedProps}
+              aria-label={ariaLabel}
+              aria-describedby={ariaDescribedBy}
               onChange={onSelect}
               ref={mergedRef}
             />


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/10070825910


___

### **PR Type**
Enhancement


___

### **Description**
- Add accessibility props to RadioButton component

- Support ariaLabel and ariaDescribedby attributes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["RadioButton Props"] --> B["Add ariaLabel prop"]
  A --> C["Add ariaDescribedby prop"]
  B --> D["Apply to input element"]
  C --> D
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>RadioButton.tsx</strong><dd><code>Add accessibility ARIA props support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/RadioButton/RadioButton.tsx

<ul><li>Add <code>ariaLabel</code> and <code>ariaDescribedby</code> optional props to interface<br> <li> Extract new props from component parameters<br> <li> Apply props as <code>aria-label</code> and <code>aria-describedby</code> attributes to input <br>element</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3112/files#diff-76aef102f87844a5d5e8bbb1436e485cb4d56b8b184fd3df6ef4e2998ff2c656">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

