### PR TITLE
fix: allow DatePicker dependency with React 19

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -110,7 +110,7 @@
     "date-fns": "^2.30.0",
     "downshift": "^9.0.8",
     "es-toolkit": "^1.39.10",
-    "react-day-picker": "^8.8.0",
+    "react-day-picker": "^8.10.2",
     "react-focus-lock": "^2.13.2",
     "react-inlinesvg": "^4.1.3",
     "react-is": "^16.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18031,15 +18031,10 @@ react-dates@21.8.0:
     react-with-styles "^4.1.0"
     react-with-styles-interface-css "^6.0.0"
 
-react-day-picker@^8.10.2:
+react-day-picker@^8.10.2, react-day-picker@^8.8.0:
   version "8.10.2"
   resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.10.2.tgz#12b7893d5b1bd6ba7f055498614c1c5aaf50accd"
   integrity sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==
-
-react-day-picker@^8.8.0:
-  version "8.10.1"
-  resolved "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz#4762ec298865919b93ec09ba69621580835b8e80"
-  integrity sha512-TMx7fNbhLk15eqcMt+7Z7S2KF7mfTId/XJDjKE8f+IUcFn0l08/kI4FiYTL/0yuOLmEcbR4Fwe3GJf/NiiMnPA==
 
 react-docgen-typescript@^2.2.2:
   version "2.2.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18031,6 +18031,11 @@ react-dates@21.8.0:
     react-with-styles "^4.1.0"
     react-with-styles-interface-css "^6.0.0"
 
+react-day-picker@^8.10.2:
+  version "8.10.2"
+  resolved "https://registry.yarnpkg.com/react-day-picker/-/react-day-picker-8.10.2.tgz#12b7893d5b1bd6ba7f055498614c1c5aaf50accd"
+  integrity sha512-LK68OTbHB3oJNhl9cA0qVizzp3o26w61YSjAFkYi67N86iro32wx86kSNeFU/hq+gI8m1yzWhnomMLfZ041RzQ==
+
 react-day-picker@^8.8.0:
   version "8.10.1"
   resolved "https://registry.npmjs.org/react-day-picker/-/react-day-picker-8.10.1.tgz#4762ec298865919b93ec09ba69621580835b8e80"


### PR DESCRIPTION
### **User description**
Updates `@vibe/core` from `react-day-picker@^8.8.0` to `^8.10.2`.

That keeps the existing v8 DatePicker API in place, but picks up `react-day-picker@8.10.2`, whose React peer dependency includes React 19. This avoids turning the fix into a larger v9 DatePicker migration while still addressing the peer dependency conflict reported in the issue.

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

Resolves #3347

Verification:

- `corepack yarn install --frozen-lockfile --ignore-scripts`
- `corepack yarn why react-day-picker` shows `@vibe/core` on `react-day-picker@8.10.2`
- `node -e "const root=require('./node_modules/react-day-picker/package.json'); console.log(root.version, root.peerDependencies.react)"`
- `corepack yarn workspace @vibe/core test src/components/DatePicker/__tests__/utils.test.ts --run`
- `git diff --check`

I also tried broader local checks, but this repo's local setup hit Windows-specific setup issues before reaching this change: `postinstall` invokes `rm -rf` from PowerShell, and `@vibe/core build:esm` then could not resolve unbuilt workspace package declarations. The focused dependency/lockfile checks above passed.

This was prepared with Codex assistance and manually reviewed before opening.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updates `react-day-picker` dependency to support React 19

- Maintains existing v8 DatePicker API compatibility

- Resolves peer dependency conflict with React 19

- Avoids larger v9 migration while addressing issue


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["react-day-picker@8.8.0<br/>React 18 only"] -- "upgrade" --> B["react-day-picker@8.10.2<br/>React 18 & 19"]
  B -- "maintains" --> C["v8 DatePicker API"]
  C -- "resolves" --> D["Issue #3347"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Bump react-day-picker to 8.10.2 for React 19</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/package.json

<ul><li>Updates <code>react-day-picker</code> from <code>^8.8.0</code> to <code>^8.10.2</code><br> <li> Enables React 19 peer dependency support<br> <li> Maintains backward compatibility with existing API<br> <li> Resolves dependency conflict without major version migration</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3361/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

