### PR TITLE
docs(search): fix broken StorybookLink size reference

### DIFF
--- a/packages/docs/src/pages/components/Search/Search.mdx
+++ b/packages/docs/src/pages/components/Search/Search.mdx
@@ -38,7 +38,7 @@ import { Search } from "@vibe/core";
 
 <Tip title="Not what you were looking for?">
   <span>If you need to filter results from a long list, consider using the </span>
-  <StorybookLink page="Components/Combobox" size={StorybookLinkSize.small}>
+  <StorybookLink page="Components/Combobox" size={StorybookLink.sizes.SMALL}>
     <span>Combobox</span>
   </StorybookLink>
   <span> component.</span>


### PR DESCRIPTION
### **User description**
The Search docs referenced a non-existent `StorybookLinkSize` identifier, which breaks the page at render time.

This switches the Combobox hint link to `StorybookLink.sizes.SMALL`, matching the exported StorybookLink API.

Resolves #3354


___

### **PR Type**
Documentation, Bug fix


___

### **Description**
- Fix broken StorybookLink size reference in Search docs

- Replace non-existent `StorybookLinkSize.small` with correct `StorybookLink.sizes.SMALL`

- Align with actual StorybookLink exported API


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Search.mdx docs"] -- "Replace StorybookLinkSize.small" --> B["StorybookLink.sizes.SMALL"]
  B -- "Matches exported API" --> C["Correct reference"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Search.mdx</strong><dd><code>Fix StorybookLink size reference in Search docs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/components/Search/Search.mdx

<ul><li>Fixed broken StorybookLink size prop reference<br> <li> Changed from non-existent <code>StorybookLinkSize.small</code> to correct <br><code>StorybookLink.sizes.SMALL</code><br> <li> Ensures Combobox hint link uses valid API</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3355/files#diff-e54bd69a89de5f1cc5f28860ce560be47660bd83e31a541c1e3147ac7406eb16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

