### PR TITLE
fix(mcp): always use @vibe/core as import path in metadata

### DIFF
--- a/packages/core/src/scripts/generate-metadata.ts
+++ b/packages/core/src/scripts/generate-metadata.ts
@@ -489,9 +489,7 @@ function mergeResults(
         }
       }
 
-      // Determine correct import path: if file is from packages/components/{pkg}/, use @vibe/{pkg}
-      const pkgMatch = agg.filePath.match(/\/components\/([^/]+)\/src\//);
-      const importPath = pkgMatch ? `@vibe/${pkgMatch[1]}` : `@vibe/core${agg.aggregator === "next" ? "/next" : ""}`;
+      const importPath = `@vibe/core${agg.aggregator === "next" ? "/next" : ""}`;
 
       return {
         filePath: toRelativePath(agg.filePath),


### PR DESCRIPTION
### **User description**
## Summary
- Fix incorrect `import` field in `metadata.json` for 16 components that live in sub-packages (`@vibe/button`, `@vibe/typography`, `@vibe/layout`, etc.)
- The metadata generation script was resolving the import path based on the component's source file location, which pointed to internal sub-packages instead of `@vibe/core`
- Since this metadata is generated for `@vibe/core` and all components are re-exported from it, the import should always reference `@vibe/core`

**Before:** `import { Button } from "@vibe/button"`  
**After:** `import { Button } from "@vibe/core"`

Affected components: Button, Box, Flex, Text, Heading, Icon, CustomSvgIcon, IconButton, Tooltip, Dialog, DialogContentContainer, Clickable, ClickableWrapper, Loader, LayerProvider

## Test plan
- [x] Ran `build:metadata` locally — all 107 components now have `@vibe/core` imports
- [ ] Verify `@vibe/mcp` `list-vibe-public-components` returns correct imports after publish


___

### **PR Type**
Bug fix


___

### **Description**
- Fix incorrect import paths in metadata for 16 sub-package components

- Always use @vibe/core as import path instead of internal packages

- Simplify metadata generation script logic for import resolution


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Metadata Generation Script"] -->|Previously| B["Resolved to Sub-packages<br/>@vibe/button, @vibe/typography"]
  A -->|Now| C["Always Uses @vibe/core<br/>for all components"]
  C --> D["Correct Public API<br/>Import Path"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate-metadata.ts</strong><dd><code>Simplify import path to always use @vibe/core</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/scripts/generate-metadata.ts

<ul><li>Removed conditional logic that resolved import paths based on file <br>location<br> <li> Simplified import path generation to always use <code>@vibe/core</code> (or <br><code>@vibe/core/next</code> for next aggregator)<br> <li> Deleted regex pattern matching for sub-package detection in file paths</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3358/files#diff-ca09b846e15c726bc06e8be1a000039932c5927521e312499d47aa3513d44722">+1/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

