### PR TITLE
ci: include components folder in bundle size check

### DIFF
--- a/scripts/bundle-check/compare-bundles.js
+++ b/scripts/bundle-check/compare-bundles.js
@@ -42,7 +42,13 @@ Array.from(allComponents)
     const baseEntry = baseMap.get(componentName);
     const prEntry = prMap.get(componentName);
 
-    const displayName = path.basename(componentName, path.extname(componentName));
+    let displayName;
+    if (componentName.startsWith("components/")) {
+      const packageName = componentName.split("/")[1];
+      displayName = `@vibe/${packageName}`;
+    } else {
+      displayName = path.basename(componentName, path.extname(componentName));
+    }
 
     if (!baseEntry && prEntry) {
       // New component

--- a/scripts/bundle-check/generate-size-limit-config.js
+++ b/scripts/bundle-check/generate-size-limit-config.js
@@ -3,31 +3,62 @@ const path = require("path");
 
 const rootPath = process.cwd();
 const distIndexPath = path.join(rootPath, "packages/core/dist/src/index.js");
+const componentsPath = path.join(rootPath, "components");
 const sizeLimitConfigPath = path.join(rootPath, ".size-limit.js");
 
 function generateSizeLimitConfig() {
-  if (!fs.existsSync(distIndexPath)) {
-    console.log(`dist index file not found at ${distIndexPath}, writing empty size-limit config.`);
+  const allComponents = [];
+
+  // Process core package components
+  if (fs.existsSync(distIndexPath)) {
+    const indexContent = fs.readFileSync(distIndexPath, "utf8");
+    const exportRegex = /export\{.*?\}from"(\.\/components\/[^"]+\.js)";/g;
+
+    let match;
+    while ((match = exportRegex.exec(indexContent)) !== null) {
+      const relativePath = match[1];
+      const fullPath = path.join("packages/core/dist/src/", relativePath).replace(/\\/g, "/");
+      allComponents.push({
+        path: fullPath
+      });
+    }
+    console.log(`Found ${allComponents.length} core components.`);
+  } else {
+    console.log(`Core dist index file not found at ${distIndexPath}.`);
+  }
+
+  // Process component packages
+  if (fs.existsSync(componentsPath)) {
+    const componentPackages = fs
+      .readdirSync(componentsPath, { withFileTypes: true })
+      .filter(dirent => dirent.isDirectory())
+      .map(dirent => dirent.name);
+
+    for (const packageName of componentPackages) {
+      const packageDistPath = path.join(componentsPath, packageName, "dist/index.js");
+      if (fs.existsSync(packageDistPath)) {
+        const relativePath = path.join("components", packageName, "dist/index.js").replace(/\\/g, "/");
+        allComponents.push({
+          path: relativePath
+        });
+        console.log(`Added component package: ${packageName}`);
+      } else {
+        console.log(`Dist file not found for component package: ${packageName}`);
+      }
+    }
+  } else {
+    console.log(`Components directory not found at ${componentsPath}.`);
+  }
+
+  if (allComponents.length === 0) {
+    console.log("No components found, writing empty size-limit config.");
     fs.writeFileSync(sizeLimitConfigPath, "module.exports = [];");
     return;
   }
 
-  const indexContent = fs.readFileSync(distIndexPath, "utf8");
-  const exportRegex = /export\{.*?\}from"(\.\/components\/[^"]+\.js)";/g;
-
-  let match;
-  const components = [];
-  while ((match = exportRegex.exec(indexContent)) !== null) {
-    const relativePath = match[1];
-    const fullPath = path.join("packages/core/dist/src/", relativePath).replace(/\\/g, "/");
-    components.push({
-      path: fullPath
-    });
-  }
-
-  const configContent = `module.exports = ${JSON.stringify(components, null, 2)};`;
+  const configContent = `module.exports = ${JSON.stringify(allComponents, null, 2)};`;
   fs.writeFileSync(sizeLimitConfigPath, configContent);
-  console.log(`Generated .size-limit.js with ${components.length} components.`);
+  console.log(`Generated .size-limit.js with ${allComponents.length} total components (core + component packages).`);
 }
 
 generateSizeLimitConfig();


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/18286653855


___

### **PR Type**
Enhancement


___

### **Description**
- Extend bundle size check to include component packages

- Parse component packages from `components/` directory

- Display component packages with `@vibe/` namespace format

- Generate size-limit config for both core and component packages


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Bundle Check Script"] --> B["Core Components"]
  A --> C["Component Packages"]
  B --> D["Generate Config"]
  C --> D
  D --> E["Size Limit Check"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-size-limit-config.js</strong><dd><code>Add component packages to size-limit config generation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/bundle-check/generate-size-limit-config.js

<ul><li>Added logic to discover and process component packages from <br><code>components/</code> directory<br> <li> Extended config generation to include both core and component package <br>distributions<br> <li> Improved error handling with separate checks for core and component <br>paths<br> <li> Updated logging to distinguish between core and component package <br>processing</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3163/files#diff-6a152afb50b8b9d3819dbffbf9cdc6433e58f55b062633ecb3442ca1f604caf1">+48/-17</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>compare-bundles.js</strong><dd><code>Format component package names with namespace</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/bundle-check/compare-bundles.js

<ul><li>Added conditional logic to format display names for component packages<br> <li> Component packages now display with <code>@vibe/</code> namespace prefix<br> <li> Preserved original display name logic for core components</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3163/files#diff-94c49176262ef7c874c387eabc3a86b093788570addb51d36a0074e886747951">+7/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

