### PR TITLE
docs(ButtonGroup): let overview story show fullWidth

### DIFF
--- a/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -19,7 +19,7 @@ export default {
 
 export const Overview: Story = {
   render: args => (
-    <div style={{ width: "100%" }}>
+    <div style={{ display: "flex", justifyContent: "flex-start", width: "100%" }}>
       <ButtonGroup {...args} />
     </div>
   ),

--- a/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { ButtonGroup, Flex, Text } from "@vibe/core";
 import { createStoryMetaSettingsDecorator } from "../../../utils/createStoryMetaSettingsDecorator";
-import { createComponentTemplate } from "vibe-storybook-components";
 import { type Meta, type StoryObj } from "@storybook/react";
 
 type Story = StoryObj<typeof ButtonGroup>;
@@ -11,8 +10,6 @@ const metaSettings = createStoryMetaSettingsDecorator({
   actionPropsArray: ["onSelect"]
 });
 
-const buttonGroupTemplate = createComponentTemplate(ButtonGroup);
-
 export default {
   title: "Components/ButtonGroup",
   component: ButtonGroup,
@@ -21,7 +18,11 @@ export default {
 } satisfies Meta<typeof ButtonGroup>;
 
 export const Overview: Story = {
-  render: buttonGroupTemplate.bind({}),
+  render: args => (
+    <div style={{ width: "100%" }}>
+      <ButtonGroup {...args} />
+    </div>
+  ),
 
   args: {
     id: "overview-button-group",

--- a/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -20,7 +20,9 @@ export default {
 export const Overview: Story = {
   render: args => (
     <div style={{ display: "flex", justifyContent: "flex-start", width: "100%" }}>
-      <ButtonGroup {...args} />
+      <div style={{ width: "100%" }}>
+        <ButtonGroup {...args} />
+      </div>
     </div>
   ),
 

--- a/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
+++ b/packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx
@@ -19,10 +19,8 @@ export default {
 
 export const Overview: Story = {
   render: args => (
-    <div style={{ display: "flex", justifyContent: "flex-start", width: "100%" }}>
-      <div style={{ width: "100%" }}>
-        <ButtonGroup {...args} />
-      </div>
+    <div style={{ width: args.fullWidth ? "100%" : "fit-content" }}>
+      <ButtonGroup {...args} />
     </div>
   ),
 


### PR DESCRIPTION
### **User description**
## Summary

Fixes #3130.

The ButtonGroup overview story now renders inside a full-width wrapper and passes the Storybook controls args directly to `ButtonGroup`. That gives the `fullWidth` prop enough container width to show a visible change when toggled from the props table.

This was implemented with Codex assistance, with the final patch manually reviewed and kept to the ButtonGroup docs story.

## Verification

- `prettier --check packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx`
- `git diff --check`

I did not run the full Storybook build locally because this fresh worktree does not have the Vibe workspace dependencies installed; the change is scoped to the story render wrapper.


___

### **PR Type**
Documentation


___

### **Description**
- Replace template-based render with custom wrapper for fullWidth support

- Wrapper dynamically adjusts container width based on fullWidth prop

- Remove unused createComponentTemplate import dependency

- Enable visible fullWidth toggle behavior in Storybook controls


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ButtonGroup Story"] -->|"Remove template"| B["Custom Render Function"]
  B -->|"Dynamic width wrapper"| C["fullWidth Toggle Visible"]
  D["Unused Import"] -->|"Remove"| E["Cleaner Dependencies"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ButtonGroup.stories.tsx</strong><dd><code>Custom render wrapper for fullWidth prop visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/components/ButtonGroup/ButtonGroup.stories.tsx

<ul><li>Removed <code>createComponentTemplate</code> import and template binding<br> <li> Replaced template-based render with custom render function using <br>wrapper div<br> <li> Wrapper applies 100% width when <code>fullWidth</code> prop is true, otherwise <br>fit-content<br> <li> Passes all story args directly to ButtonGroup component</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3362/files#diff-1d7fff98c33821838924f6dc16942e7e9bfa2e3b57795dbbb8181bb74b392dac">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

