### PR TITLE
docs: fix broken link

### DIFF
--- a/packages/core/src/components/next/Dropdown/__stories__/Dropdown.mdx
+++ b/packages/core/src/components/next/Dropdown/__stories__/Dropdown.mdx
@@ -15,7 +15,7 @@ Dropdown present a list of options from which a user can select one or several.
 
 <Tip title="Migration Guide Available" emoji="🚀">
   Migrating from the old Dropdown? Check out our comprehensive{" "}
-  <Link href="/?path=/docs/components-dropdown-alpha-migration-guide--docs">Dropdown Migration Guide</Link> for
+  <Link href="/?path=/docs/components-dropdown-new-migration-guide--docs">Dropdown Migration Guide</Link> for
   step-by-step instructions, breaking changes, and new features.
 </Tip>
 


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Update broken Dropdown migration guide link in documentation

- Change link path from `alpha-migration-guide` to `new-migration-guide`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  oldLink["/?path=/docs/components-dropdown-alpha-migration-guide--docs"] -- "update to" --> newLink["/?path=/docs/components-dropdown-new-migration-guide--docs"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dropdown.mdx</strong><dd><code>Update Dropdown migration guide link reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/__stories__/Dropdown.mdx

<ul><li>Updated the Dropdown migration guide link href from <br><code>alpha-migration-guide</code> to <code>new-migration-guide</code><br> <li> Corrects broken documentation reference in the migration tip section</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3156/files#diff-14c16bbe4d32b919410337d01e6d775cc5458e099c31a3bd080284965badca63">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

