### PR TITLE
fix(Search): cancel pending debounced onChange when clearing input

### DIFF
--- a/packages/core/src/components/Combobox/__tests__/Combobox.interactions.js
+++ b/packages/core/src/components/Combobox/__tests__/Combobox.interactions.js
@@ -37,6 +37,29 @@ async function onSelectExistFilterClearsFilterTest(canvas) {
   expect(option1).toBeInTheDocument();
 }
 
+async function onImmediateClearBeforeDebounceCompletesTest(canvas) {
+  const { comboboxElement, searchElement } = await getComponentElements(canvas);
+  // Type text but DON'T wait for debounce (simulates race condition)
+  await typeText(searchElement, "test", 0);
+
+  // Immediately clear before debounce completes (400ms default)
+  const cleanSearchButton = getByTestId(
+    comboboxElement,
+    getTestId(ComponentDefaultTestId.CLEAN_SEARCH_BUTTON, "combobox-search")
+  );
+  await clickElement(cleanSearchButton);
+
+  // Wait for debounce period to complete
+  await new Promise(resolve => setTimeout(resolve, 500));
+
+  // Input should remain empty (not reappear with "test")
+  expect(searchElement).toHaveValue("");
+
+  // All options should be visible (no filter applied)
+  const option1 = getByText(comboboxElement, "Option 1");
+  expect(option1).toBeInTheDocument();
+}
+
 async function onNavigateBetweenOptionsByArrowsAriaUpdates(canvas) {
   const { comboboxElement, searchElement } = await getComponentElements(canvas);
 
@@ -71,7 +94,8 @@ export const defaultPlaySuite = interactionSuite({
   tests: [
     onNavigateBetweenOptionsByArrowsAriaUpdates,
     onTypeFilterComboboxOptionsTest,
-    onSelectExistFilterClearsFilterTest
+    onSelectExistFilterClearsFilterTest,
+    onImmediateClearBeforeDebounceCompletesTest
   ],
   afterEach: async () => {
     await resetFocus();

--- a/packages/core/src/hooks/__tests__/useDebounceEvent.test.ts
+++ b/packages/core/src/hooks/__tests__/useDebounceEvent.test.ts
@@ -142,6 +142,28 @@ describe("useDebounceEvent", () => {
 
       expect(onChangeCallbackStub.mock.calls.length).toEqual(1);
     });
+
+    it("should cancel pending debounced onChange when clearValue is called", () => {
+      const { onEventChanged, clearValue } = hookResult.result.current;
+      const newInputValue = "test value";
+
+      // Type some text (schedules debounced onChange)
+      act(() => {
+        onEventChanged(getEventObject(newInputValue));
+      });
+
+      // Immediately clear before debounce completes
+      act(() => {
+        clearValue();
+      });
+
+      vi.runOnlyPendingTimers();
+
+      // Should only be called once with empty string from clearValue,
+      // NOT called again with stale "test value"
+      expect(onChangeCallbackStub.mock.calls.length).toEqual(1);
+      expect(onChangeCallbackStub.mock.calls[0][0]).toEqual("");
+    });
   });
 });
 

--- a/packages/core/src/hooks/useDebounceEvent/index.ts
+++ b/packages/core/src/hooks/useDebounceEvent/index.ts
@@ -31,6 +31,7 @@ export default function useDebounceEvent({
 }) {
   const [inputValue, setValue] = useState<string>(initialStateValue);
   const previousValue = useRef<string>(null);
+  const debouncedFnRef = useRef<ReturnType<typeof debounce>>(null);
 
   useEffect(() => {
     previousValue.current = initialStateValue;
@@ -45,8 +46,16 @@ export default function useDebounceEvent({
       return noop;
     }
 
-    return debounce(onChange, delay);
+    const debouncedFn = debounce(onChange, delay);
+    debouncedFnRef.current = debouncedFn;
+    return debouncedFn;
   }, [onChange, delay]);
+
+  useEffect(() => {
+    return () => {
+      debouncedFnRef.current?.cancel();
+    };
+  }, []);
 
   const onEventChanged = useCallback(
     (event: ChangeEvent<Partial<HTMLInputElement> | Partial<HTMLTextAreaElement>>) => {
@@ -59,6 +68,7 @@ export default function useDebounceEvent({
   );
 
   const clearValue = useCallback(() => {
+    debouncedFnRef.current?.cancel();
     setValue("");
     if (onChange) {
       onChange("");


### PR DESCRIPTION
### **User description**
While researching different design system implementations, I stumbled upon the following bug:
There is a race condition in the Combobox/Search component where typing text and immediately clearing the input would cause the text to reappear with "No results found" message.

https://github.com/user-attachments/assets/104cc425-854f-4d0a-b87a-2a337b2681a3

**Reproduction steps:**
  1. Open Combobox in Storybook (`story/components-combobox--overview`)
  2. Type text quickly (e.g., "test")
  3. Immediately click the clear button (before 400ms debounce completes)
  4. **Bug**: Text reappears with "No results found" instead of staying cleared

**Root cause:** The `useDebounceEvent` hook didn't cancel pending debounced callbacks when `clearValue()` was called, allowing stale values to fire after clearing.

  ## Solution

  - **Store debounced function reference** in `useDebounceEvent` hook via `useRef`
  - **Cancel pending callbacks** in `clearValue()` before clearing the value
  - **Add cleanup effect** to cancel on component unmount
  - **Follow TDD approach**: Test first (failed), then fix (passed)

  ## Changes

  ### Modified Files
  - `packages/core/src/hooks/useDebounceEvent/index.ts` - Added cancel logic
  - `packages/core/src/hooks/__tests__/useDebounceEvent.test.ts` - Added race condition test
  - `packages/core/src/components/Combobox/__tests__/Combobox.interactions.js` - Added integration test

  ### Tests
  - ✅ Unit test: `should cancel pending debounced onChange when clearValue is called`
  - ✅ Integration test: `onImmediateClearBeforeDebounceCompletesTest`
  - ✅ All existing tests pass (12/12 in useDebounceEvent)
  - ✅ Manual testing in Storybook

  ## Future Improvement Suggestion

  Currently, the test waits an arbitrary `500ms` for the debounce to complete:

```javascript
  await new Promise(resolve => setTimeout(resolve, 500));
```

  Suggestion: Export SEARCH_DEFAULT_DEBOUNCE_RATE constant from a consumer component (e.g combobox) for use in tests:

```typescript
export const COMBOBOX_SEARCH_DEBOUNCE_RATE = 400; (or depend on `SEARCH_DEBOUNCE_RATE`)
```

This makes the relationship explicit and prevents tests from breaking if the default changes.


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Fix race condition in Search/Combobox where typing and immediately clearing input caused text to reappear

- Store debounced function reference to enable cancellation of pending callbacks

- Cancel pending debounced calls when `clearValue()` is invoked

- Add cleanup effect to cancel debounced callbacks on component unmount

- Add unit and integration tests to verify race condition is resolved


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["User types text"] -->|schedules debounce| B["Pending callback"]
  C["User clears input"] -->|cancel pending| B
  B -->|stale value fires| D["Bug: text reappears"]
  C -->|fixed: cancel works| E["Text stays cleared"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>index.ts</strong><dd><code>Store debounced function reference and add cancellation logic</code></dd></summary>
<hr>

packages/core/src/hooks/useDebounceEvent/index.ts

<ul><li>Added <code>debouncedFnRef</code> to store reference to debounced function for <br>cancellation<br> <li> Store debounced function in ref when creating it in <code>useMemo</code><br> <li> Added cleanup effect to cancel pending debounced calls on unmount<br> <li> Call <code>debouncedFnRef.current?.cancel()</code> in <code>clearValue()</code> before clearing <br>state</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3155/files#diff-973d6a9ba22bc2ce1da047149d384cb5215f6d3e22c68985aafe20c2dcc1fcba">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useDebounceEvent.test.ts</strong><dd><code>Add unit test for debounce cancellation on clear</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/hooks/__tests__/useDebounceEvent.test.ts

<ul><li>Added new test case for race condition scenario<br> <li> Test verifies that typing text and immediately clearing cancels <br>pending debounced callback<br> <li> Ensures <code>onChange</code> is only called once with empty string, not with stale <br>value<br> <li> Uses <code>vi.runOnlyPendingTimers()</code> to verify no additional callbacks fire</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3155/files#diff-7a4143d41fd7c953cb6bb5e09382b6942b5fe555c5c10c5182803f47398654e3">+22/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Combobox.interactions.js</strong><dd><code>Add integration test for immediate clear before debounce</code>&nbsp; </dd></summary>
<hr>

packages/core/src/components/Combobox/__tests__/Combobox.interactions.js

<ul><li>Added new integration test <code>onImmediateClearBeforeDebounceCompletesTest</code><br> <li> Test simulates typing without waiting for debounce, then immediately <br>clearing<br> <li> Waits 500ms for debounce period to complete and verifies input remains <br>empty<br> <li> Verifies all options remain visible (no stale filter applied)<br> <li> Added test to default test suite</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3155/files#diff-f83b81b66082317c0bc13a691893a0d9fa07e44e1725728f99b5d48d5abc9add">+25/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

