### PR TITLE
fix(AttentionBox): change Text element type based on content type for…

### DIFF
--- a/packages/core/src/components/next/AttentionBox/layouts/AttentionBoxCompact/AttentionBoxCompact.tsx
+++ b/packages/core/src/components/next/AttentionBox/layouts/AttentionBoxCompact/AttentionBoxCompact.tsx
@@ -25,7 +25,7 @@ const AttentionBoxCompact = ({
     <Flex align="center" className={styles.container}>
       <Flex gap="xs" flex="1" className={styles.mainContentGroup}>
         {icon && <AttentionBoxLeadingIcon icon={icon} iconType={iconType} className={styles.leadingIcon} />}
-        <Text type="text2" element="p" ellipsis>
+        <Text type="text2" element={typeof content === "string" ? "p" : undefined} ellipsis>
           {content}
         </Text>
       </Flex>

--- a/packages/core/src/components/next/AttentionBox/layouts/AttentionBoxDefault/AttentionBoxDefault.tsx
+++ b/packages/core/src/components/next/AttentionBox/layouts/AttentionBoxDefault/AttentionBoxDefault.tsx
@@ -48,7 +48,12 @@ const AttentionBoxDefault = ({
         />
       )}
 
-      <Text type="text2" className={styles.text} ellipsis={false} element="p">
+      <Text
+        type="text2"
+        className={styles.text}
+        ellipsis={false}
+        element={typeof content === "string" ? "p" : undefined}
+      >
         {content}
       </Text>
 


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/pulses/10554342292


___

### **PR Type**
Bug fix


___

### **Description**
- Conditionally set Text element type based on content type

- Use "p" element for string content, undefined for JSX

- Ensures proper DOM structure validation in AttentionBox

- Applied to both Compact and Default layout variants


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["AttentionBox Content"] --> B{"Content Type Check"}
  B -->|String| C["element='p'"]
  B -->|JSX/Other| D["element=undefined"]
  C --> E["Valid DOM Structure"]
  D --> E
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AttentionBoxCompact.tsx</strong><dd><code>Conditional Text element type in Compact layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/AttentionBox/layouts/AttentionBoxCompact/AttentionBoxCompact.tsx

<ul><li>Changed Text element prop from hardcoded "p" to conditional expression<br> <li> Uses "p" element when content is string type<br> <li> Uses undefined element for non-string content (JSX elements)</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3186/files#diff-658c16b07898bec5855e8d615e2d00fd70786c54400ceffa8bd560aafcbb8d0b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttentionBoxDefault.tsx</strong><dd><code>Conditional Text element type in Default layout</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/AttentionBox/layouts/AttentionBoxDefault/AttentionBoxDefault.tsx

<ul><li>Changed Text element prop from hardcoded "p" to conditional expression<br> <li> Uses "p" element when content is string type<br> <li> Uses undefined element for non-string content (JSX elements)<br> <li> Reformatted Text component props for better readability</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3186/files#diff-70b6d1e7535ff9cfd92df807b157b5ae0d83e4b878bdcc2d3c342e4cb2678066">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

