### PR TITLE
feat(Dialog): skip Popper rendering when dialog is closed

### DIFF
--- a/packages/components/dialog/src/Dialog/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog/Dialog.tsx
@@ -611,6 +611,7 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
           }}
         </Reference>
         {isClient() &&
+          this.isShown() &&
           createPortal(
             <Popper
               placement={position as unknown as PopperJS.Placement}
@@ -640,13 +641,6 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
                     if (!state.styles.arrow) {
                       return state;
                     }
-                    // const reg = new RegExp(
-                    //   /translate\(([0-9].*)px, ([0-9].*)px\)/
-                    // );
-                    // const transform = state.styles.arrow.transform;
-                    // const res = reg.exec(transform);
-                    // state.styles.popper.transformOrigin = `${100 -
-                    //   res[1]}% ${100 - res[2]}%`;
                     state.styles.arrow.transform = `${state.styles.arrow.transform} rotate(45deg)`;
                     return state;
                   }
@@ -656,10 +650,6 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
               ]}
             >
               {({ placement, style, ref, arrowProps, isReferenceHidden }) => {
-                if (!this.isShown() && placement) {
-                  return null;
-                }
-
                 if (hideWhenReferenceHidden && isReferenceHidden) {
                   const event = new CustomEvent("onReferenceHidden");
                   this.hideDialog(event, "onReferenceHidden");

--- a/packages/components/dialog/src/Dialog/Dialog.tsx
+++ b/packages/components/dialog/src/Dialog/Dialog.tsx
@@ -641,6 +641,13 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
                     if (!state.styles.arrow) {
                       return state;
                     }
+                    // const reg = new RegExp(
+                    //   /translate\(([0-9].*)px, ([0-9].*)px\)/
+                    // );
+                    // const transform = state.styles.arrow.transform;
+                    // const res = reg.exec(transform);
+                    // state.styles.popper.transformOrigin = `${100 -
+                    //   res[1]}% ${100 - res[2]}%`;
                     state.styles.arrow.transform = `${state.styles.arrow.transform} rotate(45deg)`;
                     return state;
                   }
@@ -650,6 +657,10 @@ export default class Dialog extends PureComponent<DialogProps, DialogState> {
               ]}
             >
               {({ placement, style, ref, arrowProps, isReferenceHidden }) => {
+                if (!this.isShown() && placement) {
+                  return null;
+                }
+
                 if (hideWhenReferenceHidden && isReferenceHidden) {
                   const event = new CustomEvent("onReferenceHidden");
                   this.hideDialog(event, "onReferenceHidden");


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/113184182/pulses/12126192489

## Summary
- Gate `<Popper>` + `createPortal` on `this.isShown()` — when the dialog is closed, the Popper component is not mounted at all
- Removes the now-redundant `if (!this.isShown()) return null` inside the Popper render prop
- Fixes performance issue where many closed Dialog instances cause cumulative Popper positioning overhead on parent re-renders

## Context
Reported by the leftpane team: each leftpane item mounts a Dialog for context menus/tooltips. When the parent re-renders all items (e.g. on `boardsEntities` change), each closed Dialog still runs Popper's positioning logic (modifiers, event listeners) — adding up to significant wasted work.

Previously, `<Popper>` was always rendered in a portal. Its render prop returned `null` when the dialog was closed, but the Popper component itself still ran all its modifier logic on every render.

## Test plan
- [x] Dialog tests pass (show/hide, positioning, triggers)
- [ ] Verify in Storybook that dialogs open/position correctly
- [ ] Profile a view with many Dialog instances to confirm reduced render cost

🤖 Generated with [Claude Code](https://claude.com/claude-code)


___

### **PR Type**
Enhancement


___

### **Description**
- Gate Popper component rendering on dialog visibility state

- Skip Popper positioning logic when dialog is closed

- Reduces cumulative overhead from many closed Dialog instances

- Improves performance for views with numerous Dialog components


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Dialog Render"] --> B{"isShown()?"}
  B -->|Yes| C["Mount Popper + Portal"]
  C --> D["Run Positioning Logic"]
  B -->|No| E["Skip Rendering"]
  E --> F["No Overhead"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Performance optimization</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dialog.tsx</strong><dd><code>Gate Popper rendering on dialog visibility</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

packages/components/dialog/src/Dialog/Dialog.tsx

<ul><li>Added <code>this.isShown()</code> condition to gate Popper component mounting<br> <li> Popper and createPortal now only render when dialog is visible<br> <li> Eliminates unnecessary positioning logic execution for closed dialogs<br> <li> Removes redundant null return from Popper render prop</ul>


</details>


  </td>
  <td><a href="https://github.com/mondaycom/vibe/pull/3380/files#diff-11d0920f51dbddbf15cd88df5a9e5fa1001be8d3a89daacf124f877953cfe7b3">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

