### PR TITLE
chore(mcp): add ./tools export for programmatic tool access

### DIFF
--- a/packages/mcp/package.json
+++ b/packages/mcp/package.json
@@ -14,6 +14,10 @@
   "author": "monday.com",
   "license": "MIT",
   "type": "module",
+  "exports": {
+    ".": "./dist/index.js",
+    "./tools": "./dist/server/tools/index.js"
+  },
   "bin": "./dist/index.js",
   "files": [
     "dist"

--- a/packages/mcp/src/server/tools/index.ts
+++ b/packages/mcp/src/server/tools/index.ts
@@ -1,0 +1,11 @@
+export { getVibeComponentMetadataTool } from "./get-vibe-component-metadata.js";
+export { listVibePublicComponentsTool } from "./list-vibe-public-components.js";
+export { getVibeComponentExamples } from "./get-vibe-component-examples.js";
+export { getVibeComponentAccessibility } from "./get-vibe-component-accessibility.js";
+export { listVibeIconsTool } from "./list-vibe-icons.js";
+export { listVibeTokensTool } from "./list-vibe-tokens.js";
+export { v3MigrationTool } from "./v3-migration.js";
+export { dropdownMigrationTool } from "./dropdown-migration.js";
+export { IconMetadataService } from "./icon-metadata-service.js";
+export { MetadataService } from "./metadata-service.js";
+export { TokenMetadataService } from "./token-metadata-service.js";


### PR DESCRIPTION
## Summary
- Adds `exports` field to `@vibe/mcp` package.json with a `./tools` subpath
- Creates `src/server/tools/index.ts` barrel file re-exporting all tools and services

This allows consumers (e.g. `@mondaydotcomorg/ui-components-mcp`) to import tools directly via `@vibe/mcp/tools` without spawning the full MCP server process.

## Test plan
- [ ] Verify `tsc` compiles without errors
- [ ] Verify `import { getVibeComponentExamples } from '@vibe/mcp/tools'` resolves correctly after publish