### PR TITLE
docs: fix undefined StorybookLinkSize in Search docs page

### DIFF
--- a/packages/docs/src/pages/components/Search/Search.mdx
+++ b/packages/docs/src/pages/components/Search/Search.mdx
@@ -38,7 +38,7 @@ import { Search } from "@vibe/core";
 
 <Tip title="Not what you were looking for?">
   <span>If you need to filter results from a long list, consider using the </span>
-  <StorybookLink page="Components/Combobox" size={StorybookLinkSize.small}>
+  <StorybookLink page="Components/Combobox" size="small">
     <span>Combobox</span>
   </StorybookLink>
   <span> component.</span>


### PR DESCRIPTION
### **User description**
## Summary
- Fixes the Search Storybook documentation page which was broken with `StorybookLinkSize is not defined` error
- Replaced `StorybookLinkSize.small` (never imported/defined) with the string literal `"small"`

Resolves #3354

## Test plan
- [ ] Visit the Search docs page in Storybook and confirm it loads without error
- [ ] Verify the "Combobox" link in the tip renders correctly with small size


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed undefined `StorybookLinkSize` reference in Search docs

- Replaced `StorybookLinkSize.small` with string literal `"small"`

- Resolves runtime error on Search Storybook documentation page


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["StorybookLinkSize.small<br/>undefined reference"] -- "replaced with" --> B["string literal<br/>small"]
  B -- "fixes" --> C["Search docs page<br/>loads without error"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Search.mdx</strong><dd><code>Replace undefined StorybookLinkSize with string literal</code>&nbsp; &nbsp; </dd></summary>
<hr>

packages/docs/src/pages/components/Search/Search.mdx

<ul><li>Replaced undefined <code>StorybookLinkSize.small</code> with string literal <code>"small"</code> <br>in StorybookLink component<br> <li> Fixes runtime error that prevented Search documentation page from <br>loading in Storybook<br> <li> Maintains same visual appearance and functionality of the Combobox <br>component link</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3377/files#diff-e54bd69a89de5f1cc5f28860ce560be47660bd83e31a541c1e3147ac7406eb16">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

