### PR TITLE
feat(core): add storyUrl and previewUrl to component metadata

### DIFF
--- a/packages/core/src/scripts/generate-metadata.ts
+++ b/packages/core/src/scripts/generate-metadata.ts
@@ -10,6 +10,8 @@ console.log("__dirname", __dirname);
 const CACHE_FILE = path.resolve(__dirname, ".metadata-cache.json");
 console.log("CACHE_FILE", CACHE_FILE);
 
+const STORYBOOK_BASE_URL = "https://vibe.monday.com";
+
 const IS_CI = process.env.CI === "true" || process.env.CI === "True";
 
 if (IS_CI) {
@@ -50,6 +52,8 @@ type FinalOutput = Array<{
   import: string;
   parentComponent?: string;
   subComponents?: string[];
+  storyUrl?: string;
+  previewUrl?: string;
   props: Props;
 }>;
 
@@ -390,10 +394,79 @@ function findSubComponents(filePath: string, allFiles: string[]): string[] {
     .map(f => path.basename(f, path.extname(f)));
 }
 
+interface StoryMeta {
+  storyUrl: string;
+  previewUrl?: string;
+}
+
+function toStorySlug(exportName: string): string {
+  return exportName
+    .replace(/([a-z])([A-Z])/g, "$1-$2")
+    .toLowerCase()
+    .replace(/\s+/g, "-");
+}
+
+function findFirstStoryExport(content: string): string | null {
+  const re = /export\s+(?:const|function)\s+(\w+)/g;
+  let match;
+  while ((match = re.exec(content)) !== null) {
+    const name = match[1];
+    if (name !== "default" && name !== "meta" && /^[A-Z]/.test(name)) return name;
+  }
+  return null;
+}
+
+function buildStoryMap(): Map<string, StoryMeta> {
+  const docsComponentsDir = path.resolve(__dirname, "../../../docs/src/pages/components");
+  const storyMap = new Map<string, StoryMeta>();
+
+  if (!fs.existsSync(docsComponentsDir)) {
+    console.warn(`[storyMap] Docs components directory not found at ${docsComponentsDir}, skipping`);
+    return storyMap;
+  }
+
+  const titleRe = /title:\s*['"]([^'"]+)['"]/;
+  const dirs = fs.readdirSync(docsComponentsDir, { withFileTypes: true }).filter(d => d.isDirectory());
+
+  for (const dir of dirs) {
+    const dirPath = path.join(docsComponentsDir, dir.name);
+    const storyFiles = fs.readdirSync(dirPath).filter(f => f.endsWith(".stories.tsx") || f.endsWith(".stories.ts"));
+
+    for (const file of storyFiles) {
+      const content = fs.readFileSync(path.join(dirPath, file), "utf-8");
+      const match = titleRe.exec(content);
+      if (!match) continue;
+
+      const title = match[1];
+      const titleSlug = title.toLowerCase().replace(/\//g, "-").replace(/ /g, "-");
+      const componentName = title.split("/").pop()!;
+      const key = componentName.toLowerCase();
+
+      if (!storyMap.has(key)) {
+        const storyUrl = `${STORYBOOK_BASE_URL}/?path=/docs/${titleSlug}--docs`;
+        const firstStory = findFirstStoryExport(content);
+        const previewUrl = firstStory
+          ? `${STORYBOOK_BASE_URL}/iframe.html?id=${titleSlug}--${toStorySlug(
+              firstStory
+            )}&viewMode=story&shortcuts=false&singleStory=true`
+          : undefined;
+        storyMap.set(key, { storyUrl, previewUrl });
+      }
+    }
+  }
+
+  console.log(`[storyMap] Built story map: ${storyMap.size} entries`);
+  return storyMap;
+}
+
 /**
  * Merges aggregator records with docgen results and flattens the structure
  */
-function mergeResults(aggregator: AggregatorRecord[], docgen: DocgenResult[]): FinalOutput {
+function mergeResults(
+  aggregator: AggregatorRecord[],
+  docgen: DocgenResult[],
+  storyMap: Map<string, StoryMeta>
+): FinalOutput {
   const docgenMap = new Map<string, DocgenResult>();
   for (const d of docgen) {
     docgenMap.set(d.filePath, d);
@@ -429,7 +502,9 @@ function mergeResults(aggregator: AggregatorRecord[], docgen: DocgenResult[]): F
         props: filteredProps,
         import: `import { ${component.displayName} } from "${importPath}"`,
         parentComponent: getParentComponent(toRelativePath(agg.filePath)),
-        subComponents: findSubComponents(toRelativePath(agg.filePath), allFilePaths.map(toRelativePath))
+        subComponents: findSubComponents(toRelativePath(agg.filePath), allFilePaths.map(toRelativePath)),
+        storyUrl: storyMap.get(component.displayName.toLowerCase())?.storyUrl,
+        previewUrl: storyMap.get(component.displayName.toLowerCase())?.previewUrl
       };
     });
   });
@@ -486,8 +561,11 @@ async function main() {
     const docgenResults = await runReactDocgenOnFiles(finalFilePaths);
     console.log(`Successfully processed ${docgenResults.length} files`);
 
+    console.log("Building story map...");
+    const storyMap = buildStoryMap();
+
     console.log("Merging results...");
-    const finalJson = mergeResults(aggregatorRecords, docgenResults);
+    const finalJson = mergeResults(aggregatorRecords, docgenResults, storyMap);
     console.log(`Final output contains ${finalJson.length} component entries`);
 
     const outPath = path.resolve(__dirname, "../../dist/metadata.json");


### PR DESCRIPTION
### **User description**
## Summary
- Adds `storyUrl` and `previewUrl` fields to the generated `metadata.json` for each component
- Scans docs story files (`packages/docs/src/pages/components/`) to build a map of component names to their Storybook docs URL and first-story preview iframe URL
- Used by UI Hub to show direct Storybook links and embedded previews in the component detail sidebar

## Test plan
- [ ] Run `npx ts-node packages/core/src/scripts/generate-metadata.ts` and verify `dist/metadata.json` includes `storyUrl` and `previewUrl` for components with stories
- [ ] Verify existing fields (`displayName`, `props`, `import`, etc.) are unchanged
- [ ] Verify components without stories have `undefined` storyUrl/previewUrl (no breakage)


___

### **PR Type**
Enhancement


___

### **Description**
- Adds `storyUrl` and `previewUrl` fields to component metadata

- Scans docs story files to build Storybook URL mappings

- Generates direct documentation and preview iframe URLs

- Enables UI Hub to display embedded previews and links


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Story Files<br/>packages/docs/src/pages/components"] -->|"buildStoryMap()"| B["Story Map<br/>component name to URLs"]
  B -->|"mergeResults()"| C["Metadata JSON<br/>with storyUrl & previewUrl"]
  D["Aggregator Records"] -->|"mergeResults()"| C
  E["Docgen Results"] -->|"mergeResults()"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-metadata.ts</strong><dd><code>Add Storybook URL extraction and metadata enrichment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/scripts/generate-metadata.ts

<ul><li>Added <code>STORYBOOK_BASE_URL</code> constant for Storybook documentation links<br> <li> Extended <code>FinalOutput</code> type with optional <code>storyUrl</code> and <code>previewUrl</code> fields<br> <li> Implemented <code>buildStoryMap()</code> function to scan story files and extract <br>metadata<br> <li> Added helper functions <code>toStorySlug()</code> and <code>findFirstStoryExport()</code> for <br>URL generation<br> <li> Updated <code>mergeResults()</code> to accept and use story map for enriching <br>component metadata<br> <li> Modified main flow to build story map before merging results</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3357/files#diff-ca09b846e15c726bc06e8be1a000039932c5927521e312499d47aa3513d44722">+81/-3</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

