### PR TITLE
docs: fix publish storybook action path

### DIFF
--- a/.github/workflows/publish-storybook.yml
+++ b/.github/workflows/publish-storybook.yml
@@ -32,7 +32,7 @@ jobs:
           clean-exclude: |
             v2/*
             playground/*
-          folder: packages/core/static_storybook
+          folder: packages/docs/static_storybook
           branch: gh-pages
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### **PR Type**
Documentation


___

### **Description**
- Update Storybook deployment folder path from `packages/core/static_storybook` to `packages/docs/static_storybook`

- Corrects GitHub Pages deployment action to reference correct documentation build output location


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["publish-storybook.yml"] -- "updates folder path" --> B["packages/docs/static_storybook"]
  C["Old path: packages/core/static_storybook"] -.->|replaced| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>publish-storybook.yml</strong><dd><code>Update Storybook deployment folder path</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/publish-storybook.yml

<ul><li>Changed Storybook deployment folder path from <br><code>packages/core/static_storybook</code> to <code>packages/docs/static_storybook</code><br> <li> Ensures GitHub Pages deployment action deploys from the correct <br>documentation build directory</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3172/files#diff-6c670c1eeea28e5cdc0ae81ab37c9c0d9427b50ab9838620925eecb29fe120d3">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

