### PR TITLE
fix(Dropdown): set index correctly

### DIFF
--- a/packages/core/src/components/BaseListItem/BaseListItem.types.ts
+++ b/packages/core/src/components/BaseListItem/BaseListItem.types.ts
@@ -83,6 +83,10 @@ export type BaseListItemData<Item = Record<string, unknown>> = Item & {
    * The color of the chip when displayed in multi-select mode.
    */
   chipColor?: ChipsProps["color"];
+  /**
+   * The index of the item in the list.
+   */
+  index?: number;
 };
 
 export type SideElement =

--- a/packages/core/src/components/next/Dropdown/utils/dropdownUtils.ts
+++ b/packages/core/src/components/next/Dropdown/utils/dropdownUtils.ts
@@ -25,7 +25,10 @@ export function normalizeOptions<Item extends BaseListItemData>(
             }
             return matchesFilter;
           })
-          .map(item => ({ ...item, index: indexCounter++ }));
+          .map(item => {
+            item.index = indexCounter++;
+            return item;
+          });
 
         return filteredGroupOptions.length > 0 ? [{ ...group, options: filteredGroupOptions }] : [];
       })
@@ -40,7 +43,10 @@ export function normalizeOptions<Item extends BaseListItemData>(
               }
               return matchesFilter;
             })
-            .map(item => ({ ...item, index: indexCounter++ }))
+            .map(item => {
+              item.index = indexCounter++;
+              return item;
+            })
         }
       ];
 }


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/18072990259


___

### **PR Type**
Bug fix


___

### **Description**
- Modified index assignment in dropdown options to mutate items directly

- Added `index` property to `BaseListItemData` type definition

- Changed from spread operator to direct mutation for index tracking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["BaseListItemData type"] -- "add index property" --> B["Type definition updated"]
  C["normalizeOptions function"] -- "change index assignment" --> D["Direct mutation instead of spread"]
  D --> E["Correct index tracking"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseListItem.types.ts</strong><dd><code>Add index property to BaseListItemData type</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/BaseListItem/BaseListItem.types.ts

<ul><li>Added optional <code>index</code> property to <code>BaseListItemData</code> type<br> <li> Property documented to track item position in list</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3138/files#diff-b950a0242c5e86224d06e8d78ca1d4b19e8ca205945d5ec5f82a444a9aedd885">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dropdownUtils.ts</strong><dd><code>Fix index assignment using direct mutation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/utils/dropdownUtils.ts

<ul><li>Changed index assignment from spread operator to direct mutation<br> <li> Applied to both grouped and ungrouped options filtering<br> <li> Ensures correct index tracking during option normalization</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3138/files#diff-bd175f2d4eb06a73ccb0c194dac151df784d717583b70194b771bda97e351d3b">+8/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

