### PR TITLE
fix(TextArea): link character count to aria-describedby when showCharCount is used

### DIFF
--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -40,7 +40,7 @@ const TextArea = forwardRef(
   ) => {
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
-    const charCountTextId = showCharCount && typeof maxLength === "number" && `${id}-char-count`;
+    const charCountTextId = showCharCount && typeof maxLength === "number" && `${id}-allow-exceeding-max-length`;
 
     const ariaDescribedby = useMemo(
       () => [helpTextId, charCountTextId].filter(id => !!id).join(" ") || undefined,

--- a/packages/core/src/components/TextArea/TextArea.tsx
+++ b/packages/core/src/components/TextArea/TextArea.tsx
@@ -40,11 +40,11 @@ const TextArea = forwardRef(
   ) => {
     const numRows = rows || DEFAULT_ROWS[size];
     const helpTextId = helpText && `${id}-help-text`;
-    const allowExceedingMaxLengthTextId = allowExceedingMaxLength && `${id}-allow-exceeding-max-length`;
+    const charCountTextId = showCharCount && typeof maxLength === "number" && `${id}-char-count`;
 
     const ariaDescribedby = useMemo(
-      () => [helpTextId, allowExceedingMaxLengthTextId].filter(id => !!id).join(" ") || undefined,
-      [helpTextId, allowExceedingMaxLengthTextId]
+      () => [helpTextId, charCountTextId].filter(id => !!id).join(" ") || undefined,
+      [helpTextId, charCountTextId]
     );
 
     const [characterCount, setCharacterCount] = useState(value?.length || 0);
@@ -110,7 +110,7 @@ const TextArea = forwardRef(
                   {characterCount}
                   {typeof maxLength === "number" && `/${maxLength}`}
                 </Text>
-                <HiddenText id={allowExceedingMaxLengthTextId} text={`${characterCount} out of ${maxLength}`} />
+                <HiddenText id={charCountTextId} text={`${characterCount} out of ${maxLength}`} />
               </>
             )}
           </Flex>


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/113184182/pulses/12192492070

## Summary
- The hidden character count text (`HiddenText`) was only connected to the textarea via `aria-describedby` when `allowExceedingMaxLength` was set
- Now it's properly linked whenever `showCharCount` and `maxLength` are both provided, so screen readers announce the character count without needing the `allowExceedingMaxLength` prop
- Also fixes a bug where `aria-describedby` referenced a non-existent element when `allowExceedingMaxLength` was true but `showCharCount` was false

## Test plan
- [ ] Verify with screen reader (VoiceOver): `<TextArea showCharCount maxLength={100} />` announces character count on focus
- [ ] Verify `allowExceedingMaxLength` still works as before (soft limit behavior)
- [ ] Verify no regression when neither `showCharCount` nor `maxLength` is set

🤖 Generated with [Claude Code](https://claude.com/claude-code)