### PR TITLE
fix(Slider): support fractional step values during drag and rail click

### DIFF
--- a/packages/core/src/components/Slider/SliderHelpers.ts
+++ b/packages/core/src/components/Slider/SliderHelpers.ts
@@ -98,7 +98,7 @@ export function getNearest(newValue: number, ranged: boolean, value: number | nu
 export function moveToPx(offsetInPx: number, min: number, max: number, railCoords: { width: number }, step: number) {
   const valuePoints = max - min;
   const pxToValuePoints = railCoords.width / valuePoints;
-  const offsetInValuePoints = Math.round(offsetInPx / pxToValuePoints) + min;
+  const offsetInValuePoints = offsetInPx / pxToValuePoints + min;
   const newValue = Math.round(offsetInValuePoints / step) * step;
   if (newValue < min) {
     return min;

--- a/packages/core/src/components/Slider/__tests__/Slider-helpers.test.ts
+++ b/packages/core/src/components/Slider/__tests__/Slider-helpers.test.ts
@@ -1,5 +1,37 @@
 import { describe, it, expect } from "vitest";
-import { calculatePageStep } from "../SliderHelpers";
+import { calculatePageStep, moveToPx } from "../SliderHelpers";
+
+describe("Check moveToPx helper", () => {
+  const railCoords = { width: 200 };
+
+  // table: expected, offsetInPx, min, max, step
+  it.each([
+    // integer step, min=0 - existing behavior preserved
+    [0, 0, 0, 100, 1],
+    [50, 100, 0, 100, 1],
+    [100, 200, 0, 100, 1],
+    [25, 50, 0, 100, 1],
+    // integer step, shifted min - existing behavior preserved
+    [10, 0, 10, 20, 1],
+    [15, 100, 10, 20, 1],
+    [20, 200, 10, 20, 1],
+    // fractional step - must snap to sub-integer values
+    [2.5, 50, 0, 10, 0.5],
+    [5, 100, 0, 10, 0.5],
+    [7.5, 150, 0, 10, 0.5],
+    [0.5, 10, 0, 10, 0.5],
+    // fractional step with 0.1 granularity
+    [1.2, 24, 0, 10, 0.1],
+    [5, 100, 0, 10, 0.1],
+    // clamp to min/max
+    [0, -50, 0, 100, 1],
+    [100, 300, 0, 100, 1],
+    [0, -10, 0, 10, 0.5],
+    [10, 500, 0, 10, 0.5]
+  ])("should return (%s) for: offsetInPx=%i, min=%i, max=%i, step=%s", (expected, offsetInPx, min, max, step) => {
+    expect(moveToPx(offsetInPx, min, max, railCoords, step)).toBeCloseTo(expected, 5);
+  });
+});
 
 describe("Check calculatePageStep helper", () => {
   // table: expected, min, max, step


### PR DESCRIPTION
### **User description**
## Summary

Fixes a bug where fractional `step` values (e.g. `0.5`, `0.1`) were silently ignored during pointer-driven interactions (drag, rail click). Only integer-sized jumps were reachable even when a sub-integer `step` was configured.

### Root cause

`moveToPx` in `SliderHelpers.ts` rounded the raw pointer value to the nearest integer **before** applying step snapping:

```ts
// before
const offsetInValuePoints = Math.round(offsetInPx / pxToValuePoints) + min;
const newValue = Math.round(offsetInValuePoints / step) * step;
```

By the time the `step` snap ran, the value was already quantized to an integer, so `Math.round(3 / 0.5) * 0.5` stayed at `3`. Keyboard arrows worked correctly because they go through a different code path (`increaseValue`/`decreaseValue`) that doesn't touch `moveToPx`.

### Fix

Keep the raw value fractional and let the existing step snap do its job:

```ts
// after
const offsetInValuePoints = offsetInPx / pxToValuePoints + min;
const newValue = Math.round(offsetInValuePoints / step) * step;
```

- For integer `step`, behavior is identical: `Math.round(X.Y / 1) * 1` produces the same result as the previous pre-rounding.
- For fractional `step`, sub-integer positions are now reachable via drag and rail click, matching the keyboard behavior and the prop's JSDoc description.

### Tests

Added 15 parametrized cases to `Slider-helpers.test.ts` covering:
- Integer step with `min=0` and with shifted `min` (regression coverage for existing behavior).
- Fractional step (`0.5`, `0.1`) producing sub-integer snap points.
- Min/max clamping on both ends.

### Reproduction (before the fix)

```tsx
<Slider min={0} max={10} step={0.5} defaultValue={0} />
```

Dragging the thumb jumps only in whole units (`0, 1, 2, ...`). Pressing → on the keyboard correctly yields `0.5, 1.0, 1.5, ...`. After this fix, drag and click behave the same as keyboard.

## Test plan

- [x] Added unit tests for `moveToPx` covering integer step, fractional step (0.5 and 0.1), shifted `min`, and clamping — all 30 helper tests pass locally.
- [ ] CI runs the full Slider test suite (snapshot + ranged + non-ranged).
- [ ] Manual verification in Storybook: drag a slider with `step={0.5}` and confirm 0.5 increments.


Made with [Cursor](https://cursor.com)


___

### **PR Type**
Bug fix, Tests


___

### **Description**
- Remove premature rounding in `moveToPx` to support fractional steps

- Fractional step values now work correctly during drag and rail click

- Add 16 parametrized test cases covering integer and fractional steps

- Preserve existing behavior for integer steps while fixing sub-integer snapping


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Pointer interaction<br/>drag/rail click"] -->|offsetInPx| B["moveToPx helper"]
  B -->|removed premature<br/>Math.round| C["Raw fractional value"]
  C -->|step snapping<br/>Math.round/step*step| D["Correct snap point<br/>integer or fractional"]
  D --> E["Slider value updated"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>SliderHelpers.ts</strong><dd><code>Remove premature rounding in moveToPx helper</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Slider/SliderHelpers.ts

<ul><li>Removed <code>Math.round()</code> call on <code>offsetInValuePoints</code> calculation<br> <li> Changed from <code>Math.round(offsetInPx / pxToValuePoints) + min</code> to <br><code>offsetInPx / pxToValuePoints + min</code><br> <li> Allows step snapping logic to handle both integer and fractional steps <br>correctly<br> <li> Preserves existing behavior for integer steps while enabling <br>fractional step support</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3350/files#diff-29c242e0932368aa94816993dc9a3a5a5db3d694e992a65397cecf3155cb76cc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Slider-helpers.test.ts</strong><dd><code>Add comprehensive moveToPx test coverage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Slider/__tests__/Slider-helpers.test.ts

<ul><li>Import <code>moveToPx</code> function for testing<br> <li> Add new test suite "Check moveToPx helper" with 16 parametrized test <br>cases<br> <li> Cover integer step with <code>min=0</code> (4 cases) and shifted <code>min</code> (3 cases)<br> <li> Cover fractional steps with <code>0.5</code> granularity (4 cases) and <code>0.1</code> <br>granularity (2 cases)<br> <li> Cover min/max clamping on both ends (4 cases)</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3350/files#diff-d29d05cc6815f822ae6222ca1cef7722541b268e6225bc1fbb394b2c22447f73">+33/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

