### PR TITLE
perf(core): hoist inline objects and callbacks in hot list components

### DIFF
--- a/packages/core/src/components/BaseItem/BaseItem.tsx
+++ b/packages/core/src/components/BaseItem/BaseItem.tsx
@@ -9,6 +9,11 @@ import { Tooltip } from "@vibe/tooltip";
 import { renderSideElement } from "./utils";
 import styles from "./BaseItem.module.scss";
 
+const EMPTY_ITEM_PROPS: Record<string, unknown> = Object.freeze({});
+const EMPTY_TOOLTIP_PROPS = Object.freeze({}) as NonNullable<BaseItemData["tooltipProps"]>;
+const EMPTY_ITEM = Object.freeze({}) as BaseItemData;
+const TEXT_TOOLTIP_PROPS = Object.freeze({ containerSelector: "body" }) as { containerSelector: string };
+
 const BaseItem = forwardRef(
   <Item extends Record<string, unknown>>(
     {
@@ -23,8 +28,8 @@ const BaseItem = forwardRef(
       index: _index,
       dir = "auto",
       itemRenderer,
-      itemProps = {},
-      item = {} as BaseItemData<Item>
+      itemProps = EMPTY_ITEM_PROPS,
+      item = EMPTY_ITEM as BaseItemData<Item>
     }: BaseItemProps<Item>,
     ref: React.Ref<HTMLElement>
   ) => {
@@ -37,7 +42,7 @@ const BaseItem = forwardRef(
       listItemProps.refCallback?.(internalRef.current);
     }, [listItemProps]);
 
-    const { label = "", disabled = false, startElement, endElement, tooltipProps = {} } = item;
+    const { label = "", disabled = false, startElement, endElement, tooltipProps = EMPTY_TOOLTIP_PROPS } = item;
 
     const listItemClassNames = useMemo(
       () =>
@@ -79,7 +84,7 @@ const BaseItem = forwardRef(
           ) : (
             <>
               {startElement && renderSideElement(startElement, disabled, textVariant)}
-              <Text type={textVariant} color="inherit" tooltipProps={{ containerSelector: "body" }}>
+              <Text type={textVariant} color="inherit" tooltipProps={TEXT_TOOLTIP_PROPS}>
                 {label}
               </Text>
               {endElement && (

--- a/packages/core/src/components/Combobox/ComboboxHelpers/ComboboxHelpers.tsx
+++ b/packages/core/src/components/Combobox/ComboboxHelpers/ComboboxHelpers.tsx
@@ -21,6 +21,7 @@ import styles from "./ComboboxHelpers.module.scss";
 
 const DIVIDER_HEIGHT = 17;
 const CATEGORY_HEIGHT = 32;
+const DIVIDER_STYLE = { height: DIVIDER_HEIGHT };
 
 export function useItemsData({
   categories,
@@ -238,8 +239,11 @@ export function comboboxItemRenderer({
 }
 
 export function dividerItemRenderer({ id, height }: { id: string; height: number }) {
+  // Height is always DIVIDER_HEIGHT in production — use hoisted style to avoid per-render allocation.
+  // Fall back to a fresh object only if a non-default height is somehow provided.
+  const style = height === DIVIDER_HEIGHT ? DIVIDER_STYLE : { height };
   return (
-    <div className={styles.dividerContainer} style={{ height: height }}>
+    <div className={styles.dividerContainer} style={style}>
       <Divider className={styles.divider} key={id} />
     </div>
   );

--- a/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -158,6 +158,8 @@ const ComboboxOption = ({
 
   const optionRendererValue = useMemo(() => optionRenderer && optionRenderer(option), [optionRenderer, option]);
 
+  const optionStyle = useMemo(() => ({ height: optionLineHeight }), [optionLineHeight]);
+
   const optionValue = (
     <>
       {leftIcon && renderIcon(leftIcon, leftIconType, styles.left)}
@@ -188,7 +190,7 @@ const ComboboxOption = ({
           [styles.active]: isActive,
           [styles.activeOutline]: visualFocus
         })}
-        style={{ height: optionLineHeight }}
+        style={optionStyle}
       >
         {optionRendererValue || optionValue}
       </div>

--- a/packages/core/src/components/Dropdown/components/DropdownBaseList/DropdownBaseList.tsx
+++ b/packages/core/src/components/Dropdown/components/DropdownBaseList/DropdownBaseList.tsx
@@ -1,4 +1,4 @@
-import React, { forwardRef } from "react";
+import React, { forwardRef, useMemo } from "react";
 import BaseItem from "../../../BaseItem/BaseItem";
 import styles from "./DropdownBaseList.module.scss";
 import { type DropdownBaseListProps } from "./DropdownBaseList.types";
@@ -30,6 +30,7 @@ const DropdownBaseList = forwardRef(
     ref: React.Ref<HTMLUListElement>
   ) => {
     const textVariant: TextType = size === "small" ? "text2" : "text1";
+    const listStyle = useMemo(() => ({ maxHeight: maxMenuHeight }), [maxMenuHeight]);
 
     const defaultContent = renderOptions ? (
       options.every(group => group.options?.length === 0) ? (
@@ -85,7 +86,7 @@ const DropdownBaseList = forwardRef(
         className={styles.wrapper}
         {...getMenuProps?.({ "aria-label": menuAriaLabel })}
         onScroll={onScroll}
-        style={{ maxHeight: maxMenuHeight }}
+        style={listStyle}
       >
         {menuRenderer && renderOptions
           ? menuRenderer({

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx
@@ -1,9 +1,11 @@
-import React from "react";
+import React, { useMemo } from "react";
 import { Icon } from "@vibe/icon";
 import { Flex } from "@vibe/layout";
 import cx from "classnames";
 import styles from "./MenuItemIcon.module.scss";
 import { type MenuItemIconProps } from "./MenuItemIcon.types";
+
+const EMPTY_STYLE = Object.freeze({}) as React.CSSProperties;
 
 const MenuItemIcon = ({
   icon,
@@ -13,28 +15,32 @@ const MenuItemIcon = ({
   selected,
   backgroundColor,
   wrapperClassName
-}: MenuItemIconProps) => (
-  <Flex
-    justify="center"
-    className={cx(
-      styles.iconWrapper,
-      {
-        [styles.rightIcon]: isRightIcon,
-        [styles.disabled]: disabled,
-        [styles.withBackgroundColor]: !!backgroundColor
-      },
-      wrapperClassName
-    )}
-    style={{ ...(backgroundColor && { backgroundColor }) }}
-  >
-    <Icon
-      type={type || (typeof icon === "function" ? "svg" : "font")}
-      icon={icon}
-      className={cx(styles.icon, { [styles.selected]: !disabled && selected })}
-      ignoreFocusStyle
-      size={18}
-    />
-  </Flex>
-);
+}: MenuItemIconProps) => {
+  const wrapperStyle = useMemo(() => (backgroundColor ? { backgroundColor } : EMPTY_STYLE), [backgroundColor]);
+
+  return (
+    <Flex
+      justify="center"
+      className={cx(
+        styles.iconWrapper,
+        {
+          [styles.rightIcon]: isRightIcon,
+          [styles.disabled]: disabled,
+          [styles.withBackgroundColor]: !!backgroundColor
+        },
+        wrapperClassName
+      )}
+      style={wrapperStyle}
+    >
+      <Icon
+        type={type || (typeof icon === "function" ? "svg" : "font")}
+        icon={icon}
+        className={cx(styles.icon, { [styles.selected]: !disabled && selected })}
+        ignoreFocusStyle
+        size={18}
+      />
+    </Flex>
+  );
+};
 
 export default MenuItemIcon;

--- a/packages/core/src/components/Tabs/Tab/Tab.tsx
+++ b/packages/core/src/components/Tabs/Tab/Tab.tsx
@@ -1,5 +1,5 @@
 import cx from "classnames";
-import React, { type FC, forwardRef, type ReactElement, useRef } from "react";
+import React, { type FC, forwardRef, type ReactElement, useCallback, useRef } from "react";
 import { noop as NOOP } from "es-toolkit";
 import { useMergeRef, getStyle } from "@vibe/shared";
 
@@ -10,6 +10,8 @@ import styles from "./Tab.module.scss";
 import { Tooltip, type TooltipProps } from "@vibe/tooltip";
 import { ComponentVibeId } from "../../../tests/constants";
 import { keyCodes } from "../../../constants";
+
+const EMPTY_TOOLTIP_PROPS = Object.freeze({}) as Partial<TooltipProps>;
 
 export interface TabProps extends VibeComponentProps {
   /**
@@ -82,7 +84,7 @@ const Tab: FC<TabProps> = forwardRef(
       focus = false,
       stretchedUnderline = false,
       onClick = NOOP,
-      tooltipProps = {} as TooltipProps,
+      tooltipProps = EMPTY_TOOLTIP_PROPS,
       icon,
       iconType,
       iconSide = "left",
@@ -119,12 +121,19 @@ const Tab: FC<TabProps> = forwardRef(
       return [...childrenArray, iconElement];
     }
 
-    function handleKeyDown(event: React.KeyboardEvent) {
-      if (event.key === keyCodes.ENTER || event.key === keyCodes.SPACE) {
-        event.preventDefault();
-        !disabled && onClick(value);
-      }
-    }
+    const handleKeyDown = useCallback(
+      (event: React.KeyboardEvent) => {
+        if (event.key === keyCodes.ENTER || event.key === keyCodes.SPACE) {
+          event.preventDefault();
+          !disabled && onClick(value);
+        }
+      },
+      [disabled, onClick, value]
+    );
+
+    const handleClick = useCallback(() => {
+      !disabled && onClick(value);
+    }, [disabled, onClick, value]);
 
     return (
       <Tooltip {...tooltipProps} content={tooltipProps.content}>
@@ -145,7 +154,7 @@ const Tab: FC<TabProps> = forwardRef(
           tabIndex={tabIndex}
           data-testid={dataTestId || getTestId(ComponentDefaultTestId.TAB, id)}
           data-vibe={ComponentVibeId.TAB}
-          onClick={() => !disabled && onClick(value)}
+          onClick={handleClick}
           onKeyDown={handleKeyDown}
         >
           <div className={cx(styles.tabInner, tabInnerClassName)}>{renderIconAndChildren()}</div>


### PR DESCRIPTION
### **User description**
## Summary
Stops re-creating per-render objects and closures inside components that render per-item in lists. Each unstable reference forces memoized children to reconcile on every parent update; in a 100-row Combobox/Dropdown that allocation cost compounds on every keystroke.

### Files changed
- **BaseItem** — `{}` / `[]` empty-object defaults replaced with frozen module-scoped constants (`EMPTY_ITEM_PROPS`, `EMPTY_TOOLTIP_PROPS`, `EMPTY_ITEM`, `TEXT_TOOLTIP_PROPS`).
- **ComboboxOption** — `useMemo` around `style={{ height: optionLineHeight }}`.
- **ComboboxHelpers.dividerItemRenderer** — hoists the common-case `{ height: DIVIDER_HEIGHT }` style.
- **DropdownBaseList** — `useMemo` around `style={{ maxHeight }}`.
- **MenuItemIcon** — `useMemo` for the conditional `{ backgroundColor }` style.
- **Tab** — frozen `EMPTY_TOOLTIP_PROPS` constant; `useCallback` for `onClick`/`onKeyDown`.

## Why
From a performance audit (item #8): inline `style={{ }}` and `={() => ...}` in list-item renderers cause N allocations per parent render where N is the list length. The fix is mechanical (hoist or memoize) and zero-API-change.

## Test plan
- [ ] CI: tests pass for Combobox, Dropdown, Menu, Tabs, BaseItem
- [ ] Visual parity in Storybook stories

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Hoist inline objects and callbacks in list-item components
  - Replace empty-object defaults with frozen module-scoped constants
  - Wrap dynamic styles in `useMemo` to prevent per-render allocations
  - Convert inline handlers to `useCallback` in Tab component

- Eliminates N allocations per parent render where N is list length

- Improves performance in Combobox, Dropdown, Menu, and Tabs


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Per-render inline objects<br/>and callbacks"] -->|Hoist constants| B["Frozen module-scoped<br/>constants"]
  A -->|Memoize styles| C["useMemo wrapped<br/>style objects"]
  A -->|Memoize handlers| D["useCallback wrapped<br/>event handlers"]
  B --> E["Reduced allocations<br/>in list renders"]
  C --> E
  D --> E
  E --> F["Better performance<br/>in list components"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BaseItem.tsx</strong><dd><code>Hoist empty objects to frozen constants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/BaseItem/BaseItem.tsx

<ul><li>Created four frozen module-scoped constants: <code>EMPTY_ITEM_PROPS</code>, <br><code>EMPTY_TOOLTIP_PROPS</code>, <code>EMPTY_ITEM</code>, <code>TEXT_TOOLTIP_PROPS</code><br> <li> Replaced inline empty objects <code>{}</code> with frozen constants in default <br>parameters<br> <li> Replaced inline tooltip props object with <code>TEXT_TOOLTIP_PROPS</code> constant</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-f6803b49d19850c67744b1ef3988b47c927f916c5f53385eeb155c7461cb0e46">+9/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComboboxHelpers.tsx</strong><dd><code>Hoist divider style to constant</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Combobox/ComboboxHelpers/ComboboxHelpers.tsx

<ul><li>Created <code>DIVIDER_STYLE</code> constant for the common-case divider height <br>style<br> <li> Added conditional logic in <code>dividerItemRenderer</code> to use hoisted style <br>when height matches default<br> <li> Falls back to fresh object only for non-default heights</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-7da2792673cbe626fadc98a540080e26dac1c378adc634bce59b054530a0b31a">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ComboboxOption.tsx</strong><dd><code>Memoize option height style object</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx

<ul><li>Wrapped <code>style={{ height: optionLineHeight }}</code> in <code>useMemo</code> hook<br> <li> Memoized style object depends on <code>optionLineHeight</code> prop</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-cb28df19aa7cd1427fb5cf50c83820cc0d885b2e1a3017b24c55a8fe5e0bf816">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>DropdownBaseList.tsx</strong><dd><code>Memoize dropdown list max-height style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Dropdown/components/DropdownBaseList/DropdownBaseList.tsx

<ul><li>Added <code>useMemo</code> import<br> <li> Wrapped <code>style={{ maxHeight: maxMenuHeight }}</code> in <code>useMemo</code> hook<br> <li> Memoized style object depends on <code>maxMenuHeight</code> prop</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-5ce6ceec6b832bf3ee88e99cf639bea561722095f546c18eb4a6161da4b0cead">+3/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>MenuItemIcon.tsx</strong><dd><code>Memoize menu item icon background style</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Menu/MenuItem/components/MenuItemIcon/MenuItemIcon.tsx

<ul><li>Added <code>useMemo</code> import<br> <li> Created <code>EMPTY_STYLE</code> frozen constant for empty style object<br> <li> Wrapped conditional <code>backgroundColor</code> style in <code>useMemo</code> hook<br> <li> Converted component from arrow function to block body for hook usage</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-fead8bf76d7cc7985c236b8db0cdfa280cecda68a86cabf5cebcfac8d797ce21">+30/-24</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Tab.tsx</strong><dd><code>Memoize tab event handlers and tooltip props</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Tabs/Tab/Tab.tsx

<ul><li>Added <code>useCallback</code> import<br> <li> Created <code>EMPTY_TOOLTIP_PROPS</code> frozen constant for default tooltip props<br> <li> Converted inline <code>handleKeyDown</code> function to <code>useCallback</code> with <br>dependencies<br> <li> Converted inline <code>onClick</code> handler to <code>useCallback</code> named <code>handleClick</code><br> <li> Replaced inline arrow function with <code>handleClick</code> callback reference</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3367/files#diff-61c697b8815fce89298558f5231807127fd84bd241cd0e136959d94bef3d54f7">+18/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

