### PR TITLE
test: support mocked_classnames for component packages

### DIFF
--- a/packages/components/button/package.json
+++ b/packages/components/button/package.json
@@ -25,10 +25,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./mockedClassNames": {
+      "import": "./dist/mocked_classnames/src/index.js",
+      "default": "./dist/mocked_classnames/src/index.js"
     }
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && mock_classnames=on rollup -c",
     "test": "vitest run",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\""
   },

--- a/packages/components/icon/package.json
+++ b/packages/components/icon/package.json
@@ -25,10 +25,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./mockedClassNames": {
+      "import": "./dist/mocked_classnames/src/index.js",
+      "default": "./dist/mocked_classnames/src/index.js"
     }
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && mock_classnames=on rollup -c",
     "test": "vitest run",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\""
   },

--- a/packages/components/loader/package.json
+++ b/packages/components/loader/package.json
@@ -25,10 +25,14 @@
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
       "default": "./dist/index.js"
+    },
+    "./mockedClassNames": {
+      "import": "./dist/mocked_classnames/src/index.js",
+      "default": "./dist/mocked_classnames/src/index.js"
     }
   },
   "scripts": {
-    "build": "rollup -c",
+    "build": "rollup -c && mock_classnames=on rollup -c",
     "test": "vitest run",
     "lint": "eslint \"./src/**/*.{js,jsx,ts,tsx}\""
   },

--- a/packages/config/rollup.config.mjs
+++ b/packages/config/rollup.config.mjs
@@ -53,7 +53,7 @@ function onwarn(message, handler) {
 export default {
   onwarn,
   output: {
-    dir: DIST_PATH,
+    dir: shouldMockModularClassnames ? path.join(DIST_PATH, "mocked_classnames") : DIST_PATH,
     indent: false,
     strict: false,
     exports: "named",


### PR DESCRIPTION
### **User description**
For jest this should use all mocked_classnames packages:

```
'^@vibe/(.*)$': '<rootDir>/node_modules/@vibe/$1/dist/mocked_classnames/src/index.js',
```

https://monday.monday.com/boards/3532714909/pulses/18341931054


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Add `./mockedClassNames` export to component packages

- Enable mocked classnames build output via environment variable

- Configure rollup to generate mocked classnames in separate directory

- Support Jest module mapping for component test mocking


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Build Script"] -->|"mock_classnames=on"| B["Rollup Config"]
  B -->|"shouldMockModularClassnames"| C["Output to mocked_classnames/"]
  C --> D["./mockedClassNames Export"]
  D --> E["Jest Module Mapping"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add mocked classnames export to button package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/button/package.json

<ul><li>Add <code>./mockedClassNames</code> export pointing to mocked classnames build<br> <li> Update build script to generate mocked classnames with environment <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3181/files#diff-af5aff26b0a4e2c14cc31beeb6ec164b1480665be4dda74402bf556a642fcacf">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add mocked classnames export to icon package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/icon/package.json

<ul><li>Add <code>./mockedClassNames</code> export pointing to mocked classnames build<br> <li> Update build script to generate mocked classnames with environment <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3181/files#diff-2f92fc90cef1886877b7422d12e6d99d8d332734e56327477403082bfd4a3418">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Add mocked classnames export to loader package</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/loader/package.json

<ul><li>Add <code>./mockedClassNames</code> export pointing to mocked classnames build<br> <li> Update build script to generate mocked classnames with environment <br>variable</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3181/files#diff-82ee9ea1bc25294ee56dffb7aac8399fb1456af3f0e414c01a588fcb1ef61b2a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>rollup.config.mjs</strong><dd><code>Configure rollup output directory for mocked classnames</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/config/rollup.config.mjs

<ul><li>Conditionally output to <code>mocked_classnames</code> subdirectory when <br><code>shouldMockModularClassnames</code> is true<br> <li> Enables separate build output for mocked classnames based on <br>environment variable</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3181/files#diff-b53425d0ae35d39da917088d6f9e38a17c7108044e205f7a307045fd07abc606">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

