### PR TITLE
refactor(button): extract repeated tri-state patterns into mixins

### DIFF
--- a/packages/components/button/src/Button/Button.module.scss
+++ b/packages/components/button/src/Button/Button.module.scss
@@ -2,6 +2,75 @@
 
 $disabled-on-primary-color-opacity: 0.5;
 
+// Tri-state pattern: a color modifier with three states (Active class, :hover, :focus)
+// all sharing the same background. Generates two rules:
+//   .#{$class}                                 { ...defaults }
+//   .#{$class}Active, .#{$class}:hover, .#{$class}:focus { background: $bg-active }
+@mixin solid-tristate($class, $bg, $bg-active, $fg: null) {
+  &.#{$class} {
+    background: $bg;
+    @if $fg != null {
+      color: $fg;
+    }
+  }
+
+  &.#{$class}Active,
+  &.#{$class}:hover,
+  &.#{$class}:focus {
+    background: $bg-active;
+  }
+}
+
+// Outlined variant (kindSecondary): sets fg color + border-color, tri-state bg.
+@mixin outlined-tristate($class, $color, $bg-active) {
+  &.#{$class} {
+    color: $color;
+    border-color: $color;
+  }
+
+  &.#{$class}Active,
+  &.#{$class}:hover,
+  &.#{$class}:focus {
+    background: $bg-active;
+  }
+}
+
+// Flat variant (kindTertiary): sets fg color only, tri-state bg.
+@mixin flat-tristate($class, $color, $bg-active) {
+  &.#{$class} {
+    color: $color;
+  }
+
+  &.#{$class}Active,
+  &.#{$class}:hover,
+  &.#{$class}:focus {
+    background: $bg-active;
+  }
+}
+
+// Brightness overlay tri-state used by onPrimaryColor / fixedLight on all kinds.
+// $literal-bg, when given, is set as a literal background-color (used by kindPrimary
+// to overlay #e6e9ef before the brightness filter).
+@mixin brightness-overlay-tristate($class, $literal-bg: null) {
+  &.#{$class}Active,
+  &.#{$class}:hover,
+  &.#{$class}:focus {
+    @if $literal-bg != null {
+      background-color: $literal-bg;
+    }
+    backdrop-filter: brightness(85%);
+    @include focus-style-on-primary();
+  }
+}
+
+// `.disabled` with the opacity-on-primary-color pattern.
+@mixin disabled-with-opacity($class, $fg) {
+  &.#{$class}.disabled {
+    opacity: $disabled-on-primary-color-opacity;
+    color: $fg;
+  }
+}
+
 .button {
   --loader-padding: 8px;
   outline: none;
@@ -129,138 +198,70 @@ $disabled-on-primary-color-opacity: 0.5;
 
 .kindPrimary {
   color: var(--text-color-on-primary);
-}
 
-.kindPrimary.colorPrimary {
-  background: var(--primary-color);
-}
+  @include solid-tristate(colorPrimary, var(--primary-color), var(--primary-hover-color));
+  @include solid-tristate(colorBrand, var(--brand-color), var(--brand-hover-color), var(--text-color-on-brand));
+  @include solid-tristate(colorPositive, var(--positive-color), var(--positive-color-hover));
+  @include solid-tristate(colorNegative, var(--negative-color), var(--negative-color-hover));
+  @include solid-tristate(
+    colorInverted,
+    var(--inverted-color-background),
+    var(--placeholder-color),
+    var(--text-color-on-inverted)
+  );
 
-.kindPrimary.colorBrand {
-  background: var(--brand-color);
-  color: var(--text-color-on-brand);
-}
+  &.button.colorInverted.disabled {
+    background: var(--disabled-text-color);
+    color: var(--disabled-background-color);
+  }
 
-.kindPrimary.colorPrimaryActive,
-.kindPrimary.colorPrimary:hover,
-.kindPrimary.colorPrimary:focus {
-  background: var(--primary-hover-color);
-}
+  &.colorOnPrimaryColor {
+    background: var(--text-color-on-primary);
+  }
 
-.kindPrimary.colorBrandActive,
-.kindPrimary.colorBrand:hover,
-.kindPrimary.colorBrand:focus {
-  background: var(--brand-hover-color);
-}
+  @include brightness-overlay-tristate(colorOnPrimaryColor, #e6e9ef);
+  @include disabled-with-opacity(colorOnPrimaryColor, var(--text-color-on-primary));
 
-.kindPrimary.colorPositive {
-  background: var(--positive-color);
-}
+  &.colorFixedLight {
+    background: var(--fixed-light-color);
+  }
 
-.kindPrimary.colorPositiveActive,
-.kindPrimary.colorPositive:hover,
-.kindPrimary.colorPositive:focus {
-  background: var(--positive-color-hover);
-}
+  @include brightness-overlay-tristate(colorFixedLight, #e6e9ef);
+  @include disabled-with-opacity(colorFixedLight, var(--fixed-light-color));
 
-.kindPrimary.colorNegative {
-  background: var(--negative-color);
-}
+  &.colorFixedDark {
+    background: var(--fixed-dark-color);
+    color: var(--fixed-light-color);
+  }
 
-.kindPrimary.colorNegativeActive,
-.kindPrimary.colorNegative:hover,
-.kindPrimary.colorNegative:focus {
-  background: var(--negative-color-hover);
-}
+  &.colorFixedDarkActive,
+  &.colorFixedDark:hover,
+  &.colorFixedDark:focus {
+    filter: brightness(125%);
+    @include focus-style-on-primary();
+  }
 
-.kindPrimary.colorInverted {
-  background: var(--inverted-color-background);
-  color: var(--text-color-on-inverted);
-}
+  @include disabled-with-opacity(colorFixedDark, var(--fixed-dark-color));
 
-.kindPrimary.colorInvertedActive,
-.kindPrimary.colorInverted:hover,
-.kindPrimary.colorInverted:focus {
-  background: var(--placeholder-color);
-}
+  @include solid-tristate(
+    colorOnInvertedBackground,
+    var(--primary-background-color),
+    var(--ui-background-color),
+    var(--primary-text-color)
+  );
 
-.kindPrimary.button.colorInverted.disabled {
-  background: var(--disabled-text-color);
-  color: var(--disabled-background-color);
-}
+  &.button.colorOnInvertedBackground.disabled {
+    background: var(--ui-background-color);
+    color: var(--primary-text-color);
+    opacity: $disabled-on-primary-color-opacity;
+  }
 
-.kindPrimary.colorOnPrimaryColor {
-  background: var(--text-color-on-primary);
-}
-
-.kindPrimary.colorOnPrimaryColorActive,
-.kindPrimary.colorOnPrimaryColor:hover,
-.kindPrimary.colorOnPrimaryColor:focus {
-  background-color: #e6e9ef;
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
-
-.kindPrimary.colorOnPrimaryColor.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--text-color-on-primary);
-}
-
-.kindPrimary.colorFixedLight {
-  background: var(--fixed-light-color);
-}
-
-.kindPrimary.colorFixedLightActive,
-.kindPrimary.colorFixedLight:hover,
-.kindPrimary.colorFixedLight:focus {
-  background-color: #e6e9ef;
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
-
-.kindPrimary.colorFixedLight.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-light-color);
-}
-
-.kindPrimary.colorFixedDark {
-  background: var(--fixed-dark-color);
-  color: var(--fixed-light-color);
-}
-
-.kindPrimary.colorFixedDarkActive,
-.kindPrimary.colorFixedDark:hover,
-.kindPrimary.colorFixedDark:focus {
-  filter: brightness(125%);
-  @include focus-style-on-primary();
-}
-
-.kindPrimary.colorFixedDark.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-dark-color);
-}
-
-.kindPrimary.colorOnInvertedBackground {
-  background: var(--primary-background-color);
-  color: var(--primary-text-color);
-}
-
-.kindPrimary.colorOnInvertedBackgroundActive,
-.kindPrimary.colorOnInvertedBackground:hover,
-.kindPrimary.colorOnInvertedBackground:focus {
-  background: var(--ui-background-color);
-}
-
-.kindPrimary.button.colorOnInvertedBackground.disabled {
-  background: var(--ui-background-color);
-  color: var(--primary-text-color);
-  opacity: $disabled-on-primary-color-opacity;
-}
-
-.kindPrimary.button.disabled {
-  background: var(--disabled-background-color);
-  color: var(--disabled-text-color);
-  cursor: not-allowed;
-  pointer-events: none;
+  &.button.disabled {
+    background: var(--disabled-background-color);
+    color: var(--disabled-text-color);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 }
 
 .kindSecondary {
@@ -268,305 +269,183 @@ $disabled-on-primary-color-opacity: 0.5;
   border-color: var(--ui-border-color);
   color: var(--primary-text-color);
   background-color: transparent;
-}
 
-.kindSecondary.sizeSmall {
-  line-height: 22px;
-}
+  &.sizeSmall,
+  &.sizeMedium,
+  &.sizeLarge {
+    line-height: 22px;
+  }
 
-.kindSecondary.sizeMedium {
-  line-height: 22px;
-}
+  &.colorPrimaryActive {
+    background-color: var(--primary-selected-color);
+    border-color: var(--primary-color);
+  }
 
-.kindSecondary.sizeLarge {
-  line-height: 22px;
-}
+  &.colorPrimaryActive:hover {
+    background-color: var(--primary-selected-hover-color);
+    border-color: var(--primary-color);
+  }
 
-.kindSecondary.colorPrimaryActive {
-  background-color: var(--primary-selected-color);
-  border-color: var(--primary-color);
-}
+  &.colorBrandActive {
+    color: var(--text-color-on-brand);
+  }
 
-.kindSecondary.colorPrimaryActive:hover {
-  background-color: var(--primary-selected-hover-color);
-  border-color: var(--primary-color);
-}
+  &.colorBrandActive,
+  &.colorBrandActive:hover {
+    background-color: var(--brand-selected-color);
+    border-color: var(--brand-color);
+  }
 
-.kindSecondary.colorBrandActive {
-  color: var(--text-color-on-brand);
-}
+  &.colorPrimary:hover:not(.colorPrimaryActive),
+  &.colorPrimary:focus:not(.colorPrimaryActive),
+  &.colorBrand:hover:not(.colorBrandActive),
+  &.colorBrand:focus:not(.colorBrandActive) {
+    background: var(--primary-background-hover-color);
+  }
 
-.kindSecondary.colorBrandActive,
-.kindSecondary.colorBrandActive:hover {
-  background-color: var(--brand-selected-color);
-  border-color: var(--brand-color);
-}
+  @include outlined-tristate(colorPositive, var(--positive-color), var(--positive-color-selected));
+  @include outlined-tristate(colorNegative, var(--negative-color), var(--negative-color-selected));
+  @include outlined-tristate(colorInverted, var(--primary-text-color), var(--primary-background-hover-color));
 
-.kindSecondary.colorPrimary:hover:not(.colorPrimaryActive),
-.kindSecondary.colorPrimary:focus:not(.colorPrimaryActive) {
-  background: var(--primary-background-hover-color);
-}
+  &.colorInverted.disabled {
+    border-color: var(--disabled-text-color);
+    color: var(--disabled-text-color);
+  }
 
-.kindSecondary.colorBrand:hover:not(.colorBrandActive),
-.kindSecondary.colorBrand:focus:not(.colorBrandActive) {
-  background: var(--primary-background-hover-color);
-}
+  &.colorOnPrimaryColor {
+    color: var(--text-color-on-primary);
+    border-color: var(--text-color-on-primary);
+  }
 
-.kindSecondary.colorPositive {
-  color: var(--positive-color);
-  border-color: var(--positive-color);
-}
+  @include brightness-overlay-tristate(colorOnPrimaryColor);
+  @include disabled-with-opacity(colorOnPrimaryColor, var(--text-color-on-primary));
 
-.kindSecondary.colorPositiveActive,
-.kindSecondary.colorPositive:hover,
-.kindSecondary.colorPositive:focus {
-  background: var(--positive-color-selected);
-}
+  &.colorFixedLight {
+    border-color: var(--fixed-light-color);
+    color: var(--fixed-light-color);
+  }
 
-.kindSecondary.colorNegative {
-  color: var(--negative-color);
-  border-color: var(--negative-color);
-}
+  @include brightness-overlay-tristate(colorFixedLight);
 
-.kindSecondary.colorNegativeActive,
-.kindSecondary.colorNegative:hover,
-.kindSecondary.colorNegative:focus {
-  background: var(--negative-color-selected);
-}
+  &.colorFixedDark {
+    border-color: var(--fixed-dark-color);
+    color: var(--fixed-dark-color);
+  }
 
-.kindSecondary.colorInverted {
-  color: var(--primary-text-color);
-  border-color: var(--primary-text-color);
-}
+  &.colorFixedDarkActive,
+  &.colorFixedDark:hover,
+  &.colorFixedDark:focus {
+    background-color: var(--primary-background-hover-color);
+    @include focus-style-on-primary();
+  }
 
-.kindSecondary.colorInvertedActive,
-.kindSecondary.colorInverted:hover,
-.kindSecondary.colorInverted:focus {
-  background: var(--primary-background-hover-color);
-}
+  @include outlined-tristate(
+    colorOnInvertedBackground,
+    var(--text-color-on-inverted),
+    var(--icon-color)
+  );
 
-.kindSecondary.colorInverted.disabled {
-  border-color: var(--disabled-text-color);
-  color: var(--disabled-text-color);
-}
+  &.colorOnInvertedBackground.disabled {
+    border-color: var(--text-color-on-inverted);
+    color: var(--text-color-on-inverted);
+    opacity: $disabled-on-primary-color-opacity;
+  }
 
-.kindSecondary.colorOnPrimaryColor {
-  color: var(--text-color-on-primary);
-  border-color: var(--text-color-on-primary);
-}
+  @include disabled-with-opacity(colorFixedLight, var(--fixed-light-color));
+  @include disabled-with-opacity(colorFixedDark, var(--fixed-dark-color));
 
-.kindSecondary.colorOnPrimaryColorActive,
-.kindSecondary.colorOnPrimaryColor:hover,
-.kindSecondary.colorOnPrimaryColor:focus {
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
+  &.disabled {
+    border-color: var(--disabled-text-color);
+    color: var(--disabled-text-color);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 
-.kindSecondary.colorOnPrimaryColor.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--text-color-on-primary);
-}
-
-.kindSecondary.colorFixedLight {
-  border-color: var(--fixed-light-color);
-  color: var(--fixed-light-color);
-}
-
-.kindSecondary.colorFixedLightActive,
-.kindSecondary.colorFixedLight:hover,
-.kindSecondary.colorFixedLight:focus {
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
-
-.kindSecondary.colorFixedDark {
-  border-color: var(--fixed-dark-color);
-  color: var(--fixed-dark-color);
-}
-
-.kindSecondary.colorFixedDarkActive,
-.kindSecondary.colorFixedDark:hover,
-.kindSecondary.colorFixedDark:focus {
-  background-color: var(--primary-background-hover-color);
-  @include focus-style-on-primary();
-}
-
-.kindSecondary.colorOnInvertedBackground {
-  border-color: var(--text-color-on-inverted);
-  color: var(--text-color-on-inverted);
-}
-
-.kindSecondary.colorOnInvertedBackgroundActive,
-.kindSecondary.colorOnInvertedBackground:hover,
-.kindSecondary.colorOnInvertedBackground:focus {
-  background: var(--icon-color);
-}
-
-.kindSecondary.colorOnInvertedBackground.disabled {
-  border-color: var(--text-color-on-inverted);
-  color: var(--text-color-on-inverted);
-  opacity: $disabled-on-primary-color-opacity;
-}
-
-.kindSecondary.colorFixedLight.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-light-color);
-}
-
-.kindSecondary.colorFixedDark.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-dark-color);
-}
-
-.kindSecondary.disabled {
-  border-color: var(--disabled-text-color);
-  color: var(--disabled-text-color);
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.kindSecondary.disabled:hover {
-  background-color: transparent;
+  &.disabled:hover {
+    background-color: transparent;
+  }
 }
 
 .kindTertiary {
   color: var(--primary-text-color);
   background-color: transparent;
-}
 
-.kindTertiary.colorPrimaryActive {
-  background-color: var(--primary-selected-color);
-}
+  &.colorPrimaryActive {
+    background-color: var(--primary-selected-color);
+  }
 
-.kindTertiary.colorPrimaryActive:hover {
-  background-color: var(--primary-selected-hover-color);
-}
+  &.colorPrimaryActive:hover {
+    background-color: var(--primary-selected-hover-color);
+  }
 
-.kindTertiary.colorBrandActive {
-  color: var(--text-color-on-brand);
-}
+  &.colorBrandActive {
+    color: var(--text-color-on-brand);
+  }
 
-.kindTertiary.colorBrandActive,
-.kindTertiary.colorBrandActive:hover {
-  background-color: var(--brand-selected-color);
-}
+  &.colorBrandActive,
+  &.colorBrandActive:hover {
+    background-color: var(--brand-selected-color);
+  }
 
-.kindTertiary.colorPrimary:hover:not(.colorPrimaryActive),
-.kindTertiary.colorPrimary:focus:not(.colorPrimaryActive) {
-  background: var(--primary-background-hover-color);
-}
+  &.colorPrimary:hover:not(.colorPrimaryActive),
+  &.colorPrimary:focus:not(.colorPrimaryActive),
+  &.colorBrand:hover:not(.colorBrandActive),
+  &.colorBrand:focus:not(.colorBrandActive) {
+    background: var(--primary-background-hover-color);
+  }
 
-.kindTertiary.colorBrand:hover:not(.colorBrandActive),
-.kindTertiary.colorBrand:focus:not(.colorBrandActive) {
-  background: var(--primary-background-hover-color);
-}
+  @include flat-tristate(colorPositive, var(--positive-color), var(--positive-color-selected));
+  @include flat-tristate(colorNegative, var(--negative-color), var(--negative-color-selected));
+  @include flat-tristate(colorInverted, var(--primary-text-color), var(--primary-background-hover-color));
 
-.kindTertiary.colorPositive {
-  color: var(--positive-color);
-}
+  &.colorInverted.disabled {
+    color: var(--disabled-text-color);
+  }
 
-.kindTertiary.colorPositiveActive,
-.kindTertiary.colorPositive:hover,
-.kindTertiary.colorPositive:focus {
-  background: var(--positive-color-selected);
-}
+  &.colorOnPrimaryColor {
+    color: var(--text-color-on-primary);
+  }
 
-.kindTertiary.colorNegative {
-  color: var(--negative-color);
-}
+  @include brightness-overlay-tristate(colorOnPrimaryColor);
+  @include disabled-with-opacity(colorOnPrimaryColor, var(--text-color-on-primary));
 
-.kindTertiary.colorNegativeActive,
-.kindTertiary.colorNegative:hover,
-.kindTertiary.colorNegative:focus {
-  background: var(--negative-color-selected);
-}
+  &.colorFixedLight {
+    color: var(--fixed-light-color);
+  }
 
-.kindTertiary.colorInverted {
-  color: var(--primary-text-color);
-}
+  @include brightness-overlay-tristate(colorFixedLight);
+  @include disabled-with-opacity(colorFixedLight, var(--fixed-light-color));
 
-.kindTertiary.colorInvertedActive,
-.kindTertiary.colorInverted:hover,
-.kindTertiary.colorInverted:focus {
-  background: var(--primary-background-hover-color);
-}
+  &.colorFixedDark {
+    color: var(--fixed-dark-color);
+  }
 
-.kindTertiary.colorInverted.disabled {
-  color: var(--disabled-text-color);
-}
+  &.colorFixedDarkActive,
+  &.colorFixedDark:hover,
+  &.colorFixedDark:focus {
+    background-color: var(--primary-background-hover-color);
+    @include focus-style-on-primary();
+  }
 
-.kindTertiary.colorOnPrimaryColor {
-  color: var(--text-color-on-primary);
-}
+  @include disabled-with-opacity(colorFixedDark, var(--fixed-dark-color));
 
-.kindTertiary.colorOnPrimaryColorActive,
-.kindTertiary.colorOnPrimaryColor:hover,
-.kindTertiary.colorOnPrimaryColor:focus {
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
+  @include flat-tristate(colorOnInvertedBackground, var(--text-color-on-inverted), var(--icon-color));
 
-.kindTertiary.colorOnPrimaryColor.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--text-color-on-primary);
-}
+  &.colorOnInvertedBackground.disabled {
+    background: var(--icon-color);
+    opacity: $disabled-on-primary-color-opacity;
+    color: var(--text-color-on-inverted);
+  }
 
-.kindTertiary.colorFixedLight {
-  color: var(--fixed-light-color);
-}
+  &.disabled {
+    color: var(--disabled-text-color);
+    cursor: not-allowed;
+    pointer-events: none;
+  }
 
-.kindTertiary.colorFixedLightActive,
-.kindTertiary.colorFixedLight:hover,
-.kindTertiary.colorFixedLight:focus {
-  backdrop-filter: brightness(85%);
-  @include focus-style-on-primary();
-}
-
-.kindTertiary.colorFixedLight.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-light-color);
-}
-
-.kindTertiary.colorFixedDark {
-  color: var(--fixed-dark-color);
-}
-
-.kindTertiary.colorFixedDarkActive,
-.kindTertiary.colorFixedDark:hover,
-.kindTertiary.colorFixedDark:focus {
-  background-color: var(--primary-background-hover-color);
-  @include focus-style-on-primary();
-}
-
-.kindTertiary.colorFixedDark.disabled {
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--fixed-dark-color);
-}
-
-.kindTertiary.colorOnInvertedBackground {
-  color: var(--text-color-on-inverted);
-}
-
-.kindTertiary.colorOnInvertedBackgroundActive,
-.kindTertiary.colorOnInvertedBackground:hover,
-.kindTertiary.colorOnInvertedBackground:focus {
-  background: var(--icon-color);
-}
-
-.kindTertiary.colorOnInvertedBackground.disabled {
-  background: var(--icon-color);
-  opacity: $disabled-on-primary-color-opacity;
-  color: var(--text-color-on-inverted);
-}
-
-.kindTertiary.disabled {
-  color: var(--disabled-text-color);
-  cursor: not-allowed;
-  pointer-events: none;
-}
-
-.kindTertiary.disabled:hover {
-  background-color: transparent;
+  &.disabled:hover {
+    background-color: transparent;
+  }
 }
 
 .noSidePadding {


### PR DESCRIPTION
### **User description**
## Summary

`Button.module.scss` is a 3 (kind) × 9 (color) × ~3 (state) combinatorial matrix. Five recurring patterns accounted for the bulk of the file's repetition. Each is now a SCSS mixin defined once and applied per color.

### Mixins

| Mixin | Used by |
|---|---|
| `solid-tristate(class, bg, bg-active, fg?)` | `kindPrimary` regular colors (primary, brand, positive, negative, inverted, onInvertedBackground) |
| `outlined-tristate(class, color, bg-active)` | `kindSecondary` (positive, negative, inverted, onInvertedBackground) |
| `flat-tristate(class, color, bg-active)` | `kindTertiary` (positive, negative, inverted, onInvertedBackground) |
| `brightness-overlay-tristate(class, literal-bg?)` | onPrimaryColor / fixedLight on all kinds (extra `literal-bg` param for `kindPrimary` `#e6e9ef` overlay) |
| `disabled-with-opacity(class, fg)` | onPrimaryColor / fixedLight / fixedDark on all kinds |

Result: **578 → 457 lines** (-121, ~21% smaller source) with no semantic change.

## Equivalence verification

I diffed the compiled CSS string in `dist/Button/Button.module.scss.js` against master's. The only differences are:

1. Two source rules with identical bodies (`A { x }` `B { x }`) merged into one (`A, B { x }`) — identical CSS cascade.
2. Whitespace within selector lists (multi-line vs single-line) — purely cosmetic.

Class-name hashes (`button_2f1d87d372`, `kindPrimary_306927aec1`, etc.) are **byte-identical** to master. No DOM, snapshot, or visual regressions possible from this change.

## Test plan

- [x] `yarn workspace @vibe/button build` succeeds
- [x] Compiled CSS is logically equivalent to master (verified via normalized rule-set diff — see commit message)
- [x] Class-name → hash dictionary is unchanged (verified by extracting the JSON map from both builds)
- [ ] CI green (snapshot tests, lint, full test suite)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Extract five recurring SCSS patterns into reusable mixins

- Reduce Button.module.scss from 578 to 457 lines (~21% reduction)

- Consolidate tri-state (Active/hover/focus) styling logic

- Maintain identical compiled CSS and class-name hashes


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Repetitive tri-state<br/>CSS rules"] -->|"Extract patterns"| B["5 SCSS mixins:<br/>solid/outlined/flat<br/>brightness-overlay<br/>disabled-with-opacity"]
  B -->|"Apply per color"| C["Consolidated<br/>Button.module.scss<br/>-121 lines"]
  C -->|"Compile"| D["Identical CSS<br/>& class hashes"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Button.module.scss</strong><dd><code>Refactor tri-state patterns into reusable SCSS mixins</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/button/src/Button/Button.module.scss

<ul><li>Added five SCSS mixins at file top: <code>solid-tristate</code>, <code>outlined-tristate</code>, <br><code>flat-tristate</code>, <code>brightness-overlay-tristate</code>, <code>disabled-with-opacity</code><br> <li> Replaced 450+ lines of repetitive color/state rules with mixin <br>invocations across <code>kindPrimary</code>, <code>kindSecondary</code>, <code>kindTertiary</code> blocks<br> <li> Consolidated selector groups (e.g., <code>.colorPositiveActive, </code><br><code>.colorPositive:hover, .colorPositive:focus</code>) into mixin-generated rules<br> <li> Maintained all CSS semantics and visual behavior with zero functional <br>changes</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3372/files#diff-5398139372bad72209199b676b21be0e7d45cca2cfd6232b6606cccc50b5ca2e">+257/-378</a></td>

</tr>
</table></td></tr></tbody></table>

</details>

___

