### PR TITLE
feat(Dropdown): add zIndex prop to control menu popup stacking order

### DIFF
--- a/packages/core/src/components/Dropdown/Dropdown.types.ts
+++ b/packages/core/src/components/Dropdown/Dropdown.types.ts
@@ -267,6 +267,10 @@ export type BaseDropdownProps<Item extends BaseItemData<Record<string, unknown>>
      * If true, displays a loading indicator in the dropdown controls.
      */
     loading?: boolean;
+    /**
+     * The z-index of the dropdown menu popup. Use when the dropdown appears behind sticky or fixed elements.
+     */
+    zIndex?: number;
   } & (MultiSelectSpecifics<Item> | SingleSelectSpecifics<Item>);
 
 export type DropdownSizes = "small" | "medium" | "large";

--- a/packages/core/src/components/Dropdown/components/DropdownPopup/DropdownPopup.tsx
+++ b/packages/core/src/components/Dropdown/components/DropdownPopup/DropdownPopup.tsx
@@ -7,7 +7,7 @@ import SingleSelectTrigger from "../Trigger/SingleSelectTrigger";
 import MultiSelectTrigger from "../Trigger/MultiSelectTrigger";
 
 const DropdownPopup = () => {
-  const { multi } = useDropdownContext();
+  const { multi, zIndex } = useDropdownContext();
 
   return (
     <Dialog
@@ -21,6 +21,7 @@ const DropdownPopup = () => {
       middleware={[matchWidthMiddleware]}
       content={<Menu />}
       referenceWrapperElement="div"
+      zIndex={zIndex}
     >
       {multi ? <MultiSelectTrigger /> : <SingleSelectTrigger />}
     </Dialog>

--- a/packages/core/src/components/Dropdown/context/DropdownContext.types.ts
+++ b/packages/core/src/components/Dropdown/context/DropdownContext.types.ts
@@ -48,6 +48,7 @@ type InheritedDropdownProps<Item extends BaseItemData<Record<string, unknown>>> 
     | "onKeyDown"
     | "onScroll"
     | "onClear"
+    | "zIndex"
   >
 >;
 


### PR DESCRIPTION
## Summary
- Adds `zIndex?: number` prop to `Dropdown`
- Threads it through `DropdownContext` to the internal `Dialog` used in `DropdownPopup`
- No breaking changes — prop is optional with no default

## Problem
When a Dropdown is used above a `Table`, the sticky table header (`z-index: 2`) covers the dropdown menu popup, with no way to override it.

## Usage
```tsx
<Dropdown options={options} placeholder="All statuses" zIndex={3} />
```

## Monday task
https://monday.monday.com/boards/3532714909/views/113184182/pulses/12213596157

## Test plan
- [ ] Open a Dropdown with `zIndex={3}` next to a Table with a sticky header — menu should appear above the header
- [ ] Dropdown without `zIndex` prop behaves identically to before

🤖 Generated with [Claude Code](https://claude.com/claude-code)