### PR TITLE
fix: use react-select v3.4.0

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -109,7 +109,7 @@
     "react-is": "^16.9.0",
     "react-popper": "^2.3.0",
     "react-remove-scroll": "^2.6.0",
-    "react-select": "npm:react-select-module@3.2.6",
+    "react-select": "npm:react-select-module@3.4.0",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -16845,10 +16845,10 @@ react-select@3.1.0:
     react-input-autosize "^2.2.2"
     react-transition-group "^4.3.0"
 
-"react-select@npm:react-select-module@3.2.6":
-  version "3.2.6"
-  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.2.6.tgz#f21939951d706b64720233b22e872ede88caa01b"
-  integrity sha512-Q8cp+tjtuDWaX48agmJZ5urczp5YDVh8KDkGe+FmkMxjOvdz0PNnjcEvZP6fon7T5x5BFNvoDQnDUFtVRvtiKg==
+"react-select@npm:react-select-module@3.4.0":
+  version "3.4.0"
+  resolved "https://registry.npmjs.org/react-select-module/-/react-select-module-3.4.0.tgz#0a132a29428e841928ce16e7c758683f747ee189"
+  integrity sha512-d9swlWWqqQyrZPfako6aKFK/kdLY9m4TQMIdhuD387VVAqB3+0zEKGb0ANQWsNNobo5ga46SltQzXuklxUvteA==
   dependencies:
     "@babel/runtime" "^7.4.4"
     "@emotion/cache" "^10.0.9"


### PR DESCRIPTION
### **PR Type**
Other


___

### **Description**
- Update `react-select` dependency from v3.2.6 to v3.4.0


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["react-select v3.2.6"] -- "upgrade" --> B["react-select v3.4.0"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Upgrade react-select dependency version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/package.json

<ul><li>Updated <code>react-select</code> dependency from <code>npm:react-select-module@3.2.6</code> to <br><code>npm:react-select-module@3.4.0</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3119/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

