### PR TITLE
chore: add @vibe/hooks to postinstall build scope

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "lerna run lint",
     "test": "lerna run test",
     "storybook": "lerna run storybook --parallel --stream",
-    "postinstall": "lerna run build --scope={vibe-storybook-components,@vibe/icons,@vibe/hooks}"
+    "postinstall": "lerna run build --scope={vibe-storybook-components,@vibe/shared,@vibe/icons,@vibe/hooks}"
   },
   "devDependencies": {
     "@size-limit/preset-small-lib": "^11.2.0",


### PR DESCRIPTION
### **User description**
take a look at https://github.com/mondaycom/vibe/actions/runs/19932001028/job/57146545077?pr=3197 when running `testkit` without changes to `core`, the `hooks` package isn't being built

https://monday.monday.com/boards/3532714909/pulses/10703147379

FYI @hanan-monday


___

### **PR Type**
Enhancement


___

### **Description**
- Add @vibe/hooks and @vibe/shared to postinstall build scope

- Ensures hooks package builds when testkit is modified

- Fixes missing dependencies in CI/CD pipeline


___

### Diagram Walkthrough


```mermaid
flowchart LR
  postinstall["postinstall script"] -- "builds" --> storybook["vibe-storybook-components"]
  postinstall -- "builds" --> shared["@vibe/shared"]
  postinstall -- "builds" --> icons["@vibe/icons"]
  postinstall -- "builds" --> hooks["@vibe/hooks"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Expand postinstall build scope with new packages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

<ul><li>Updated postinstall script to include @vibe/shared and @vibe/hooks in <br>build scope<br> <li> Previously only built vibe-storybook-components and @vibe/icons<br> <li> Ensures all required packages are built during installation</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3198/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

