### PR TITLE
fix(ButtonGroup): apply fullWidth to root element

### DIFF
--- a/packages/core/src/components/ButtonGroup/ButtonGroup.tsx
+++ b/packages/core/src/components/ButtonGroup/ButtonGroup.tsx
@@ -211,7 +211,7 @@ const ButtonGroup = forwardRef(
     return (
       <div
         className={cx(styles.buttonGroup, className, getStyle(styles, camelCase("kind-" + kind)), {
-          [styles.disabled]: disabled
+          [styles.disabled]: disabled, [styles.fullWidth]: fullWidth,
         })}
         id={id}
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.BUTTON_GROUP, id)}


### PR DESCRIPTION
### **User description**
This fix applies the missing `fullWidth` class to the ButtonGroup root element.
The SCSS already defines `.fullWidth { flex: 1 }`, which makes sense here since
`flex: 1` allows the ButtonGroup to expand proportionally inside its flex container.
This resolves the issue where `fullWidth` had no effect in Storybook.

- [x] I have read the Contribution Guide.

Resolves #3130


___

### **PR Type**
Bug fix


___

### **Description**
- Apply missing `fullWidth` class to ButtonGroup root element

- Enables flex: 1 styling for proportional expansion

- Resolves fullWidth prop having no effect in Storybook


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ButtonGroup component"] -- "add fullWidth class" --> B["Root div with flex: 1 styling"]
  C["fullWidth prop"] -- "conditional rendering" --> B
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ButtonGroup.tsx</strong><dd><code>Add fullWidth class binding to root element</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/ButtonGroup/ButtonGroup.tsx

<ul><li>Added <code>fullWidth</code> prop to the conditional className binding<br> <li> Applies <code>styles.fullWidth</code> class when <code>fullWidth</code> prop is true<br> <li> Enables the existing SCSS rule <code>flex: 1</code> to take effect</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3187/files#diff-d50c59f4592310742bbd3da5e2b8a2bf85efa61b1aa9bb465b0a66855bd59cae">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

