### PR TITLE
feat(AlertBanner): add ariaLive to AlertBanner

### DIFF
--- a/packages/core/src/components/AlertBanner/AlertBannerText/AlertBannerText.tsx
+++ b/packages/core/src/components/AlertBanner/AlertBannerText/AlertBannerText.tsx
@@ -16,9 +16,19 @@ export interface AlertBannerTextProps extends VibeComponentProps {
    * If true, a left margin is applied to the alert banner text.
    */
   marginLeft?: boolean;
+  /**
+   * The aria-live attribute value for the alert banner text.
+   */
+  ariaLive?: "polite" | "assertive" | "off";
 }
 
-const AlertBannerText: FC<AlertBannerTextProps> = ({ text, marginLeft = false, id, "data-testid": dataTestId }) => {
+const AlertBannerText: FC<AlertBannerTextProps> = ({
+  text,
+  marginLeft = false,
+  id,
+  "data-testid": dataTestId,
+  ariaLive
+}) => {
   const componentRef = useRef(null);
   const classNames = cx(styles.bannerText, {
     [styles.marginLeft]: marginLeft
@@ -38,7 +48,7 @@ const AlertBannerText: FC<AlertBannerTextProps> = ({ text, marginLeft = false, i
         id={id}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.ALERT_BANNER_TEXT, id)}
       >
-        <span>{text}</span>
+        <span aria-live={ariaLive}>{text}</span>
       </div>
     </Tooltip>
   );

--- a/packages/core/src/components/AlertBanner/__tests__/AlertBanner.test.tsx
+++ b/packages/core/src/components/AlertBanner/__tests__/AlertBanner.test.tsx
@@ -43,6 +43,17 @@ describe("<AlertBanner />", () => {
         const alertBannerComponentLabel = getByLabelText(ariaLabel);
         expect(alertBannerComponentLabel).toBeTruthy();
       });
+
+      it("should set aria-live on alert banner text when provided", () => {
+        const { container } = render(
+          <AlertBanner>
+            <AlertBannerText text="Important update" ariaLive="polite" />
+          </AlertBanner>
+        );
+        const textSpan = container.querySelector("[data-testid='alert-banner-text'] span");
+        expect(textSpan).toBeTruthy();
+        expect(textSpan.getAttribute("aria-live")).toBe("polite");
+      });
     });
   });
 });

--- a/packages/docs/src/pages/components/AlertBanner/AlertBanner.mdx
+++ b/packages/docs/src/pages/components/AlertBanner/AlertBanner.mdx
@@ -45,6 +45,11 @@ import { AlertBanner } from "@vibe/core";
     <>
       For dismissible AlertBanners, use the <code>closeButtonAriaLabel</code> prop to provide a descriptive accessible
       name for the close button.
+    </>,
+    <>
+      When the banner text should be announced by screen readers (e.g., for dynamic updates), set the{" "}
+      <code>ariaLive</code> prop on AlertBannerText to control the live region behavior ("polite", "assertive", or
+      "off"). By default, AlertBannerText does not set a live region.
     </>
   ]}
 />

--- a/packages/docs/src/pages/components/AlertBanner/AlertBanner.stories.tsx
+++ b/packages/docs/src/pages/components/AlertBanner/AlertBanner.stories.tsx
@@ -32,7 +32,9 @@ export default {
     AlertBannerLink,
     AlertBannerButton
   },
-  argTypes: metaSettings.argTypes,
+  argTypes: {
+    ...metaSettings.argTypes
+  },
   decorators: [
     ...metaSettings.decorators,
     (Story: React.ComponentType) => (


### PR DESCRIPTION
### **User description**
This change adds an ariaLive attribute to the AlertBanner component. AlertBanner can often be used for critical information purposes (For my context, submitting workforms and having errors appear). For screen readers, we want to have ariaLive available to read out the error message. This is a backwards compatible change and assumes the user passes no prop for it.

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.


___

### **PR Type**
Enhancement


___

### **Description**
- Add `ariaLive` prop to AlertBannerText for screen reader announcements

- Support "polite", "assertive", and "off" aria-live values

- Add test coverage for aria-live attribute functionality

- Update documentation with accessibility guidelines


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AlertBannerText Props"] -->|add ariaLive| B["aria-live attribute"]
  B -->|values| C["polite/assertive/off"]
  D["Test Coverage"] -->|validates| B
  E["Documentation"] -->|explains usage| B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertBannerText.tsx</strong><dd><code>Add ariaLive prop and apply to span element</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/AlertBanner/AlertBannerText/AlertBannerText.tsx

<ul><li>Add <code>ariaLive</code> prop to <code>AlertBannerTextProps</code> interface with type "polite" <br>| "assertive" | "off"<br> <li> Destructure <code>ariaLive</code> parameter from component props<br> <li> Apply <code>aria-live</code> attribute to the text span element</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3182/files#diff-4f340c5705a3c2cda13705047e6e2ec90e9bb493c19a5c09bf405bddc204d3b2">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertBanner.test.tsx</strong><dd><code>Add test for aria-live attribute functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/AlertBanner/__tests__/AlertBanner.test.tsx

<ul><li>Add new test case to verify aria-live attribute is set correctly<br> <li> Test renders AlertBanner with AlertBannerText using ariaLive="polite"<br> <li> Verify the span element has the correct aria-live attribute value</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3182/files#diff-6dfa4e61707aafe1e6cdd0318b4a82acbd11f7194ef17ec2c93412166d404f1c">+11/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertBanner.mdx</strong><dd><code>Document ariaLive accessibility guidelines</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/components/AlertBanner/AlertBanner.mdx

<ul><li>Add accessibility guideline for <code>ariaLive</code> prop usage<br> <li> Document the three supported values: "polite", "assertive", "off"<br> <li> Explain when to use aria-live for dynamic updates<br> <li> Note that AlertBannerText does not set live region by default</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3182/files#diff-0aae7276e1cfa8a7a648204799825a0627a39d7acbd226c5646a3e22263779e9">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Formatting</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertBanner.stories.tsx</strong><dd><code>Refactor argTypes configuration structure</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/components/AlertBanner/AlertBanner.stories.tsx

<ul><li>Refactor <code>argTypes</code> to use spread operator for <code>metaSettings.argTypes</code><br> <li> Maintain existing functionality while improving code structure</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3182/files#diff-6f6157af3814442104e455b1398bd6a12e2baac6d6e73a8c9f56978b446a985e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

