### PR TITLE
docs: add icon example for playground

### DIFF
--- a/packages/core/src/storybook/stand-alone-documentaion/playground/playground-helpers.ts
+++ b/packages/core/src/storybook/stand-alone-documentaion/playground/playground-helpers.ts
@@ -31,9 +31,12 @@ const jsx = `() => {
         className="vibe-logo"
       />
       <Flex direction="column" align="center" justify="center" gap="xs">
-        <Heading type="h3" align="center">
-          Playground
-        </Heading>
+        <Flex align="center" gap="xs">
+          <Icon icon={VibeIcons.Labs} iconSize="16" />
+          <Heading type="h3" align="center">
+            Playground
+          </Heading>
+        </Flex>
         <Text type="text2" ellipsis={false}>
           Craft, Experiment, and Innovate with Vibe.
         </Text>


### PR DESCRIPTION
### **User description**
consumers reported not knowing how to write icons at Playground

https://monday.monday.com/boards/3532714909/pulses/18241523308


___

### **PR Type**
Documentation


___

### **Description**
- Add icon example to playground documentation

- Demonstrate icon usage with VibeIcons.Labs component

- Wrap heading with Flex container for icon display


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Playground Heading"] -->|Wrap with Flex| B["Flex Container"]
  B -->|Add Icon| C["VibeIcons.Labs Icon"]
  C -->|Display with| D["Updated Heading"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>playground-helpers.ts</strong><dd><code>Add icon example to playground heading</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/storybook/stand-alone-documentaion/playground/playground-helpers.ts

<ul><li>Wrapped heading with Flex container for layout<br> <li> Added Icon component using VibeIcons.Labs with 16px size<br> <li> Maintained existing gap and alignment properties<br> <li> Demonstrates icon usage pattern for playground consumers</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3150/files#diff-aa280ef4ef9fbae75d6769586d16999839e0429d09e489866ffee2597d0e2b63">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

