### PR TITLE
feat(animations): tasteful motion refresh with reduced-motion support

### DIFF
--- a/packages/components/dialog/src/Dialog/components/DialogContent/DialogContent.module.scss
+++ b/packages/components/dialog/src/Dialog/components/DialogContent/DialogContent.module.scss
@@ -1,4 +1,5 @@
 @import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
 
 .contentWrapper {
   outline: 0;
@@ -53,121 +54,147 @@
 }
 
 // Animations
+//
+// Two flavors driven by Dialog's `animationType` prop:
+//   - opacity-and-slide: fade + 16px translate from origin (default for popovers)
+//   - expand: scale-from-origin + fade (used by Tooltip, Menu submenus)
+//
+// Both are gated on `prefers-reduced-motion: no-preference`. Reduced-motion
+// users get the popover at rest immediately with no transition.
 
 $translate-minus-px: calc(var(--space-16) * -1);
 
 .opacitySlideAppear {
-  opacity: 0;
+  @include motion-safe {
+    opacity: 0;
 
-  &.top {
-    transform: translateY(var(--space-16));
-  }
+    &.top {
+      transform: translateY(var(--space-16));
+    }
 
-  &.right {
-    transform: translateX($translate-minus-px);
-  }
+    &.right {
+      transform: translateX($translate-minus-px);
+    }
 
-  &.bottom {
-    transform: translateY($translate-minus-px);
-  }
+    &.bottom {
+      transform: translateY($translate-minus-px);
+    }
 
-  &.left {
-    transform: translateX(var(--space-16));
+    &.left {
+      transform: translateX(var(--space-16));
+    }
   }
 }
 
 .opacitySlideAppearActive {
-  transition: opacity 0.2s ease, transform 0.2s ease-out;
-  opacity: 1;
   pointer-events: none;
 
-  &.top,
-  &.bottom {
-    transform: translateY(0);
-  }
+  @include motion-safe {
+    transition: opacity var(--motion-productive-long) var(--motion-timing-enter),
+      transform var(--motion-productive-long) var(--motion-timing-enter);
+    opacity: 1;
 
-  &.right,
-  &.left {
-    transform: translateX(0);
+    &.top,
+    &.bottom {
+      transform: translateY(0);
+    }
+
+    &.right,
+    &.left {
+      transform: translateX(0);
+    }
   }
 }
 
 .expandAppear,
 .expandExit {
-  transition: transform 0.1s $expand-animation-timing;
-  &.top,
-  &.topStart,
-  &.topEnd {
-    transform-origin: bottom center;
-    transform: scale(0.8);
-    &.edgeBottom {
-      transform-origin: bottom left;
-    }
-    &.edgeTop {
-      transform-origin: bottom right;
-    }
-  }
+  @include motion-safe {
+    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
+      opacity var(--motion-productive-long) var(--motion-timing-enter);
+    opacity: 0;
 
-  &.right,
-  &.rightStart,
-  &.rightEnd {
-    transform-origin: left;
-    transform: scale(0.8);
-    &.edgeBottom {
-      transform-origin: top left;
+    &.top,
+    &.topStart,
+    &.topEnd {
+      transform-origin: bottom center;
+      transform: scale(0.92);
+      &.edgeBottom {
+        transform-origin: bottom left;
+      }
+      &.edgeTop {
+        transform-origin: bottom right;
+      }
     }
-    &.edgeTop {
-      transform-origin: bottom left;
-    }
-  }
 
-  &.bottom,
-  &.bottomStart,
-  &.bottomEnd {
-    transform-origin: top;
-    transform: scale(0.8);
-    &.edgeBottom {
-      transform-origin: top left;
+    &.right,
+    &.rightStart,
+    &.rightEnd {
+      transform-origin: left;
+      transform: scale(0.92);
+      &.edgeBottom {
+        transform-origin: top left;
+      }
+      &.edgeTop {
+        transform-origin: bottom left;
+      }
     }
-    &.edgeTop {
-      transform-origin: top right;
-    }
-  }
 
-  &.left,
-  &.leftStart,
-  &.leftEnd {
-    transform-origin: right;
-    transform: scale(0.8);
-    &.edgeBottom {
-      transform-origin: top right;
+    &.bottom,
+    &.bottomStart,
+    &.bottomEnd {
+      transform-origin: top;
+      transform: scale(0.92);
+      &.edgeBottom {
+        transform-origin: top left;
+      }
+      &.edgeTop {
+        transform-origin: top right;
+      }
     }
-    &.edgeTop {
-      transform-origin: bottom right;
+
+    &.left,
+    &.leftStart,
+    &.leftEnd {
+      transform-origin: right;
+      transform: scale(0.92);
+      &.edgeBottom {
+        transform-origin: top right;
+      }
+      &.edgeTop {
+        transform-origin: bottom right;
+      }
     }
   }
 }
 
 .expandExit {
-  transition: transform 0.1s $expand-animation-timing;
+  @include motion-safe {
+    transition: transform var(--motion-productive-medium) var(--motion-timing-exit),
+      opacity var(--motion-productive-medium) var(--motion-timing-exit);
+  }
 }
 
 .expandAppearActive {
-  transition: transform 0.1s $expand-animation-timing;
   pointer-events: none;
 
-  &.top,
-  &.topStart,
-  &.topEnd,
-  &.bottom,
-  &.bottomStart,
-  &.bottomEnd,
-  &.right,
-  &.rightStart,
-  &.rightEnd,
-  &.left,
-  &.leftStart,
-  &.leftEnd {
-    transform: scale(1);
+  @include motion-safe {
+    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
+      opacity var(--motion-productive-long) var(--motion-timing-enter);
+    opacity: 1;
+
+    &.top,
+    &.topStart,
+    &.topEnd,
+    &.bottom,
+    &.bottomStart,
+    &.bottomEnd,
+    &.right,
+    &.rightStart,
+    &.rightEnd,
+    &.left,
+    &.leftStart,
+    &.leftEnd {
+      transform: scale(1);
+    }
   }
 }

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.module.scss
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.module.scss
@@ -4,43 +4,58 @@
 // Submenu open/close animation. Mirrors the `expand` variant in DialogContent —
 // fade + scale-from-origin keyed off the floating-ui placement so the submenu
 // grows out of the parent menu item's edge.
+//
+// Uses CSS animations instead of transitions because CSSTransition+mountOnEnter
+// can skip the "from" frame when the class swap lands in a single paint —
+// keyframes fire reliably on a freshly mounted element.
 
-.appear,
-.exit {
-  @include motion-safe {
-    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
-      opacity var(--motion-productive-long) var(--motion-timing-enter);
+@keyframes submenuExpandIn {
+  from {
     opacity: 0;
     transform: scale(0.92);
-
-    &.rightStart {
-      transform-origin: top left;
-    }
-    &.rightEnd {
-      transform-origin: bottom left;
-    }
-    &.leftStart {
-      transform-origin: top right;
-    }
-    &.leftEnd {
-      transform-origin: bottom right;
-    }
+  }
+  to {
+    opacity: 1;
+    transform: scale(1);
   }
 }
 
-.exit {
-  @include motion-safe {
-    transition: transform var(--motion-productive-medium) var(--motion-timing-exit),
-      opacity var(--motion-productive-medium) var(--motion-timing-exit);
+@keyframes submenuExpandOut {
+  from {
+    opacity: 1;
+    transform: scale(1);
   }
+  to {
+    opacity: 0;
+    transform: scale(0.92);
+  }
+}
+
+.rightStart {
+  transform-origin: top left;
+}
+
+.rightEnd {
+  transform-origin: bottom left;
+}
+
+.leftStart {
+  transform-origin: top right;
+}
+
+.leftEnd {
+  transform-origin: bottom right;
 }
 
 .appearActive,
 .enterActive {
   @include motion-safe {
-    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
-      opacity var(--motion-productive-long) var(--motion-timing-enter);
-    opacity: 1;
-    transform: scale(1);
+    animation: submenuExpandIn var(--motion-productive-long) var(--motion-timing-enter) forwards;
+  }
+}
+
+.exitActive {
+  @include motion-safe {
+    animation: submenuExpandOut var(--motion-productive-medium) var(--motion-timing-exit) forwards;
   }
 }

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.module.scss
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.module.scss
@@ -1,0 +1,46 @@
+@import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
+
+// Submenu open/close animation. Mirrors the `expand` variant in DialogContent —
+// fade + scale-from-origin keyed off the floating-ui placement so the submenu
+// grows out of the parent menu item's edge.
+
+.appear,
+.exit {
+  @include motion-safe {
+    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
+      opacity var(--motion-productive-long) var(--motion-timing-enter);
+    opacity: 0;
+    transform: scale(0.92);
+
+    &.rightStart {
+      transform-origin: top left;
+    }
+    &.rightEnd {
+      transform-origin: bottom left;
+    }
+    &.leftStart {
+      transform-origin: top right;
+    }
+    &.leftEnd {
+      transform-origin: bottom right;
+    }
+  }
+}
+
+.exit {
+  @include motion-safe {
+    transition: transform var(--motion-productive-medium) var(--motion-timing-exit),
+      opacity var(--motion-productive-medium) var(--motion-timing-exit);
+  }
+}
+
+.appearActive,
+.enterActive {
+  @include motion-safe {
+    transition: transform var(--motion-productive-long) var(--motion-timing-enter),
+      opacity var(--motion-productive-long) var(--motion-timing-enter);
+    opacity: 1;
+    transform: scale(1);
+  }
+}

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.tsx
@@ -1,5 +1,4 @@
 import React, { useMemo, useRef } from "react";
-import cx from "classnames";
 import { CSSTransition } from "react-transition-group";
 import { camelCase } from "es-toolkit";
 import { DialogContentContainer } from "@vibe/dialog";
@@ -66,15 +65,12 @@ const MenuItemSubMenu = ({
         nodeRef={transitionRef}
         timeout={{ appear: 150, enter: 150, exit: 100 }}
         classNames={{
-          appear: cx(styles.appear, placementClassName),
-          appearActive: cx(styles.appearActive, placementClassName),
-          enter: cx(styles.appear, placementClassName),
-          enterActive: cx(styles.enterActive, placementClassName),
-          exit: cx(styles.exit, placementClassName),
-          exitActive: cx(styles.exit, placementClassName)
+          appearActive: styles.appearActive,
+          enterActive: styles.enterActive,
+          exitActive: styles.exitActive
         }}
       >
-        <div ref={transitionRef}>
+        <div ref={transitionRef} className={placementClassName}>
           <DialogContentContainer>
             {React.cloneElement(subMenu, {
               ...subMenu?.props,

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/MenuItemSubMenu.tsx
@@ -1,9 +1,13 @@
 import React, { useMemo, useRef } from "react";
+import cx from "classnames";
+import { CSSTransition } from "react-transition-group";
+import { camelCase } from "es-toolkit";
 import { DialogContentContainer } from "@vibe/dialog";
 import { useFloating, flip, type Placement } from "@floating-ui/react-dom";
 import { type MenuChild } from "../../../Menu/MenuConstants";
 import { type MenuItemSubMenuProps } from "./MenuItemSubMenu.types";
-import { useIsomorphicLayoutEffect } from "@vibe/shared";
+import { useIsomorphicLayoutEffect, getStyle } from "@vibe/shared";
+import styles from "./MenuItemSubMenu.module.scss";
 
 const DEFAULT_FALLBACK_PLACEMENTS: Placement[] = ["right-end", "left-start", "left-end"];
 
@@ -16,6 +20,7 @@ const MenuItemSubMenu = ({
   submenuPosition
 }: MenuItemSubMenuProps) => {
   const childRef = useRef<HTMLDivElement>(null);
+  const transitionRef = useRef<HTMLDivElement>(null);
 
   useIsomorphicLayoutEffect(() => {
     if (!autoFocusOnMount || !open || !childRef?.current) {
@@ -49,24 +54,39 @@ const MenuItemSubMenu = ({
     return null;
   }
 
+  const placementClassName = getStyle(styles, camelCase(actualPlacement));
+
   return (
-    <div
-      style={{ ...floatingStyles, visibility: open ? "visible" : "hidden" }}
-      ref={refs.setFloating}
-      data-popper-placement={actualPlacement}
-    >
-      {subMenu && open && (
-        <DialogContentContainer>
-          {React.cloneElement(subMenu, {
-            ...subMenu?.props,
-            isVisible: open,
-            isSubMenu: true,
-            onClose,
-            ref: childRef,
-            useDocumentEventListeners: !autoFocusOnMount
-          })}
-        </DialogContentContainer>
-      )}
+    <div style={floatingStyles} ref={refs.setFloating} data-popper-placement={actualPlacement}>
+      <CSSTransition
+        in={open}
+        appear
+        mountOnEnter
+        unmountOnExit
+        nodeRef={transitionRef}
+        timeout={{ appear: 150, enter: 150, exit: 100 }}
+        classNames={{
+          appear: cx(styles.appear, placementClassName),
+          appearActive: cx(styles.appearActive, placementClassName),
+          enter: cx(styles.appear, placementClassName),
+          enterActive: cx(styles.enterActive, placementClassName),
+          exit: cx(styles.exit, placementClassName),
+          exitActive: cx(styles.exit, placementClassName)
+        }}
+      >
+        <div ref={transitionRef}>
+          <DialogContentContainer>
+            {React.cloneElement(subMenu, {
+              ...subMenu?.props,
+              isVisible: open,
+              isSubMenu: true,
+              onClose,
+              ref: childRef,
+              useDocumentEventListeners: !autoFocusOnMount
+            })}
+          </DialogContentContainer>
+        </div>
+      </CSSTransition>
     </div>
   );
 };

--- a/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/__tests__/MenuItemSubMenu.test.tsx
+++ b/packages/core/src/components/Menu/MenuItem/components/MenuItemSubMenu/__tests__/MenuItemSubMenu.test.tsx
@@ -24,24 +24,24 @@ const MockMenuChild = React.forwardRef(({ onClose }: MenuProps, ref: React.Forwa
 Object.assign(MockMenuChild, { isMenu: true });
 
 describe("MenuItemSubMenu", () => {
-  it("should render correctly with visibility hidden when not open", () => {
+  it("should not render submenu content when not open", () => {
     const mockAnchor = document.createElement("div");
-    const { container } = render(
+    const { queryByText } = render(
       <MenuItemSubMenu anchorRef={{ current: mockAnchor }} open={false}>
         <MockMenuChild />
       </MenuItemSubMenu>
     );
-    expect(container.firstChild).toHaveStyle("visibility: hidden");
+    expect(queryByText("Items")).not.toBeInTheDocument();
   });
 
-  it("should render correctly and become visible when open is true", () => {
+  it("should render submenu content when open is true", () => {
     const mockAnchor = document.createElement("div");
-    const { container } = render(
+    const { getByText } = render(
       <MenuItemSubMenu anchorRef={{ current: mockAnchor }} open>
         <MockMenuChild />
       </MenuItemSubMenu>
     );
-    expect(container.firstChild).toHaveStyle("visibility: visible");
+    expect(getByText("Items")).toBeInTheDocument();
   });
 
   it("should call onClose when requested to close", () => {

--- a/packages/core/src/components/Modal/Modal/Modal.module.scss
+++ b/packages/core/src/components/Modal/Modal/Modal.module.scss
@@ -1,3 +1,6 @@
+@import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
+
 $full-view-margin: 40px;
 
 .container {
@@ -113,129 +116,131 @@ $full-view-margin: 40px;
   }
 }
 
-// FROM state — must match 0% keyframes exactly to prevent flash on mount.
+// FROM state — must match keyframes exactly to prevent flash on mount.
+// Only applied under motion-safe, otherwise the modal mounts directly at rest.
 .containerEnter {
-  .overlay {
-    opacity: 0;
-  }
+  @include motion-safe {
+    .overlay {
+      opacity: 0;
+    }
 
-  .centerPop {
-    opacity: 0;
-    transform: translate(-50%, -50%) scale(0.8);
-  }
+    .centerPop {
+      opacity: 0;
+      transform: translate(-50%, -50%) scale(0.94);
+    }
 
-  .anchorPop {
-    opacity: 0;
-    transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px))) scale(0.8);
-  }
+    .anchorPop {
+      opacity: 0;
+      transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px)))
+        scale(0.94);
+    }
 
-  .fullView {
-    opacity: 0.3;
-    transform: translateY(30px);
+    .fullView {
+      opacity: 0.3;
+      transform: translateY(var(--space-24));
+    }
   }
 }
 
 .containerEnterActive {
-  .overlay {
-    opacity: 1;
-    transition: opacity 100ms cubic-bezier(0, 0, 0.4, 1);
-  }
+  @include motion-safe {
+    .overlay {
+      opacity: 1;
+      transition: opacity var(--motion-productive-medium) var(--motion-timing-enter);
+    }
 
-  .centerPop {
-    animation: centerPopIn 150ms cubic-bezier(0, 0, 0.4, 1) forwards;
-  }
+    .centerPop {
+      animation: centerPopIn var(--motion-expressive-short) var(--motion-timing-emphasize) forwards;
+    }
 
-  .anchorPop {
-    animation: anchorPopIn 200ms cubic-bezier(0, 0, 0.4, 1) forwards;
-  }
+    .anchorPop {
+      animation: anchorPopIn var(--motion-expressive-short) var(--motion-timing-emphasize) forwards;
+    }
 
-  .fullView {
-    animation: fullViewIn 250ms cubic-bezier(0, 0, 0.4, 1) forwards;
+    .fullView {
+      animation: fullViewIn var(--motion-expressive-short) var(--motion-timing-enter) forwards;
+    }
   }
 }
 
 .containerExitActive {
-  .overlay {
-    opacity: 0;
-    transition: opacity 100ms cubic-bezier(0.6, 0, 1, 1);
-  }
+  @include motion-safe {
+    .overlay {
+      opacity: 0;
+      transition: opacity var(--motion-productive-medium) var(--motion-timing-exit);
+    }
 
-  .centerPop {
-    animation: centerPopOut 100ms cubic-bezier(0.6, 0, 1, 1) forwards;
-  }
+    .centerPop {
+      animation: centerPopOut var(--motion-productive-long) var(--motion-timing-exit) forwards;
+    }
 
-  .anchorPop {
-    animation: anchorPopOut 150ms cubic-bezier(0.6, 0, 1, 1) forwards;
-  }
+    .anchorPop {
+      animation: anchorPopOut var(--motion-productive-long) var(--motion-timing-exit) forwards;
+    }
 
-  .fullView {
-    animation: fullViewOut 100ms cubic-bezier(0.6, 0, 1, 1) forwards;
+    .fullView {
+      animation: fullViewOut var(--motion-productive-medium) var(--motion-timing-exit) forwards;
+    }
   }
 }
 
 @keyframes centerPopIn {
-  0% {
+  from {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.8);
+    transform: translate(-50%, -50%) scale(0.94);
   }
 
-  50%,
-  100% {
+  to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
 }
 
 @keyframes centerPopOut {
-  0%,
-  50% {
+  from {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
 
-  100% {
+  to {
     opacity: 0;
-    transform: translate(-50%, -50%) scale(0.8);
+    transform: translate(-50%, -50%) scale(0.94);
   }
 }
 
 @keyframes anchorPopIn {
-  0%,
-  40% {
+  from {
     opacity: 0;
-    transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px))) scale(0.8);
+    transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px)))
+      scale(0.94);
   }
 
-  100% {
+  to {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
 }
 
 @keyframes anchorPopOut {
-  0% {
+  from {
     opacity: 1;
     transform: translate(-50%, -50%) scale(1);
   }
 
-  60%,
-  100% {
+  to {
     opacity: 0;
-    transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px))) scale(0.8);
+    transform: translate(calc(-50% + var(--modal-start-x, 0px)), calc(-50% + var(--modal-start-y, 0px)))
+      scale(0.94);
   }
 }
 
 @keyframes fullViewIn {
-  0% {
+  from {
     opacity: 0.3;
-    transform: translateY(30px);
+    transform: translateY(var(--space-24));
   }
 
-  33% {
-    opacity: 1;
-  }
-
-  100% {
+  to {
     opacity: 1;
     transform: translateY(0);
   }
@@ -249,6 +254,6 @@ $full-view-margin: 40px;
 
   to {
     opacity: 0;
-    transform: translateY(30px);
+    transform: translateY(var(--space-24));
   }
 }

--- a/packages/core/src/components/Skeleton/Skeleton.module.scss
+++ b/packages/core/src/components/Skeleton/Skeleton.module.scss
@@ -1,20 +1,25 @@
+@import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
 @import "SkeletonVariables";
 
 @mixin shine-animation() {
   overflow: hidden;
-  animation-duration: 0.8s;
-  animation-direction: alternate;
-  animation-iteration-count: infinite;
-  animation-name: shine;
-  animation-timing-function: steps(10, end);
 
-  @keyframes shine {
-    0% {
-      opacity: 0.4;
-    }
-    100% {
-      opacity: 1;
-    }
+  @include motion-safe {
+    animation: shine 0.8s steps(10, end) infinite alternate;
+  }
+
+  @include motion-reduce {
+    opacity: 0.7;
+  }
+}
+
+@keyframes shine {
+  0% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
   }
 }
 

--- a/packages/core/src/components/Tabs/Tab/Tab.module.scss
+++ b/packages/core/src/components/Tabs/Tab/Tab.module.scss
@@ -1,4 +1,5 @@
 @import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
 @import "../../../styles/states";
 @import "../../../styles/typography";
 
@@ -66,7 +67,10 @@
 
 .tabWrapper.active:after {
   transform: scaleX(1);
-  transition: transform var(--motion-productive-medium) var(--motion-timing-enter);
+
+  @include motion-safe {
+    transition: transform var(--motion-productive-medium) var(--motion-timing-enter);
+  }
 }
 
 .tabWrapper.disabled .tabInner {

--- a/packages/core/src/components/Toast/Toast.module.scss
+++ b/packages/core/src/components/Toast/Toast.module.scss
@@ -1,3 +1,5 @@
+@import "~@vibe/style/dist/mixins";
+@import "~@vibe/style/dist/mixins/motion";
 @import "../../styles/keyframes";
 
 .toast {
@@ -17,7 +19,11 @@
   border-radius: var(--border-radius-small);
   color: var(--fixed-light-color);
   transform: translateX(-50%);
-  transition: background-color 80ms cubic-bezier(0.6, 0, 0.4, 1), width 200ms cubic-bezier(0, 0, 0.4, 1);
+
+  @include motion-safe {
+    transition: background-color var(--motion-productive-short) var(--motion-timing-transition),
+      width var(--motion-expressive-short) var(--motion-timing-enter);
+  }
 
   &.typeNormal {
     background-color: var(--primary-color);
@@ -69,9 +75,14 @@
 
 .actionButton.withTransition {
   opacity: 0;
-  animation: bounceIn 150ms cubic-bezier(0, 0, 0.4, 1);
-  animation-delay: 300ms;
-  animation-fill-mode: forwards;
+
+  @include motion-safe {
+    animation: bounceIn var(--motion-productive-long) var(--motion-timing-emphasize) 300ms forwards;
+  }
+
+  @include motion-reduce {
+    opacity: 1;
+  }
 }
 
 .content {
@@ -85,19 +96,19 @@
 }
 
 .enterActive {
-  animation-iteration-count: 1;
-  animation-fill-mode: forwards;
-  animation-name: slideIn;
-  animation-duration: 350ms;
-  animation-timing-function: cubic-bezier(0.6, 0, 0.4, 1);
+  @include motion-safe {
+    animation: slideIn var(--motion-expressive-short) var(--motion-timing-emphasize) forwards;
+  }
 }
 
 .exitActive {
-  animation-iteration-count: 1;
-  animation-fill-mode: forwards;
-  animation-name: slideOut;
-  animation-duration: 350ms;
-  animation-timing-function: cubic-bezier(0.6, 0, 0.4, 1);
+  @include motion-safe {
+    animation: slideOut var(--motion-productive-long) var(--motion-timing-exit) forwards;
+  }
+
+  @include motion-reduce {
+    opacity: 0;
+  }
 }
 
 .closeButton {
@@ -105,42 +116,37 @@
 }
 
 @keyframes slideIn {
-  0% {
-    transform: translate(-50%, -100px);
+  from {
+    transform: translate(-50%, -100%);
+    opacity: 0;
   }
 
-  40% {
-    transform: translate(-50%, 16px);
-  }
-
-  100% {
-    transform: translate(-50%, 0px);
+  to {
+    transform: translate(-50%, 0);
+    opacity: 1;
   }
 }
 
 @keyframes slideOut {
-  0% {
+  from {
     transform: translate(-50%, 0);
+    opacity: 1;
   }
 
-  100% {
-    transform: translate(-50%, -100px);
+  to {
+    transform: translate(-50%, -100%);
     opacity: 0;
   }
 }
 
 @keyframes bounceIn {
-  0% {
-    transform: scale(0.8);
+  from {
+    transform: scale(0.85);
     opacity: 0;
   }
 
-  50% {
-    opacity: 1;
-  }
-
-  100% {
-    opacity: 1;
+  to {
     transform: scale(1);
+    opacity: 1;
   }
 }

--- a/packages/docs/src/pages/components/Menu/Menu.interactions.ts
+++ b/packages/docs/src/pages/components/Menu/Menu.interactions.ts
@@ -1,4 +1,4 @@
-import { userEvent, within } from "@storybook/test";
+import { userEvent, waitFor, within } from "@storybook/test";
 import {
   getByRole,
   getByText,
@@ -45,12 +45,14 @@ const showSubSubMenusOnHover = async canvas => {
   await userEvent.hover(
     getByText(menuElement, TWO_DEPTHS_MENU_TEXTS.TOP_MENU_NON_SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
   );
-  expect(
-    canvas.queryByText(TWO_DEPTHS_MENU_TEXTS.SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
-  ).not.toBeInTheDocument();
-  expect(
-    canvas.queryByText(TWO_DEPTHS_MENU_TEXTS.SUB_SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
-  ).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      canvas.queryByText(TWO_DEPTHS_MENU_TEXTS.SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
+    ).not.toBeInTheDocument();
+    expect(
+      canvas.queryByText(TWO_DEPTHS_MENU_TEXTS.SUB_SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
+    ).not.toBeInTheDocument();
+  });
 };
 
 const showSubSubMenusWithKeyboard = async canvas => {
@@ -86,14 +88,18 @@ const showSubSubMenusWithKeyboard = async canvas => {
 
   //close sub-sub-menu - using left arrow
   await pressNavigationKey(NavigationCommand.LEFT_ARROW);
-  expect(
-    canvas.queryByText(menuElement, TWO_DEPTHS_MENU_TEXTS.SUB_SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
-  ).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(
+      canvas.queryByText(menuElement, TWO_DEPTHS_MENU_TEXTS.SUB_SUB_MENU_ITEM, { ignore: HIDDEN_ELEMENT_SELECTOR })
+    ).not.toBeInTheDocument();
+  });
   expectActiveElementToHavePartialText(TWO_DEPTHS_MENU_TEXTS.SUB_MENU_ITEM);
 
   //close sub-menu - using escape
   await userEvent.keyboard("{escape}");
-  expect(canvas.queryByText(menuElement, TWO_DEPTHS_MENU_TEXTS.SUB_MENU_ITEM)).not.toBeInTheDocument();
+  await waitFor(() => {
+    expect(canvas.queryByText(menuElement, TWO_DEPTHS_MENU_TEXTS.SUB_MENU_ITEM)).not.toBeInTheDocument();
+  });
   expectActiveElementToHavePartialText(TWO_DEPTHS_MENU_TEXTS.TOP_MENU_SUB_MENU_ITEM);
 };
 

--- a/packages/style/src/mixins/_motion.scss
+++ b/packages/style/src/mixins/_motion.scss
@@ -1,0 +1,15 @@
+// Wrap any non-essential animation or movement transition in `motion-safe`
+// so users with `prefers-reduced-motion: reduce` get a static experience.
+// `motion-reduce` is for the rare case where you need an explicit alternative
+// (e.g. swap a slide for an instant opacity change).
+@mixin motion-safe {
+  @media (prefers-reduced-motion: no-preference) {
+    @content;
+  }
+}
+
+@mixin motion-reduce {
+  @media (prefers-reduced-motion: reduce) {
+    @content;
+  }
+}

--- a/packages/style/src/mixins/index.scss
+++ b/packages/style/src/mixins/index.scss
@@ -1,3 +1,4 @@
 @import "common";
+@import "motion";
 @import "states";
 @import "typography";


### PR DESCRIPTION
### **User description**
## Summary

Refreshes Vibe's animation language so popovers, Toast, Modal, Skeleton, and Menu submenus feel intentional and consistent — and respect `prefers-reduced-motion` across the board.

- New `motion-safe` / `motion-reduce` mixins in `@vibe/style` give every component a single, dependency-free way to gate non-essential motion.
- All animation durations and easings now use existing motion tokens (`--motion-productive-*`, `--motion-expressive-*`, `--motion-timing-*`) — no more hardcoded `0.2s ease`.
- Scale-pops tightened (Modal/popovers from `0.8` → `0.92–0.94`) for a more refined entrance.
- Keyframes normalized to clean `from`/`to` pairs; the natural overshoot now comes from `--motion-timing-emphasize` instead of bespoke `0%/50%/100%` curves.
- **Menu submenus now animate** — they were rendering instantly before. Fade + scale-from-origin keyed off floating-ui placement so the submenu grows out of the parent item's edge.

### What changed by component

- **DialogContent** (used by Tooltip, Dropdown, Dialog popovers): `expand` variant now combines fade + scale-from-origin (was scale-only). Both `opacity-and-slide` and `expand` paths gated on `motion-safe`. Tightened scale to `0.92`.
- **Modal**: `centerPop`, `anchorPop`, `fullView` enter/exit gated on `motion-safe`. Token-based durations. Scale tightened to `0.94`.
- **Toast**: slide-in/out + action-button bounce gated on `motion-safe`, with explicit `motion-reduce` fallbacks (instant opacity). Slide uses `motion-timing-emphasize` for natural overshoot.
- **Skeleton**: shine animation now `motion-safe`; reduce-motion users get a stable `opacity: 0.7` instead of a pulse.
- **Tab**: active indicator transition gated on `motion-safe`.
- **MenuItemSubMenu** (new behavior): wrapped in `CSSTransition` with placement-aware `submenuExpandIn` / `submenuExpandOut` keyframes. Uses CSS animations rather than transitions because CSSTransition + `mountOnEnter` can collapse the start/active class swap into one paint and skip the "from" frame on a fresh mount. Visibility-toggle render strategy replaced with mount/unmount.

### Reduced-motion: the new headline capability

Before this branch, prod ignored `prefers-reduced-motion`. Now Toast, Skeleton, Tooltip, Menu submenu, Modal, Tabs, and Dropdown all respect it.

### Note on the import pattern

A second import `@import "~@vibe/style/dist/mixins/motion";` is added alongside the existing `@import "~@vibe/style/dist/mixins";` in each consumer. This is intentional: `rollup-plugin-postcss`'s Sass importer prefers a partial-prefixed lookup before directory resolution, and in worktree-based dev setups node-resolve can walk up past the worktree boundary into a stale `_mixins.scss` in the main repo's `node_modules`. Importing the partial directly bypasses that ambiguity.

## Test plan

- [x] `yarn workspace @vibe/core build` — clean
- [x] `yarn workspace @vibe/dialog build` — clean
- [x] `yarn workspace @vibe/core test` — 1338 tests passing
- [x] `yarn workspace @vibe/dialog test` — 45 tests passing
- [x] `yarn workspace @vibe/core stylelint` — clean
- [x] `yarn workspace @vibe/dialog stylelint` — clean
- [x] Storybook visual QA: Tooltip, Menu (submenu open + close), Modal, Toast, Skeleton, Tabs
- [ ] Toggle `prefers-reduced-motion: reduce` in DevTools and confirm animations are suppressed (Toast/Skeleton get explicit fallbacks; others mount at rest)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Implement motion-safe/motion-reduce mixins for reduced-motion support

- Replace hardcoded animation durations with motion tokens across components

- Tighten scale-pop ratios (0.8 → 0.92–0.94) for refined entrance animations

- Normalize keyframes to clean from/to pairs with token-based timing

- Animate Menu submenus with placement-aware fade + scale transitions

- Update interaction tests to await animation completion with waitFor


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Motion Mixins<br/>motion-safe/motion-reduce"] --> B["DialogContent<br/>Popovers/Tooltip"]
  A --> C["Modal<br/>Pop animations"]
  A --> D["Toast<br/>Slide + bounce"]
  A --> E["Skeleton<br/>Shine animation"]
  A --> F["Tabs<br/>Indicator transition"]
  A --> G["Menu Submenus<br/>Expand animation"]
  B --> H["Token-based<br/>durations & easing"]
  C --> H
  D --> H
  E --> H
  F --> H
  G --> H
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>_motion.scss</strong><dd><code>New motion-safe and motion-reduce mixins</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-839056850846cdbe2eb48b7bced6a674bdebd7f5e00776265bdbeadc4cd067e1">+15/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>index.scss</strong><dd><code>Export motion mixins from main index</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-73efb663ba5b5418bc476d1b80712bc7c791c94f967e6b630dd294387dc27c43">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DialogContent.module.scss</strong><dd><code>Gate animations on motion-safe, use motion tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-cdb60a24c16c04999753f37653a6529b18146eb2faf9f0c7af7cfb321836a045">+107/-80</a></td>

</tr>

<tr>
  <td><strong>Modal.module.scss</strong><dd><code>Apply motion tokens and reduce-motion support to modals</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-2abf7cf5dd17e9c99928ed0a7de1e6b6fc8a646d336c8f8df72f403d3ff0d2f8">+68/-63</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Toast.module.scss</strong><dd><code>Replace hardcoded durations with motion tokens</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-5e62518014fa9fb4f3b414eb98c7bcceab9e4782a10ebebf3e2527727374f6c4">+39/-33</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Skeleton.module.scss</strong><dd><code>Gate shine animation on motion-safe with fallback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-f35935336aa6f3d7a3cc2870aa0a5c515cb14bd838614659bf33029ebd58cc58">+18/-13</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>Tab.module.scss</strong><dd><code>Gate tab indicator transition on motion-safe</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-7c0b73b8ca6c3c8b4998a9ca09d22d863891009d305a8966125260914da9c612">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MenuItemSubMenu.module.scss</strong><dd><code>New submenu animation styles with placement-aware transforms</code></dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-df8928b18175c90fe6efc3ad091f30f666124b2b5c42be3ec007ca028cf2a0cd">+61/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MenuItemSubMenu.tsx</strong><dd><code>Wrap submenu in CSSTransition with placement-aware animations</code></dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-a0b4d5b39bed49d4b5ce055877405e0bd49e580de99ef88bdb93fd6fd3ca20b7">+34/-18</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>MenuItemSubMenu.test.tsx</strong><dd><code>Update tests to assert mount/unmount instead of visibility</code></dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-5a2e2178b885a3e2c35dcaea61240e572c21466997be5536ae4c5eded917216a">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Menu.interactions.ts</strong><dd><code>Add waitFor to await animation completion in tests</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3375/files#diff-d0ea1b7beaf4c04dd96efef3cf6cbe3ba52d85ce283bcefd7a1a45984b1d5c80">+17/-11</a>&nbsp; </td>

</tr>
</table></details></td></tr></tbody></table>

</details>

___

