### PR TITLE
chore(core): remove react-remove-scroll dependency

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -114,7 +114,6 @@
     "react-focus-lock": "^2.13.2",
     "react-inlinesvg": "^4.1.3",
     "react-is": "^16.9.0",
-    "react-remove-scroll": "^2.6.0",
     "react-transition-group": "^4.4.5",
     "react-virtualized-auto-sizer": "^1.0.7",
     "react-window": "^1.8.7",

--- a/packages/core/src/components/Modal/Modal/Modal.tsx
+++ b/packages/core/src/components/Modal/Modal/Modal.tsx
@@ -1,6 +1,5 @@
 import React, { forwardRef, useCallback, useMemo, useRef, useState } from "react";
 import cx from "classnames";
-import { RemoveScroll } from "react-remove-scroll";
 import FocusLock from "react-focus-lock";
 import { CSSTransition } from "react-transition-group";
 import { getTestId } from "../../../tests/test-ids-utils";
@@ -16,6 +15,7 @@ import { keyCodes } from "../../../constants";
 import { createPortal } from "react-dom";
 import usePortalTarget from "../hooks/usePortalTarget/usePortalTarget";
 import useFocusEscapeTargets from "../hooks/useFocusEscapeTargets/useFocusEscapeTargets";
+import useBodyScrollLock from "../hooks/useBodyScrollLock/useBodyScrollLock";
 import { LayerProvider } from "@vibe/layer";
 
 // @ts-expect-error This is a precaution to support all possible module systems (ESM/CJS)
@@ -111,6 +111,8 @@ const Modal = forwardRef(
 
     const shouldAllowFocusEscape = useFocusEscapeTargets(allowFocusEscapeTo);
 
+    useBodyScrollLock(show);
+
     /**
      * Returning true means that the focus-lock is allowed to manage the element.
      * Returning false means that the focus-lock would surrender control to the element.
@@ -158,34 +160,33 @@ const Modal = forwardRef(
                     onClick={onBackdropClick}
                     aria-hidden
                   />
-                  <RemoveScroll forwardProps ref={modalMergedRef}>
-                    <div
-                      className={cx(
-                        styles.modal,
-                        styles[animationType],
-                        getStyle(styles, camelCase("size-" + size)),
-                        { [styles.withHeaderAction]: !!renderHeaderAction },
-                        className
-                      )}
-                      id={id}
-                      data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL, id)}
-                      data-vibe={ComponentVibeId.MODAL}
-                      role="dialog"
-                      aria-modal
-                      aria-labelledby={ariaLabelledby || titleId}
-                      aria-describedby={ariaDescribedby || descriptionId}
-                      style={{ ...style, ...anchorVars }}
-                      tabIndex={-1}
-                    >
-                      {children}
-                      <ModalTopActions
-                        renderAction={renderHeaderAction}
-                        theme={closeButtonTheme}
-                        closeButtonAriaLabel={closeButtonAriaLabel}
-                        onClose={onClose}
-                      />
-                    </div>
-                  </RemoveScroll>
+                  <div
+                    ref={modalMergedRef}
+                    className={cx(
+                      styles.modal,
+                      styles[animationType],
+                      getStyle(styles, camelCase("size-" + size)),
+                      { [styles.withHeaderAction]: !!renderHeaderAction },
+                      className
+                    )}
+                    id={id}
+                    data-testid={dataTestId || getTestId(ComponentDefaultTestId.MODAL, id)}
+                    data-vibe={ComponentVibeId.MODAL}
+                    role="dialog"
+                    aria-modal
+                    aria-labelledby={ariaLabelledby || titleId}
+                    aria-describedby={ariaDescribedby || descriptionId}
+                    style={{ ...style, ...anchorVars }}
+                    tabIndex={-1}
+                  >
+                    {children}
+                    <ModalTopActions
+                      renderAction={renderHeaderAction}
+                      theme={closeButtonTheme}
+                      closeButtonAriaLabel={closeButtonAriaLabel}
+                      onClose={onClose}
+                    />
+                  </div>
                 </div>
               </FocusLockComponent>,
               portalTargetElement

--- a/packages/core/src/components/Modal/hooks/useBodyScrollLock/useBodyScrollLock.ts
+++ b/packages/core/src/components/Modal/hooks/useBodyScrollLock/useBodyScrollLock.ts
@@ -1,0 +1,38 @@
+import { useEffect } from "react";
+
+// Reference-counted body scroll lock so multiple stacked modals don't
+// fight over `document.body` styles. The first lock captures and applies
+// the styles; the last unlock restores them.
+let activeLockCount = 0;
+let savedBodyOverflow = "";
+let savedBodyPaddingRight = "";
+
+const useBodyScrollLock = (locked: boolean) => {
+  useEffect(() => {
+    if (!locked || typeof document === "undefined") return undefined;
+
+    if (activeLockCount === 0) {
+      const { body, documentElement } = document;
+      savedBodyOverflow = body.style.overflow;
+      savedBodyPaddingRight = body.style.paddingRight;
+
+      const scrollbarWidth = window.innerWidth - documentElement.clientWidth;
+      body.style.overflow = "hidden";
+      if (scrollbarWidth > 0) {
+        const currentPaddingRight = parseFloat(getComputedStyle(body).paddingRight) || 0;
+        body.style.paddingRight = `${currentPaddingRight + scrollbarWidth}px`;
+      }
+    }
+
+    activeLockCount += 1;
+    return () => {
+      activeLockCount -= 1;
+      if (activeLockCount === 0) {
+        document.body.style.overflow = savedBodyOverflow;
+        document.body.style.paddingRight = savedBodyPaddingRight;
+      }
+    };
+  }, [locked]);
+};
+
+export default useBodyScrollLock;


### PR DESCRIPTION
### **User description**
## Summary
- Modal was the only consumer of `react-remove-scroll`. Replaced it with a small internal hook (`useBodyScrollLock`) that toggles `document.body`'s `overflow` and pads for the scrollbar to prevent layout jump.
- Multiple stacked modals share a single lock via a module-level counter, so the body styles are only touched on the first lock and restored on the last unlock.

## Why
`@vibe/core` is shipped into every monday MFE that uses Vibe via Trident's shared-dependencies system, but `react-remove-scroll` is **not** in Trident's shared lists (`BASE_LIST` / `EXPANDED_LIST`). Every MFE bundle re-includes it. Removing this dependency reduces the per-MFE bundle size and trims one source of dependency-permutation risk.

## Test plan
- [x] All 72 existing Modal tests pass locally
- [ ] Verify in Storybook that the body doesn't scroll while a modal is open
- [ ] Verify there's no layout shift when opening the modal on a page with a vertical scrollbar
- [ ] Verify stacked modals still lock scroll correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Replace `react-remove-scroll` with internal `useBodyScrollLock` hook

- Implement reference-counted scroll lock for stacked modals

- Prevent layout shift by padding body for scrollbar width

- Remove third-party dependency from package.json


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Modal Component"] -->|"uses"| B["useBodyScrollLock Hook"]
  B -->|"manages"| C["document.body styles"]
  C -->|"toggles"| D["overflow hidden"]
  C -->|"adjusts"| E["padding-right"]
  F["Reference Counter"] -->|"tracks"| B
  F -->|"prevents conflicts"| G["Stacked Modals"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>useBodyScrollLock.ts</strong><dd><code>New useBodyScrollLock hook implementation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Modal/hooks/useBodyScrollLock/useBodyScrollLock.ts

<ul><li>New hook that manages body scroll lock with reference counting<br> <li> Saves and restores original <code>overflow</code> and <code>paddingRight</code> styles<br> <li> Calculates scrollbar width to prevent layout shift<br> <li> Supports multiple stacked modals via counter mechanism</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3373/files#diff-d6e38a1b506ff39ca8ef92d81d81b212658dfae0d0e2ae2b0432b4ec34c2208e">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Modal.tsx</strong><dd><code>Replace RemoveScroll with useBodyScrollLock hook</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/src/components/Modal/Modal/Modal.tsx

<ul><li>Remove <code>RemoveScroll</code> component import and wrapper<br> <li> Add <code>useBodyScrollLock</code> hook import and call<br> <li> Unwrap modal content from <code>RemoveScroll</code> component<br> <li> Simplify JSX structure by removing wrapper element</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3373/files#diff-ae273d1fbb99fc4e4045d805b44f26f9c8844b9be0a70167269daeba64063141">+30/-29</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Remove react-remove-scroll dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/core/package.json

<ul><li>Remove <code>react-remove-scroll</code> dependency from dependencies list<br> <li> Reduces bundle size for all consuming MFEs</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3373/files#diff-0b810c38f3c138a3d5e44854edefd5eb966617ca84e62f06511f60acc40546c7">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

