### PR TITLE
perf(Dialog): Return default when `containerSelector` is undefined

### DIFF
--- a/packages/core/src/components/Dialog/Dialog.tsx
+++ b/packages/core/src/components/Dialog/Dialog.tsx
@@ -328,7 +328,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
 
   getContainer() {
     const { containerSelector } = this.props;
-    if(!containerSelector) {
+    if (!containerSelector) {
       return this.getDefaultContainer();
     }
 


### PR DESCRIPTION
### **User description**
Dialog is running over the dom (`document.querySelector`) even when the input is not valid (`undefined`) this may happen a lot and without a reason

return the default layer (content layer or body)


Additional Steps - 
* Add a `WeakMap` with `WeakRef` for caching of containers
* Adding smarter validation for `querySelector`


___

### **PR Type**
Enhancement


___

### **Description**
- Optimize Dialog container resolution performance

- Add early return for undefined containerSelector

- Extract default container logic into separate method

- Reduce unnecessary DOM queries


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["containerSelector check"] --> B["undefined?"]
  B -->|Yes| C["getDefaultContainer()"]
  B -->|No| D["document.querySelector()"]
  D --> E["valid element?"]
  E -->|No| C
  E -->|Yes| F["return containerElement"]
  C --> G["return layerRef or document.body"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Optimize container resolution with early validation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Dialog/Dialog.tsx

<ul><li>Add early validation for <code>containerSelector</code> before DOM query<br> <li> Extract default container logic into <code>getDefaultContainer</code> method<br> <li> Bind new method in constructor<br> <li> Reduce redundant DOM operations when container is undefined</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3113/files#diff-be19ccc83be5090b818f3376492bfcab1976fda7b004e715c295a7914265fc6e">+14/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

