### PR TITLE
test: resolve internal packages for tests

### DIFF
--- a/components/button/src/Button/__tests__/__snapshots__/Button.snapshot.test.tsx.snap
+++ b/components/button/src/Button/__tests__/__snapshots__/Button.snapshot.test.tsx.snap
@@ -405,7 +405,7 @@ exports[`Button renders correctly > renders correctly with leftIcon 1`] = `
 >
   <svg
     aria-hidden={true}
-    className="icon_aef505ec69 leftIcon noFocusStyle_d080cfd070"
+    className="icon leftIcon noFocusStyle"
     data-testid="icon"
     data-vibe="Icon"
     fill="currentColor"
@@ -458,7 +458,7 @@ exports[`Button renders correctly > renders correctly with rightIcon 1`] = `
   Button
   <svg
     aria-hidden={true}
-    className="icon_aef505ec69 rightIcon noFocusStyle_d080cfd070"
+    className="icon rightIcon noFocusStyle"
     data-testid="icon"
     data-vibe="Icon"
     fill="currentColor"

--- a/packages/config/vitest.config.mjs
+++ b/packages/config/vitest.config.mjs
@@ -1,6 +1,31 @@
 /// <reference types="vitest" />
 import { defineConfig } from "vitest/config";
 import react from "@vitejs/plugin-react";
+import path from "path";
+import fs from "fs";
+import { fileURLToPath } from "url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function generateVibeComponentAliases() {
+  const componentsFolder = path.resolve(__dirname, "../../components");
+  const vibeComponents = {};
+
+  if (fs.existsSync(componentsFolder)) {
+    const componentDirs = fs.readdirSync(componentsFolder);
+
+    componentDirs.forEach(component => {
+      const componentFolderPath = path.resolve(componentsFolder, component);
+      const srcPath = path.join(componentFolderPath, "src");
+
+      if (fs.statSync(componentFolderPath).isDirectory() && fs.existsSync(srcPath)) {
+        vibeComponents[`@vibe/${component}`] = srcPath;
+      }
+    });
+  }
+
+  return vibeComponents;
+}
 
 export default defineConfig({
   plugins: [
@@ -8,6 +33,11 @@ export default defineConfig({
       jsxRuntime: "classic"
     })
   ],
+  resolve: {
+    alias: {
+      ...generateVibeComponentAliases()
+    }
+  },
   define: {
     "process.env.NODE_ENV": '"test"'
   },


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/18286305299


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Add dynamic path resolution for Vibe component aliases in tests

- Generate component aliases from `@vibe/*` packages automatically

- Enable tests to resolve internal package imports correctly

- Improve test configuration maintainability and scalability


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["vitest.config.mjs"] -->|"scans components folder"| B["generateVibeComponentAliases()"]
  B -->|"creates aliases"| C["@vibe/* mappings"]
  C -->|"resolves in tests"| D["Internal packages"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>vitest.config.mjs</strong><dd><code>Add dynamic component alias resolution for Vitest</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/config/vitest.config.mjs

<ul><li>Added utility function <code>generateVibeComponentAliases()</code> to dynamically <br>scan components folder<br> <li> Generates path aliases for each component under <code>@vibe/*</code> namespace<br> <li> Integrated aliases into Vitest <code>resolve.alias</code> configuration<br> <li> Enables tests to import internal packages using <code>@vibe/component-name</code> <br>syntax</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3162/files#diff-955375823977b7d451bce449b961a5a5a19a269c8c9916b79896059403a0927c">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

