### PR TITLE
perf(core): memoize context provider values to prevent cascading re-renders

### DIFF
--- a/packages/components/layer/src/LayerProvider/LayerProvider.tsx
+++ b/packages/components/layer/src/LayerProvider/LayerProvider.tsx
@@ -1,4 +1,4 @@
-import React, { type FC, type ReactNode, type RefObject } from "react";
+import React, { type FC, type ReactNode, type RefObject, useMemo } from "react";
 import LayerContext from "./LayerContext";
 
 export interface LayerProviderType {
@@ -13,7 +13,8 @@ export interface LayerProviderType {
 }
 
 const LayerProvider: FC<LayerProviderType> = ({ children, layerRef }) => {
-  return <LayerContext.Provider value={{ layerRef }}>{children}</LayerContext.Provider>;
+  const value = useMemo(() => ({ layerRef }), [layerRef]);
+  return <LayerContext.Provider value={value}>{children}</LayerContext.Provider>;
 };
 
 export default LayerProvider;

--- a/packages/components/typography/src/Heading/Heading.tsx
+++ b/packages/components/typography/src/Heading/Heading.tsx
@@ -9,6 +9,7 @@ import { type HeadingType, type HeadingWeight } from "./Heading.types";
 import { type TypographyAlign, type TypographyColor } from "../Typography/Typography.types";
 
 const OVERFLOW_TOLERANCE_IN_PX = 4;
+const HEADING_TYPOGRAPHY_CONTEXT_VALUE = { overflowTolerance: OVERFLOW_TOLERANCE_IN_PX };
 
 export interface HeadingProps extends TypographyProps {
   /**
@@ -39,7 +40,7 @@ const Heading = forwardRef(
     ref: React.ForwardedRef<HTMLElement>
   ) => {
     return (
-      <TypographyContext.Provider value={{ overflowTolerance: OVERFLOW_TOLERANCE_IN_PX }}>
+      <TypographyContext.Provider value={HEADING_TYPOGRAPHY_CONTEXT_VALUE}>
         <Typography
           element={type}
           ref={ref}

--- a/packages/core/src/components/AlertBanner/AlertBanner.tsx
+++ b/packages/core/src/components/AlertBanner/AlertBanner.tsx
@@ -71,6 +71,7 @@ const AlertBanner = forwardRef(
       }
       return isDarkBackground ? "onInverted" : "onPrimary";
     }, [isDarkBackground, isFixedColor]);
+    const alertBannerContextValue = useMemo(() => ({ textColor }), [textColor]);
     const children = useMemo(() => {
       const allChildren = React.Children.toArray(originalChildren) as ReactElement[];
       const filteredChildren = allChildren.filter(
@@ -109,7 +110,7 @@ const AlertBanner = forwardRef(
         data-testid={dataTestId || getTestId(ComponentDefaultTestId.ALERT_BANNER, id)}
         data-vibe={ComponentVibeId.ALERT_BANNER}
       >
-        <AlertBannerContext.Provider value={{ textColor }}>
+        <AlertBannerContext.Provider value={alertBannerContextValue}>
           <div className={cx(styles.content)}>
             {children.map(
               (

--- a/packages/core/src/components/AlertBanner/AlertBanner.tsx
+++ b/packages/core/src/components/AlertBanner/AlertBanner.tsx
@@ -13,7 +13,7 @@ import { getTestId } from "../../tests/test-ids-utils";
 import { type VibeComponentProps } from "../../types";
 import styles from "./AlertBanner.module.scss";
 import { Text } from "@vibe/typography";
-import { AlertBannerContext } from "./AlertBannerContext";
+import { AlertBannerContext, type AlertBannerContextType } from "./AlertBannerContext";
 
 type ChildrenType = ReactElement<AlertBannerButtonProps | AlertBannerLinkProps | AlertBannerTextProps>;
 
@@ -71,7 +71,7 @@ const AlertBanner = forwardRef(
       }
       return isDarkBackground ? "onInverted" : "onPrimary";
     }, [isDarkBackground, isFixedColor]);
-    const alertBannerContextValue = useMemo(() => ({ textColor }), [textColor]);
+    const alertBannerContextValue = useMemo<AlertBannerContextType>(() => ({ textColor }), [textColor]);
     const children = useMemo(() => {
       const allChildren = React.Children.toArray(originalChildren) as ReactElement[];
       const filteredChildren = allChildren.filter(

--- a/packages/core/src/components/AlertBanner/AlertBannerContext.ts
+++ b/packages/core/src/components/AlertBanner/AlertBannerContext.ts
@@ -1,7 +1,7 @@
 import React from "react";
 import { type TypographyColor } from "@vibe/typography";
 
-type AlertBannerContextType = {
+export type AlertBannerContextType = {
   textColor: Extract<TypographyColor, "onPrimary" | "onInverted" | "fixedDark">;
 };
 

--- a/packages/core/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.ts
+++ b/packages/core/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.ts
@@ -56,5 +56,5 @@ export const useGridKeyboardNavigationContext = (
     },
     [directionMaps, upperContext, wrapperRef, options.disabled]
   );
-  return { onOutboundNavigation };
+  return useMemo(() => ({ onOutboundNavigation }), [onOutboundNavigation]);
 };

--- a/packages/core/src/components/List/List.tsx
+++ b/packages/core/src/components/List/List.tsx
@@ -142,6 +142,8 @@ const List = forwardRef(
       }
     }, [updateFocusedItem]);
 
+    const listContextValue = useMemo(() => ({ updateFocusedItem }), [updateFocusedItem]);
+
     const overrideChildren = useMemo(() => {
       let override: ReactElement | ReactElement[] = Array.isArray(children) ? children : [children];
       if (renderOnlyVisibleItems) {
@@ -170,7 +172,7 @@ const List = forwardRef(
     }, [children, component, focusIndex, overrideId, renderOnlyVisibleItems]);
 
     return (
-      <ListContext.Provider value={{ updateFocusedItem }}>
+      <ListContext.Provider value={listContextValue}>
         <Component
           data-testid={dataTestId || getTestId(ComponentDefaultTestId.LIST, id)}
           data-vibe={ComponentVibeId.LIST}

--- a/packages/core/src/components/Table/TableContainer/TableContainer.tsx
+++ b/packages/core/src/components/Table/TableContainer/TableContainer.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef, useRef } from "react";
+import React, { forwardRef, useMemo, useRef } from "react";
 import { TableContainerProvider } from "../context/TableContainerContext/TableContainerContext";
 import { type TableContainerProps } from "./TableContainer.types";
 import { getTestId } from "../../../tests/test-ids-utils";
@@ -12,9 +12,10 @@ const TableContainer = forwardRef(
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
     const menuContainerRef = useRef<HTMLDivElement>(null);
+    const tableContainerContextValue = useMemo(() => ({ menuContainerRef }), []);
 
     return (
-      <TableContainerProvider value={{ menuContainerRef }}>
+      <TableContainerProvider value={tableContainerContextValue}>
         <div
           ref={ref}
           id={id}

--- a/packages/storybook-blocks/src/components/related-components/related-components.tsx
+++ b/packages/storybook-blocks/src/components/related-components/related-components.tsx
@@ -25,8 +25,10 @@ const RelatedComponents: React.FC<RelatedComponentsProps> & { linkTargets?: type
     [componentsNames, descriptionComponentsMap],
   );
 
+  const relatedComponentsContextValue = useMemo(() => ({ linkTarget }), [linkTarget]);
+
   return (
-    <RelatedComponentsContext.Provider value={{ linkTarget }}>
+    <RelatedComponentsContext.Provider value={relatedComponentsContextValue}>
       <article className={styles.relatedComponents}>{componentsDataElements}</article>
     </RelatedComponentsContext.Provider>
   );


### PR DESCRIPTION
### **User description**
## Summary
Stabilizes `value` references on the following Context providers so that consumers stop re-rendering when the value object is structurally identical:

- `LayerProvider` (packages/components/layer)
- `Heading` → `TypographyContext` (packages/components/typography) — hoisted to module-scope constant
- `AlertBannerContext` (packages/core)
- `GridKeyboardNavigationContext` (packages/core)
- `ListContext` (packages/core)
- `TableContainerProvider` (packages/core)
- `RelatedComponentsContext` (packages/storybook-blocks)

## Why
From a performance audit (item #15): when a Provider receives a fresh object literal each render (`value={{ foo, bar }}`), **every consumer of the context re-renders** — even when nothing in the value actually changed. For widely-used providers like Layer and Table, that cascade hits every nested element on every parent update.

## Test plan
- [ ] CI: existing tests pass
- [ ] No public API surface change — same value shape in/out, only stable references

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Memoize context provider values to prevent cascading re-renders
  - Wraps `value` props in `useMemo` or hoists to module-scoped constants
  - Affects LayerProvider, Heading's TypographyContext, AlertBannerContext, GridKeyboardNavigationContext, ListContext, TableContainerProvider, and RelatedComponentsContext

- Fix AlertBannerContextType preservation after memoization
  - Exports AlertBannerContextType and annotates useMemo with explicit type
  - Prevents type widening of textColor union literal


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Context Providers<br/>with fresh object literals"] -->|"Apply useMemo<br/>or hoist to constant"| B["Stable value<br/>references"]
  B -->|"Prevents unnecessary<br/>consumer re-renders"| C["Performance<br/>improvement"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>AlertBannerContext.ts</strong><dd><code>Export AlertBannerContextType for type safety</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/AlertBanner/AlertBannerContext.ts

<ul><li>Export <code>AlertBannerContextType</code> to allow type annotation in AlertBanner <br>component<br> <li> Enables explicit type preservation when wrapping context value in <br><code>useMemo</code></ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-2a7b4fce01fcd3c12351b75685732e365d571ef546b57dee037e8b6588b50050">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AlertBanner.tsx</strong><dd><code>Memoize AlertBanner context value with type annotation</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/AlertBanner/AlertBanner.tsx

<ul><li>Import <code>AlertBannerContextType</code> from AlertBannerContext<br> <li> Wrap context value in <code>useMemo</code> with explicit type annotation to <br>preserve textColor union literal<br> <li> Prevents type widening that would break context type assignability</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-0ef16c534dcd1688e6c451201ad5d8074a37fcff5b77b4596e6c2bb3d2b5c9e7">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GridKeyboardNavigationContext.ts</strong><dd><code>Memoize GridKeyboardNavigation context return value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/GridKeyboardNavigationContext/GridKeyboardNavigationContext.ts

<ul><li>Wrap return value in <code>useMemo</code> to stabilize context object reference<br> <li> Memoizes based on <code>onOutboundNavigation</code> dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-f6550920c7d6077ec9d2600356c62607b02aaf70bc62d1e5dcf86575057fe17e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>List.tsx</strong><dd><code>Memoize List context value to prevent re-renders</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/List/List.tsx

<ul><li>Create <code>listContextValue</code> variable with <code>useMemo</code> to stabilize context <br>reference<br> <li> Memoizes based on <code>updateFocusedItem</code> dependency<br> <li> Pass memoized value to ListContext.Provider</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-6451dffa66df5a6511ec66470bceecd419703d5aa001058d792eda7da3a39a32">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>TableContainer.tsx</strong><dd><code>Memoize TableContainer context value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Table/TableContainer/TableContainer.tsx

<ul><li>Import <code>useMemo</code> hook<br> <li> Create <code>tableContainerContextValue</code> with <code>useMemo</code> to stabilize context <br>reference<br> <li> Empty dependency array since <code>menuContainerRef</code> is created once per <br>component instance</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-eedcdc6c1d5f38cb7f57e9f092f173856006450fbd8a3135561b595ab7fb40c9">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>LayerProvider.tsx</strong><dd><code>Memoize LayerProvider context value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/layer/src/LayerProvider/LayerProvider.tsx

<ul><li>Import <code>useMemo</code> hook<br> <li> Create <code>value</code> variable with <code>useMemo</code> to stabilize context reference<br> <li> Memoizes based on <code>layerRef</code> dependency</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-a3d8df6d09b31c0094b093ca83aeae0c109f59773fa5ee4bca358a6d95df7b3c">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Heading.tsx</strong><dd><code>Hoist Heading TypographyContext value to constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/typography/src/Heading/Heading.tsx

<ul><li>Create module-scoped constant <code>HEADING_TYPOGRAPHY_CONTEXT_VALUE</code> for <br>TypographyContext value<br> <li> Replace inline object literal with constant reference in <br>TypographyContext.Provider<br> <li> Ensures stable reference across all Heading renders</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-138e3976c2b74aac48e98517d75da6eee6cd263766e1997b88460f5de0d9b4e3">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>related-components.tsx</strong><dd><code>Memoize RelatedComponents context value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/storybook-blocks/src/components/related-components/related-components.tsx

<ul><li>Create <code>relatedComponentsContextValue</code> with <code>useMemo</code> to stabilize context <br>reference<br> <li> Memoizes based on <code>linkTarget</code> dependency<br> <li> Pass memoized value to RelatedComponentsContext.Provider</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3366/files#diff-8b8264fe943be51d3ee76557b4d3a1f31e75d58bfd9dfe164d111f8999c4d3d7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

