### PR TITLE
feat(Dialog): skip floating-ui computation when closed

### DIFF
--- a/packages/components/dialog/src/Dialog/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog/Dialog.tsx
@@ -99,8 +99,10 @@ function Dialog({
   const isOpenInternal = useDerivedStateFromProps ? isOpenProp : isOpenState;
   const isShown = isOpenInternal || open;
 
-  // Build middleware array for Floating UI
+  // Build middleware array for Floating UI — skip when closed to avoid per-render overhead
   const floatingMiddleware = useMemo<Middleware[]>(() => {
+    if (!isShown) return [];
+
     const middlewareList: Middleware[] = [];
 
     // Get user-provided middleware (filter out invalid ones)
@@ -140,7 +142,7 @@ function Dialog({
     }
 
     return middlewareList;
-  }, [moveBy.main, moveBy.secondary, tooltip, hideWhenReferenceHidden, middlewareProp]);
+  }, [isShown, moveBy.main, moveBy.secondary, tooltip, hideWhenReferenceHidden, middlewareProp]);
 
   // Configure autoUpdate for position tracking
   const whileElementsMounted = useCallback(
@@ -153,11 +155,11 @@ function Dialog({
     [observeContentResize]
   );
 
-  // Use Floating UI hook
+  // Use Floating UI hook — whileElementsMounted is omitted when closed to skip autoUpdate setup
   const { refs, floatingStyles, placement, middlewareData } = useFloating({
     placement: position as Placement,
     middleware: floatingMiddleware,
-    whileElementsMounted,
+    whileElementsMounted: isShown ? whileElementsMounted : undefined,
     elements: {
       reference: referenceElement
     }


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/113184182/pulses/12126192489


### **User description**
## Summary
- Gate `useFloating` middleware on `isShown` — returns `[]` when dialog is closed, avoiding `offset()`, `flip()`, `shift()` etc. construction on every render
- Omit `whileElementsMounted` when closed to skip `autoUpdate` subscription setup
- Fixes performance issue where many closed Dialog instances (e.g. one per list item) cause cumulative overhead on parent re-renders

## Context
Reported by the leftpane team: each leftpane item mounts a Dialog for context menus/tooltips. When the parent re-renders all items (e.g. on `boardsEntities` change), each closed Dialog still runs floating-ui middleware computation — adding up to significant wasted work.

This issue existed in the old react-popper implementation too (`<Popper>` was always rendered even when closed), and carried over into the floating-ui rewrite.

## Test plan
- [x] All 45 Dialog tests pass (show/hide, positioning, triggers, click-outside, tooltips, nested dialogs)
- [ ] Verify in Storybook that dialogs open/position correctly
- [ ] Profile a view with many Dialog instances to confirm reduced render cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Skip floating-ui middleware computation when dialog is closed

- Omit `whileElementsMounted` callback to prevent autoUpdate subscription

- Reduces cumulative overhead from many closed Dialog instances

- Fixes performance regression from floating-ui rewrite


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dialog renders"] --> B{"isShown?"}
  B -->|Yes| C["Build middleware array"]
  B -->|No| D["Return empty middleware"]
  C --> E["Setup autoUpdate"]
  D --> F["Skip autoUpdate"]
  E --> G["Position floating element"]
  F --> G
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Gate floating-ui middleware on dialog visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/dialog/src/Dialog/Dialog.tsx

<ul><li>Gate <code>floatingMiddleware</code> computation on <code>isShown</code> to return empty array <br>when closed<br> <li> Add <code>isShown</code> to dependency array of <code>floatingMiddleware</code> useMemo hook<br> <li> Conditionally pass <code>whileElementsMounted</code> only when <code>isShown</code> is true<br> <li> Update comments to document performance optimization rationale</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3379/files#diff-11d0920f51dbddbf15cd88df5a9e5fa1001be8d3a89daacf124f877953cfe7b3">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

