### PR TITLE
fix: Revert Dropdown use Select component as named export

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "react-is": "^16.9.0",
     "react-popper": "^2.3.0",
     "react-remove-scroll": "^2.6.0",
-    "react-select": "npm:react-select-module@^3.2.6",
+    "react-select": "npm:react-select-module@3.2.6",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.7",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "react-is": "^16.9.0",
     "react-popper": "^2.3.0",
     "react-remove-scroll": "^2.6.0",
-    "react-select": "npm:react-select-module@^3.3.0",
+    "react-select": "npm:react-select-module@^3.2.6",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.7",

--- a/packages/core/src/components/Dropdown/Dropdown.tsx
+++ b/packages/core/src/components/Dropdown/Dropdown.tsx
@@ -2,8 +2,7 @@ import { ComponentDefaultTestId, getTestId } from "../../tests/test-ids-utils";
 import cx from "classnames";
 import { BaseSizes, type SIZES_VALUES } from "../../constants";
 import React, { forwardRef, useCallback, useMemo, useRef, useState, useEffect, useContext } from "react";
-// @ts-expect-error - Select is named export in react-select 3.3.0 (forked)
-import { Select, type InputProps, components, createFilter, type ActionMeta } from "react-select";
+import Select, { type InputProps, components, createFilter, type ActionMeta } from "react-select";
 import AsyncSelect from "react-select/async";
 import BaseSelect from "react-select/base";
 import { noop as NOOP } from "es-toolkit";

--- a/yarn.lock
+++ b/yarn.lock
@@ -16845,10 +16845,10 @@ react-select@3.1.0:
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
 
-"react-select@npm:react-select-module@^3.3.0":
-  version "3.3.0"
-  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.3.0.tgz#612b561a91700c68671bc8710d2dd61b083ca719"
-  integrity sha512-8b39GHTRNT9Ij9yLRv14/kc/5O0vb7nW3TrARELu4rPPDrV8lFFSEUUQ3yNGSIQMxyekMvNZ+ASFuIF6R78AUg==
+"react-select@npm:react-select-module@^3.2.6":
+  version "3.2.6"
+  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.2.6.tgz"
+  integrity sha512-Q8cp+tjtuDWaX48agmJZ5urczp5YDVh8KDkGe+FmkMxjOvdz0PNnjcEvZP6fon7T5x5BFNvoDQnDUFtVRvtiKg==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/cache" "^10.0.9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -16845,9 +16845,9 @@ react-select@3.1.0:
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
 
-"react-select@npm:react-select-module@^3.2.6":
+"react-select@npm:react-select-module@3.2.6":
   version "3.2.6"
-  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.2.6.tgz"
+  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.2.6.tgz#f21939951d706b64720233b22e872ede88caa01b"
   integrity sha512-Q8cp+tjtuDWaX48agmJZ5urczp5YDVh8KDkGe+FmkMxjOvdz0PNnjcEvZP6fon7T5x5BFNvoDQnDUFtVRvtiKg==
   dependencies:
     "@babel/runtime" "^7.4.4"


### PR DESCRIPTION
### **User description**
Reverts mondaycom/vibe#3116


___

### **PR Type**
Bug fix


___

### **Description**
- Revert Dropdown component to use default Select import

- Fix react-select version to 3.2.6 from 3.3.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dropdown component"] -- "revert import" --> B["Default Select import"]
  C["react-select 3.3.0"] -- "downgrade" --> D["react-select 3.2.6"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Downgrade react-select dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/package.json

- Change react-select version from 3.3.0 to 3.2.6


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3117/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dropdown.tsx</strong><dd><code>Revert Select component import method</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Dropdown/Dropdown.tsx

<ul><li>Revert to default Select import instead of named export<br> <li> Remove TypeScript error suppression comment</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3117/files#diff-436334767a224e5447c6f5fc7413a1bd7d599b85ff99729b29e93b37eae08843">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

