### PR TITLE
feat(Dropdown): add borderless prop

### DIFF
--- a/packages/core/src/components/next/Dropdown/Dropdown.types.ts
+++ b/packages/core/src/components/next/Dropdown/Dropdown.types.ts
@@ -118,6 +118,10 @@ export type BaseDropdownProps<Item extends BaseListItemData<Record<string, unkno
      */
     dir?: DropdownDirection;
     /**
+     * If true, the dropdown has no visible border by default, but shows border on hover, focus, and active states.
+     */
+    borderless?: boolean;
+    /**
      * The function to call to render an option.
      */
     optionRenderer?: (option: Item) => React.ReactNode;

--- a/packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.module.scss
+++ b/packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.module.scss
@@ -40,6 +40,19 @@
     background: transparent;
     cursor: default;
   }
+
+  &.borderless {
+    --border-color: transparent;
+
+    &:hover {
+      --border-color: var(--primary-text-color);
+    }
+
+    &.active,
+    &:focus {
+      --border-color: var(--primary-color);
+    }
+  }
 }
 .helperText {
   margin-top: var(--spacing-xs);

--- a/packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.tsx
+++ b/packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.tsx
@@ -31,7 +31,8 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
     helperText,
     dir,
     tooltipProps,
-    boxMode
+    boxMode,
+    borderless
   } = useDropdownContext<BaseListItemData>();
 
   const coreDropdownElement = (
@@ -44,7 +45,8 @@ const DropdownBase = ({ dropdownRef, children }: DropdownBaseProps) => {
           [styles.readOnly]: readOnly,
           [styles.error]: error,
           [styles.active]: isFocused || isOpen,
-          [styles.boxMode]: boxMode
+          [styles.boxMode]: boxMode,
+          [styles.borderless]: borderless
         },
         className
       )}

--- a/packages/core/src/components/next/Dropdown/context/DropdownContext.types.ts
+++ b/packages/core/src/components/next/Dropdown/context/DropdownContext.types.ts
@@ -41,6 +41,7 @@ type InheritedDropdownProps<Item extends BaseListItemData<Record<string, unknown
     | "menuWrapperClassName"
     | "loading"
     | "boxMode"
+    | "borderless"
     | "onFocus"
     | "onBlur"
     | "onKeyDown"


### PR DESCRIPTION
### **User description**
https://monday.monday.com/boards/3532714909/views/80492480/pulses/10651583362


___

### **PR Type**
Enhancement


___

### **Description**
- Add `borderless` prop to Dropdown component

- Border hidden by default, visible on hover/focus/active

- Prop inherited through DropdownContext for child components

- Styling applied via SCSS module with state-based border colors


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dropdown.types.ts<br/>Add borderless prop"] --> B["DropdownContext.types.ts<br/>Inherit borderless prop"]
  B --> C["DropdownBase.tsx<br/>Apply borderless class"]
  C --> D["DropdownBase.module.scss<br/>Style borderless states"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dropdown.types.ts</strong><dd><code>Add borderless prop type definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/Dropdown.types.ts

<ul><li>Added <code>borderless?: boolean</code> property to <code>BaseDropdownProps</code> type<br> <li> Documented that borderless hides border by default but shows on hover, <br>focus, and active states</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3195/files#diff-3fa87b38b32b99245ee6e0c05b44bef3ee4de88df75a3a7915870d07ff4fc4d9">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownContext.types.ts</strong><dd><code>Include borderless in inherited props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/context/DropdownContext.types.ts

<ul><li>Added <code>borderless</code> to the <code>InheritedDropdownProps</code> union type<br> <li> Ensures borderless prop is inherited through dropdown context</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3195/files#diff-52b411d8fdbd674df5e3f406bc883229e8749fc5fda5de656cab5dd68e3fc8bb">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownBase.module.scss</strong><dd><code>Add borderless styling with state-based borders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.module.scss

<ul><li>Added <code>.borderless</code> class with transparent border by default<br> <li> Border becomes primary text color on hover<br> <li> Border becomes primary color on active and focus states</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3195/files#diff-c2eb02a39c3763c2e955e1d3e6027a9d44eb88bf9e8f25bd80aad1f61d8c601e">+13/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownBase.tsx</strong><dd><code>Apply borderless class to dropdown wrapper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/next/Dropdown/components/DropdownBase/DropdownBase.tsx

<ul><li>Destructured <code>borderless</code> from <code>useDropdownContext</code> hook<br> <li> Applied <code>borderless</code> class conditionally to wrapper element</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3195/files#diff-265babc8f249155c5daff1c98b8cf30e783ed215bb88af0e72882f91f32646a2">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

