### PR TITLE
fix(Label): align celebration animation stroke radius with small size

### DIFF
--- a/packages/core/src/components/Label/Label.tsx
+++ b/packages/core/src/components/Label/Label.tsx
@@ -171,15 +171,8 @@ const Label = forwardRef<HTMLElement, LabelProps>(
 
     // Celebration animation is applied only for line kind
     if (isCelebrationAnimation && kind === "line") {
-      // Small labels use a 2px border-radius (see Label.module.scss `.label.small`),
-      // while medium labels use --border-radius-small (4px). Pass the matching value so the
-      // animated stroke follows the label's actual rounded corners.
-      const labelBorderRadius = size === "small" ? 2 : 4;
       return (
-        <LabelCelebrationAnimation
-          borderRadius={labelBorderRadius}
-          onAnimationEnd={() => setIsCelebrationAnimation(false)}
-        >
+        <LabelCelebrationAnimation onAnimationEnd={() => setIsCelebrationAnimation(false)}>
           {label}
         </LabelCelebrationAnimation>
       );

--- a/packages/core/src/components/Label/Label.tsx
+++ b/packages/core/src/components/Label/Label.tsx
@@ -171,8 +171,15 @@ const Label = forwardRef<HTMLElement, LabelProps>(
 
     // Celebration animation is applied only for line kind
     if (isCelebrationAnimation && kind === "line") {
+      // Small labels use a 2px border-radius (see Label.module.scss `.label.small`),
+      // while medium labels use --border-radius-small (4px). Pass the matching value so the
+      // animated stroke follows the label's actual rounded corners.
+      const labelBorderRadius = size === "small" ? 2 : 4;
       return (
-        <LabelCelebrationAnimation onAnimationEnd={() => setIsCelebrationAnimation(false)}>
+        <LabelCelebrationAnimation
+          borderRadius={labelBorderRadius}
+          onAnimationEnd={() => setIsCelebrationAnimation(false)}
+        >
           {label}
         </LabelCelebrationAnimation>
       );

--- a/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
+++ b/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
@@ -3,7 +3,6 @@ import cx from "classnames";
 import { useResizeObserver } from "@vibe/hooks";
 import styles from "./LabelCelebrationAnimation.module.scss";
 
-const DEFAULT_BORDER_RADIUS = 4;
 const DEFAULT_STROKE_WIDTH = 1;
 
 export interface LabelCelebrationAnimationProps {
@@ -15,18 +14,27 @@ export interface LabelCelebrationAnimationProps {
    * Callback fired when the celebration animation ends.
    */
   onAnimationEnd: () => void;
-  /**
-   * Border radius of the wrapped label, in pixels. Used to draw the animated stroke so it follows
-   * the label's actual rounded corners (e.g. small labels use a 2px radius, medium labels 4px).
-   */
-  borderRadius?: number;
 }
 
-function LabelCelebrationAnimation({
-  children,
-  onAnimationEnd,
-  borderRadius = DEFAULT_BORDER_RADIUS
-}: LabelCelebrationAnimationProps) {
+interface CornerRadii {
+  tl: number;
+  tr: number;
+  br: number;
+  bl: number;
+}
+
+function readCornerRadii(element: HTMLElement | null | undefined): CornerRadii {
+  if (!element) return { tl: 0, tr: 0, br: 0, bl: 0 };
+  const cs = getComputedStyle(element);
+  return {
+    tl: parseFloat(cs.borderTopLeftRadius) || 0,
+    tr: parseFloat(cs.borderTopRightRadius) || 0,
+    br: parseFloat(cs.borderBottomRightRadius) || 0,
+    bl: parseFloat(cs.borderBottomLeftRadius) || 0
+  };
+}
+
+function LabelCelebrationAnimation({ children, onAnimationEnd }: LabelCelebrationAnimationProps) {
   const wrapperRef = useRef<HTMLDivElement>();
   const childRef = useRef<HTMLDivElement>();
 
@@ -36,15 +44,17 @@ function LabelCelebrationAnimation({
     ({ borderBoxSize }: { borderBoxSize: { blockSize: number; inlineSize: number } }) => {
       const { blockSize: height, inlineSize: width } = borderBoxSize || {};
 
-      if (wrapperRef.current) {
-        const d = getPath({ width, height, borderRadius });
-        setPath(d);
+      if (!wrapperRef.current || !width || !height) return;
 
-        const perimeter = getPerimeter({ width, height, borderRadius });
-        wrapperRef.current.style.setProperty("--container-perimeter", String(perimeter));
-      }
+      // Read the actual rendered radii from the child so the stroke matches the label's
+      // shape regardless of size or token overrides, and handles non-uniform corners
+      // (e.g. labels with a leg, where one corner is squared off).
+      const radii = readCornerRadii(childRef.current);
+
+      setPath(getPath({ width, height, radii }));
+      wrapperRef.current.style.setProperty("--container-perimeter", String(getPerimeter({ width, height, radii })));
     },
-    [borderRadius]
+    []
   );
 
   useResizeObserver({
@@ -77,38 +87,34 @@ export default LabelCelebrationAnimation;
 function getPath({
   width,
   height,
-  borderRadius = DEFAULT_BORDER_RADIUS,
+  radii,
   strokeWidth = DEFAULT_STROKE_WIDTH
 }: {
   width: number;
   height: number;
-  borderRadius?: number;
+  radii: CornerRadii;
   strokeWidth?: number;
 }) {
+  const { tl, tr, br, bl } = radii;
   const offset = strokeWidth / 2;
 
-  return `M ${width - strokeWidth / 2}, ${borderRadius} V ${
-    height - borderRadius
-  } A ${borderRadius} ${borderRadius} 0 0 1 ${width - borderRadius} ${height - strokeWidth / 2} H ${
-    borderRadius + offset
-  } A ${borderRadius} ${borderRadius} 0 0 1 ${strokeWidth / 2} ${height - borderRadius} V ${
-    borderRadius + offset
-  } A ${borderRadius} ${borderRadius} 0 0 1 ${borderRadius} ${strokeWidth / 2} L ${width - borderRadius}, ${
+  // Trace the perimeter clockwise: start on the right edge below the top-right corner,
+  // arc through each corner using that corner's own radius.
+  return `M ${width - strokeWidth / 2}, ${tr} V ${height - br} A ${br} ${br} 0 0 1 ${width - br} ${
+    height - strokeWidth / 2
+  } H ${bl + offset} A ${bl} ${bl} 0 0 1 ${strokeWidth / 2} ${height - bl} V ${
+    tl + offset
+  } A ${tl} ${tl} 0 0 1 ${tl} ${strokeWidth / 2} L ${width - tr}, ${
     strokeWidth / 2
-  } A ${borderRadius} ${borderRadius} 0 0 1 ${width - strokeWidth / 2} ${borderRadius} Z`;
+  } A ${tr} ${tr} 0 0 1 ${width - strokeWidth / 2} ${tr} Z`;
 }
 
-function getPerimeter({
-  width,
-  height,
-  borderRadius = DEFAULT_BORDER_RADIUS
-}: {
-  width: number;
-  height: number;
-  borderRadius?: number;
-}) {
-  const straightWidth = width - 2 * borderRadius;
-  const straightHeight = height - 2 * borderRadius;
-  const cornerCircumference = 2 * Math.PI * borderRadius;
-  return cornerCircumference + 2 * straightWidth + 2 * straightHeight;
+function getPerimeter({ width, height, radii }: { width: number; height: number; radii: CornerRadii }) {
+  const { tl, tr, br, bl } = radii;
+  const totalRadius = tl + tr + br + bl;
+  // Straight segments: full perimeter minus the radius slice taken from each end of every edge.
+  const straightEdges = 2 * width + 2 * height - 2 * totalRadius;
+  // Each corner contributes a quarter-circle of its own radius.
+  const corners = (Math.PI / 2) * totalRadius;
+  return straightEdges + corners;
 }

--- a/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
+++ b/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
@@ -46,10 +46,12 @@ function LabelCelebrationAnimation({ children, onAnimationEnd }: LabelCelebratio
 
       if (!wrapperRef.current || !width || !height) return;
 
-      // Read the actual rendered radii from the child so the stroke matches the label's
-      // shape regardless of size or token overrides, and handles non-uniform corners
-      // (e.g. labels with a leg, where one corner is squared off).
-      const radii = readCornerRadii(childRef.current);
+      // Border-radius is applied to the inner Text element (marked with data-celebration-text),
+      // not the outer wrapper that childRef points to. Resolve the inner element so the stroke
+      // matches the label's actual shape regardless of size, token overrides, or non-uniform
+      // corners (e.g. labels with a leg, where one corner is squared off).
+      const shapeElement = childRef.current?.querySelector<HTMLElement>("[data-celebration-text]") ?? childRef.current;
+      const radii = readCornerRadii(shapeElement);
 
       setPath(getPath({ width, height, radii }));
       wrapperRef.current.style.setProperty("--container-perimeter", String(getPerimeter({ width, height, radii })));

--- a/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
+++ b/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
@@ -98,25 +98,37 @@ function getPath({
   strokeWidth?: number;
 }) {
   const { tl, tr, br, bl } = radii;
+  // Inset every edge by half the stroke width so the 1px stroke stays fully inside the label box.
   const offset = strokeWidth / 2;
 
-  // Trace the perimeter clockwise: start on the right edge below the top-right corner,
-  // arc through each corner using that corner's own radius.
-  return `M ${width - strokeWidth / 2}, ${tr} V ${height - br} A ${br} ${br} 0 0 1 ${width - br} ${
-    height - strokeWidth / 2
-  } H ${bl + offset} A ${bl} ${bl} 0 0 1 ${strokeWidth / 2} ${height - bl} V ${
-    tl + offset
-  } A ${tl} ${tl} 0 0 1 ${tl} ${strokeWidth / 2} L ${width - tr}, ${
-    strokeWidth / 2
-  } A ${tr} ${tr} 0 0 1 ${width - strokeWidth / 2} ${tr} Z`;
+  // Trace the rounded rectangle clockwise, starting just below the top-right corner on the right
+  // edge. Each edge endpoint is inset by `offset` and each corner is a clean quarter-circle of its
+  // own radius, so the drawn length matches getPerimeter() exactly and the stroke loops smoothly.
+  return `M ${width - offset} ${offset + tr} V ${height - offset - br} A ${br} ${br} 0 0 1 ${width - offset - br} ${
+    height - offset
+  } H ${offset + bl} A ${bl} ${bl} 0 0 1 ${offset} ${height - offset - bl} V ${offset + tl} A ${tl} ${tl} 0 0 1 ${
+    offset + tl
+  } ${offset} H ${width - offset - tr} A ${tr} ${tr} 0 0 1 ${width - offset} ${offset + tr} Z`;
 }
 
-function getPerimeter({ width, height, radii }: { width: number; height: number; radii: CornerRadii }) {
+function getPerimeter({
+  width,
+  height,
+  radii,
+  strokeWidth = DEFAULT_STROKE_WIDTH
+}: {
+  width: number;
+  height: number;
+  radii: CornerRadii;
+  strokeWidth?: number;
+}) {
   const { tl, tr, br, bl } = radii;
   const totalRadius = tl + tr + br + bl;
-  // Straight segments: full perimeter minus the radius slice taken from each end of every edge.
-  const straightEdges = 2 * width + 2 * height - 2 * totalRadius;
-  // Each corner contributes a quarter-circle of its own radius.
+  // Mirror getPath(): every edge loses 2*offset to the stroke inset at its two ends (4 edges ->
+  // 4 * strokeWidth total) plus its two corner radii, and each corner adds a quarter-circle of its
+  // own radius. Keeping this equal to the drawn path length makes stroke-dasharray land exactly on
+  // the seam, so the looping stroke doesn't overshoot and jump.
+  const straightEdges = 2 * width + 2 * height - 4 * strokeWidth - 2 * totalRadius;
   const corners = (Math.PI / 2) * totalRadius;
   return straightEdges + corners;
 }

--- a/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
+++ b/packages/core/src/components/Label/LabelCelebrationAnimation.tsx
@@ -15,9 +15,18 @@ export interface LabelCelebrationAnimationProps {
    * Callback fired when the celebration animation ends.
    */
   onAnimationEnd: () => void;
+  /**
+   * Border radius of the wrapped label, in pixels. Used to draw the animated stroke so it follows
+   * the label's actual rounded corners (e.g. small labels use a 2px radius, medium labels 4px).
+   */
+  borderRadius?: number;
 }
 
-function LabelCelebrationAnimation({ children, onAnimationEnd }: LabelCelebrationAnimationProps) {
+function LabelCelebrationAnimation({
+  children,
+  onAnimationEnd,
+  borderRadius = DEFAULT_BORDER_RADIUS
+}: LabelCelebrationAnimationProps) {
   const wrapperRef = useRef<HTMLDivElement>();
   const childRef = useRef<HTMLDivElement>();
 
@@ -28,14 +37,14 @@ function LabelCelebrationAnimation({ children, onAnimationEnd }: LabelCelebratio
       const { blockSize: height, inlineSize: width } = borderBoxSize || {};
 
       if (wrapperRef.current) {
-        const d = getPath({ width, height });
+        const d = getPath({ width, height, borderRadius });
         setPath(d);
 
-        const perimeter = getPerimeter({ width, height });
+        const perimeter = getPerimeter({ width, height, borderRadius });
         wrapperRef.current.style.setProperty("--container-perimeter", String(perimeter));
       }
     },
-    []
+    [borderRadius]
   );
 
   useResizeObserver({


### PR DESCRIPTION
### **User description**
Fixes the celebration animation overflowing on small labels — it was drawing 4px corners around a 2px-radius box. Now passes the label's actual border-radius through to the animation.

Closes #3128


___

### **PR Type**
Bug fix


___

### **Description**
- Dynamically read corner radii from rendered element instead of hardcoding

- Support non-uniform border-radius on labels with legs or CSS overrides

- Fix celebration stroke path to match label's actual shape and size

- Align stroke-dasharray with drawn path length to prevent animation jumps


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hardcoded 4px radius"] -->|Remove| B["Read from computed style"]
  B -->|Query inner element| C["Get actual corner radii"]
  C -->|Pass to path generator| D["Generate matching SVG path"]
  D -->|Calculate perimeter| E["Align stroke-dasharray"]
  E -->|Result| F["Smooth looping animation"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>LabelCelebrationAnimation.tsx</strong><dd><code>Dynamic corner radii and path alignment fixes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Label/LabelCelebrationAnimation.tsx

<ul><li>Removed hardcoded <code>DEFAULT_BORDER_RADIUS</code> constant<br> <li> Added <code>CornerRadii</code> interface to track individual corner radii (tl, tr, <br>br, bl)<br> <li> Implemented <code>readCornerRadii()</code> function to dynamically read computed <br>border-radius values from the styled inner element via <br><code>getComputedStyle()</code><br> <li> Updated <code>getPath()</code> to accept individual corner radii and generate SVG <br>path with proper insets for stroke width, ensuring smooth animation<br> <li> Updated <code>getPerimeter()</code> to calculate perimeter based on actual corner <br>radii and stroke width, fixing animation loop alignment<br> <li> Modified resize observer callback to query the inner <br><code>[data-celebration-text]</code> element for accurate border-radius values</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3353/files#diff-394ef28a11cd0389be0c32b667a27512cd0d4148fabb3f6878f1aa7c4feb4399">+53/-24</a>&nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

