### PR TITLE
docs: keep resources hover readable in dark mode

### DIFF
--- a/packages/docs/src/pages/welcome/resources/ResourceCard.module.scss
+++ b/packages/docs/src/pages/welcome/resources/ResourceCard.module.scss
@@ -31,7 +31,6 @@
 
   &:hover {
     background: var(--sb-allgrey-background-color);
-    mix-blend-mode: multiply;
 
     .icon {
       display: none;


### PR DESCRIPTION
### **User description**
<!-- Thank you for contributing!
Before we can review your submission, please fill the information below:

Please describe the changes you're making. Include the motivation for these changes, any additional context, and the impact on the project. If your changes are related to any open issues, please link to them here. -->

Removes the `mix-blend-mode: multiply` hover style from the welcome page resource cards. The cards still use the existing `--sb-allgrey-background-color` hover token, but without multiplying it into the dark page background, so the dark-mode hover state stays readable instead of collapsing toward black.

Verification:
- `prettier --check packages/docs/src/pages/welcome/resources/ResourceCard.module.scss`
- `git diff --check`

I did not run the full Storybook locally to avoid reinstalling the docs dependency tree for this one-line SCSS change.

This was implemented with Codex assistance, with the final patch kept focused and manually reviewed.

- [x] I have read the [Contribution Guide](../CONTRIBUTING.md) for this project.

<!-- Please add the issue number that this PR closes: -->

Resolves #3160


___

### **PR Type**
Bug fix


___

### **Description**
- Removes `mix-blend-mode: multiply` from resource card hover state

- Improves dark mode readability by preventing color collapse to black

- Maintains existing grey background color token for hover styling


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["ResourceCard hover state"] -- "remove mix-blend-mode multiply" --> B["Readable dark mode hover"]
  C["--sb-allgrey-background-color token"] -- "applied without blending" --> B
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ResourceCard.module.scss</strong><dd><code>Remove multiply blend mode from hover state</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/welcome/resources/ResourceCard.module.scss

<ul><li>Removed <code>mix-blend-mode: multiply</code> CSS property from the <code>&:hover</code> <br>selector<br> <li> Preserves the <code>background: var(--sb-allgrey-background-color)</code> styling<br> <li> Fixes dark mode hover state visibility issue on resource cards</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3363/files#diff-c29e201ea9adf4b1510acde5e1d9ffc0008536df05a70b44e8bf77aa64c7efd4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

