### PR TITLE
perf(core): memoize hot leaf components and lazy-render Tooltip content

### DIFF
--- a/packages/components/button/src/Button/Button.tsx
+++ b/packages/components/button/src/Button/Button.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable react/button-has-type */
-import React, { type AriaAttributes, forwardRef, useCallback, useEffect, useMemo, useRef } from "react";
+import React, { type AriaAttributes, forwardRef, memo, useCallback, useEffect, useMemo, useRef } from "react";
 import { camelCase } from "es-toolkit";
 import cx from "classnames";
 import { useMergeRef, NOOP } from "@vibe/shared";
@@ -93,7 +93,9 @@ export interface ButtonProps extends VibeComponentProps {
   tabIndex?: number;
 }
 
-const Button = forwardRef<HTMLButtonElement, ButtonProps>(
+// TODO(perf): callers commonly pass inline `onClick`/`children` closures which defeat memoization.
+// Memoization here still helps when parent props are stable; consumer call sites are out of scope for this PR.
+const ButtonComponent = forwardRef<HTMLButtonElement, ButtonProps>(
   (
     {
       className,
@@ -378,5 +380,10 @@ const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     );
   }
 );
+
+ButtonComponent.displayName = "Button";
+
+const Button = memo(ButtonComponent);
+Button.displayName = "Button";
 
 export default Button;

--- a/packages/components/dialog/src/Dialog/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog/Dialog.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import React, { useState, useEffect, useRef, useContext, useCallback, useMemo } from "react";
+import React, { memo, useState, useEffect, useRef, useContext, useCallback, useMemo } from "react";
 import { createPortal } from "react-dom";
 import {
   useFloating,
@@ -29,7 +29,9 @@ import styles from "./Dialog.module.scss";
 import { type DialogTriggerEvent, type DialogEvent, type DialogProps } from "./Dialog.types";
 import { LayerContext, LayerProvider } from "@vibe/layer";
 
-function Dialog({
+// TODO(perf): consumers commonly pass inline `content` functions/`children`/`middleware` arrays which defeat
+// memoization. Fixing those is out of scope for this PR; memo still avoids re-renders when parents pass stable props.
+function DialogComponent({
   // Core props
   id,
   "data-testid": dataTestId,
@@ -544,5 +546,10 @@ function Dialog({
     </>
   );
 }
+
+DialogComponent.displayName = "Dialog";
+
+const Dialog = memo(DialogComponent);
+Dialog.displayName = "Dialog";
 
 export default Dialog;

--- a/packages/components/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip/Tooltip.tsx
@@ -113,13 +113,7 @@ const globalState: { lastTooltipHideTS: number; openTooltipsCount: number } = {
   openTooltipsCount: 0
 };
 
-interface TooltipState {
-  shown: boolean;
-}
-
-// TODO(perf): consumers commonly pass inline `content` (functions/elements) which can't be deduped here.
-// Lazy content rendering below avoids the work when the tooltip isn't visible.
-export default class Tooltip extends PureComponent<TooltipProps, TooltipState> {
+export default class Tooltip extends PureComponent<TooltipProps> {
   wasShown: boolean;
   /* eslint-disable react/default-props-match-prop-types -- props inherited from DialogProps via Omit<> */
   static defaultProps = {
@@ -149,16 +143,10 @@ export default class Tooltip extends PureComponent<TooltipProps, TooltipState> {
     this.onTooltipHide = this.onTooltipHide.bind(this);
 
     this.wasShown = false;
-    this.state = { shown: !!props.shouldShowOnMount };
   }
 
   renderTooltipContent() {
-    const { theme, content, className, style, maxWidth, title, image, icon, dir, withoutDialog, open } = this.props;
-    // Lazy content rendering: skip the (potentially expensive) tooltip body unless the tooltip is
-    // actually visible. Dialog still calls this on every render, but we short-circuit early when hidden.
-    if (!withoutDialog && !this.state.shown && !open) {
-      return null;
-    }
+    const { theme, content, className, style, maxWidth, title, image, icon, dir } = this.props;
     if (!content) {
       // don't render empty tooltip
       return null;
@@ -204,7 +192,6 @@ export default class Tooltip extends PureComponent<TooltipProps, TooltipState> {
       const { onTooltipShow } = this.props;
       globalState.openTooltipsCount++;
       this.wasShown = true;
-      this.setState({ shown: true });
       onTooltipShow && onTooltipShow();
     }
   }
@@ -215,7 +202,6 @@ export default class Tooltip extends PureComponent<TooltipProps, TooltipState> {
       globalState.lastTooltipHideTS = Date.now();
       globalState.openTooltipsCount--;
       this.wasShown = false;
-      this.setState({ shown: false });
       onTooltipHide && onTooltipHide();
     }
   }

--- a/packages/components/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip/Tooltip.tsx
@@ -113,7 +113,13 @@ const globalState: { lastTooltipHideTS: number; openTooltipsCount: number } = {
   openTooltipsCount: 0
 };
 
-export default class Tooltip extends PureComponent<TooltipProps> {
+interface TooltipState {
+  shown: boolean;
+}
+
+// TODO(perf): consumers commonly pass inline `content` (functions/elements) which can't be deduped here.
+// Lazy content rendering below avoids the work when the tooltip isn't visible.
+export default class Tooltip extends PureComponent<TooltipProps, TooltipState> {
   wasShown: boolean;
   /* eslint-disable react/default-props-match-prop-types -- props inherited from DialogProps via Omit<> */
   static defaultProps = {
@@ -143,10 +149,16 @@ export default class Tooltip extends PureComponent<TooltipProps> {
     this.onTooltipHide = this.onTooltipHide.bind(this);
 
     this.wasShown = false;
+    this.state = { shown: !!props.shouldShowOnMount };
   }
 
   renderTooltipContent() {
-    const { theme, content, className, style, maxWidth, title, image, icon, dir } = this.props;
+    const { theme, content, className, style, maxWidth, title, image, icon, dir, withoutDialog, open } = this.props;
+    // Lazy content rendering: skip the (potentially expensive) tooltip body unless the tooltip is
+    // actually visible. Dialog still calls this on every render, but we short-circuit early when hidden.
+    if (!withoutDialog && !this.state.shown && !open) {
+      return null;
+    }
     if (!content) {
       // don't render empty tooltip
       return null;
@@ -192,6 +204,7 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       const { onTooltipShow } = this.props;
       globalState.openTooltipsCount++;
       this.wasShown = true;
+      this.setState({ shown: true });
       onTooltipShow && onTooltipShow();
     }
   }
@@ -202,6 +215,7 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       globalState.lastTooltipHideTS = Date.now();
       globalState.openTooltipsCount--;
       this.wasShown = false;
+      this.setState({ shown: false });
       onTooltipHide && onTooltipHide();
     }
   }

--- a/packages/core/src/components/AttentionBox/AttentionBox.tsx
+++ b/packages/core/src/components/AttentionBox/AttentionBox.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, memo } from "react";
 import cx from "classnames";
 import type { AttentionBoxProps, AttentionBoxRole } from "./AttentionBox.types";
 import AttentionBoxDefault from "./layouts/AttentionBoxDefault/AttentionBoxDefault";
@@ -8,7 +8,9 @@ import { ComponentDefaultTestId, ComponentVibeId } from "../../tests/constants";
 import { getTestId } from "../../tests/test-ids-utils";
 import styles from "./AttentionBox.module.scss";
 
-const AttentionBox = forwardRef(
+// TODO(perf): callers may pass inline `action`/`link` objects which defeat memoization.
+// Memoization helps when parents pass stable props; fixing call sites is out of scope.
+const AttentionBoxComponent = forwardRef(
   (
     {
       compact = false,
@@ -70,5 +72,10 @@ const AttentionBox = forwardRef(
     );
   }
 );
+
+AttentionBoxComponent.displayName = "AttentionBox";
+
+const AttentionBox = memo(AttentionBoxComponent);
+AttentionBox.displayName = "AttentionBox";
 
 export default AttentionBox;

--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -2,7 +2,7 @@ import { camelCase } from "es-toolkit";
 import { getStyle } from "@vibe/shared";
 import { ComponentDefaultTestId, getTestId } from "../../tests/test-ids-utils";
 import cx from "classnames";
-import React, { type AriaRole, useCallback, useMemo } from "react";
+import React, { type AriaRole, memo, useCallback, useMemo } from "react";
 import { isNil } from "es-toolkit";
 import { type ElementAllowedColor, getElementColor } from "../../types/Colors";
 import { type AvatarSize, type AvatarType } from "./Avatar.types";
@@ -114,7 +114,9 @@ export interface AvatarProps extends VibeComponentProps {
   onClick?: (event: React.MouseEvent | React.KeyboardEvent, avatarId: string) => void;
 }
 
-const Avatar = ({
+// TODO(perf): consumers may pass inline `tooltipProps`/badge prop objects, defeating memoization at call sites.
+// Fixing those is out of scope; memo still avoids re-renders when parents pass stable props.
+const AvatarComponent = ({
   id,
   type = "text",
   className,
@@ -263,5 +265,10 @@ const Avatar = ({
     </div>
   );
 };
+
+AvatarComponent.displayName = "Avatar";
+
+const Avatar = memo(AvatarComponent);
+Avatar.displayName = "Avatar";
 
 export default Avatar;


### PR DESCRIPTION
### **User description**
## Summary
- Wraps **Button**, **Avatar**, **AttentionBox**, **Dialog** in `React.memo` (preserved `forwardRef` and `displayName`).
- **Tooltip**: `renderTooltipContent()` now short-circuits when the tooltip is not visible (gated by `state.shown`/`open`/`withoutDialog`).

## Why
From a performance audit (item #5): only 2 of ~50 leaf components in `@vibe/core` use `React.memo`. Components like Button, Avatar, and Tooltip are rendered hundreds-to-thousands of times per page in monday.com — every parent re-render that doesn't affect their props still pays full reconciliation cost. Tooltip additionally rendered its content on every parent render even when hidden, multiplying the wasted work across every assignee/user dropdown on a board view.

## Caveats
- `// TODO(perf):` comments mark the consumer call sites that still pass inline closures/objects (e.g. inline `onClick`, `tooltipProps={{...}}`). Those break memoization and need a follow-up sweep — explicitly out of scope here.
- `displayName` is set on every wrapped component so React DevTools still shows "Button" instead of "Memo(...)".

## Test plan
- [ ] CI: existing tests pass in @vibe/button, @vibe/dialog, @vibe/tooltip, @vibe/core
- [ ] React DevTools shows correct displayNames during review
- [ ] Storybook stories for Button/Avatar/AttentionBox/Dialog/Tooltip render and animate as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Wraps Button, Avatar, AttentionBox, Dialog in `React.memo` to prevent unnecessary re-renders

- Preserves `displayName` on memoized components for React DevTools visibility

- Adds TODO comments flagging consumer call sites with inline props that defeat memoization

- Targets high-frequency leaf components rendered hundreds-to-thousands of times per page


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Button, Avatar, AttentionBox, Dialog components"] -->|wrap with React.memo| B["Memoized components"]
  B -->|preserve displayName| C["React DevTools shows correct names"]
  B -->|skip re-render| D["Same props = no reconciliation"]
  D -->|performance gain| E["Reduced CPU cycles on parent updates"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Button.tsx</strong><dd><code>Memoize Button component with displayName preservation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/button/src/Button/Button.tsx

<ul><li>Imports <code>memo</code> from React<br> <li> Renames component to <code>ButtonComponent</code> and wraps with <code>React.memo</code><br> <li> Sets <code>displayName</code> on both wrapped and memoized versions<br> <li> Adds TODO comment about inline <code>onClick</code>/<code>children</code> closures defeating <br>memoization</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3365/files#diff-310a29a16b742413cb90e770391bbe498df552c7969a8e68d27b34c0e02278ae">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Memoize Dialog component with displayName preservation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/dialog/src/Dialog/Dialog.tsx

<ul><li>Imports <code>memo</code> from React<br> <li> Renames function to <code>DialogComponent</code> and wraps with <code>React.memo</code><br> <li> Sets <code>displayName</code> on both wrapped and memoized versions<br> <li> Adds TODO comment about inline <code>content</code>/<code>children</code>/<code>middleware</code> defeating <br>memoization</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3365/files#diff-11d0920f51dbddbf15cd88df5a9e5fa1001be8d3a89daacf124f877953cfe7b3">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AttentionBox.tsx</strong><dd><code>Memoize AttentionBox component with displayName preservation</code></dd></summary>
<hr>

packages/core/src/components/AttentionBox/AttentionBox.tsx

<ul><li>Imports <code>memo</code> from React<br> <li> Renames component to <code>AttentionBoxComponent</code> and wraps with <code>React.memo</code><br> <li> Sets <code>displayName</code> on both wrapped and memoized versions<br> <li> Adds TODO comment about inline <code>action</code>/<code>link</code> objects defeating <br>memoization</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3365/files#diff-492d0d0dc4696e03a284c348fdef28a69cbf0522f28eb8c5efe6226eaa936c3f">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Avatar.tsx</strong><dd><code>Memoize Avatar component with displayName preservation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Avatar/Avatar.tsx

<ul><li>Imports <code>memo</code> from React<br> <li> Renames component to <code>AvatarComponent</code> and wraps with <code>React.memo</code><br> <li> Sets <code>displayName</code> on both wrapped and memoized versions<br> <li> Adds TODO comment about inline <code>tooltipProps</code>/badge objects defeating <br>memoization</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3365/files#diff-edafcf920334069931422ca6e7589489360c7f72dd3eb457ac304029453b9323">+9/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

