### PR TITLE
feat(Chips): add size prop with small variant

### DIFF
--- a/packages/core/src/components/Chips/Chips.module.scss
+++ b/packages/core/src/components/Chips/Chips.module.scss
@@ -27,6 +27,25 @@
     margin: 0;
   }
 
+  &.small {
+    height: 20px;
+    padding: 0 4px;
+
+    .icon,
+    .avatar,
+    .customRenderer {
+      &.left {
+        margin-inline-end: var(--space-2);
+      }
+      &.right {
+        margin-inline-start: var(--space-2);
+      }
+      &.close {
+        margin-inline-start: var(--space-2);
+      }
+    }
+  }
+
   .label {
     @include ellipsis();
   }

--- a/packages/core/src/components/Chips/Chips.tsx
+++ b/packages/core/src/components/Chips/Chips.tsx
@@ -16,6 +16,7 @@ import useSetFocus from "../../hooks/useSetFocus";
 import { useClickableProps } from "@vibe/clickable";
 import styles from "./Chips.module.scss";
 import { ComponentVibeId } from "../../tests/constants";
+import { type ChipsSize } from "./Chips.types";
 
 const CHIPS_AVATAR_SIZE = 18;
 
@@ -120,6 +121,10 @@ export interface ChipsProps extends VibeComponentProps {
    * If true, removes the default margin from the chip.
    */
   noMargin?: boolean;
+  /**
+   * The size of the chip.
+   */
+  size?: ChipsSize;
 }
 
 const Chips = forwardRef(
@@ -152,7 +157,8 @@ const Chips = forwardRef(
       leftRenderer,
       rightRenderer,
       closeButtonAriaLabel = "Remove",
-      noMargin = false
+      noMargin = false,
+      size = "medium"
     }: ChipsProps,
     ref: React.ForwardedRef<HTMLDivElement>
   ) => {
@@ -176,7 +182,8 @@ const Chips = forwardRef(
       [styles.noAnimation]: noAnimation,
       [styles.withUserSelect]: allowTextSelection,
       [styles.border]: showBorder,
-      [styles.noMargin]: noMargin
+      [styles.noMargin]: noMargin,
+      [styles.small]: size === "small"
     });
     const clickableClassName = cx(styles.clickable, overrideClassName, {
       [styles.disabled]: disabled,

--- a/packages/core/src/components/Chips/Chips.types.ts
+++ b/packages/core/src/components/Chips/Chips.types.ts
@@ -1,0 +1,1 @@
+export type ChipsSize = "small" | "medium";

--- a/packages/core/src/components/Chips/__tests__/Chips.snapshot.test.tsx
+++ b/packages/core/src/components/Chips/__tests__/Chips.snapshot.test.tsx
@@ -10,6 +10,11 @@ describe("Chips renders correctly", () => {
     expect(tree).toMatchSnapshot();
   });
 
+  it("renders correctly with small size", () => {
+    const tree = renderer.create(<Chips label="small chip" size="small" />).toJSON();
+    expect(tree).toMatchSnapshot();
+  });
+
   it("renders correctly with color", () => {
     const tree = renderer.create(<Chips color="negative" />).toJSON();
     expect(tree).toMatchSnapshot();

--- a/packages/core/src/components/Chips/__tests__/__snapshots__/Chips.snapshot.test.tsx.snap
+++ b/packages/core/src/components/Chips/__tests__/__snapshots__/Chips.snapshot.test.tsx.snap
@@ -491,6 +491,68 @@ exports[`Chips renders correctly > renders correctly with right icon 1`] = `
 </div>
 `;
 
+exports[`Chips renders correctly > renders correctly with small size 1`] = `
+<div
+  aria-label="small chip"
+  className="chips noAnimation small"
+  data-testid="chip"
+  data-vibe="Chips"
+  onClick={[Function]}
+  onMouseEnter={[Function]}
+  onMouseLeave={[Function]}
+  style={
+    {
+      "backgroundColor": "var(--primary-selected-color)",
+    }
+  }
+>
+  <div
+    className="typography primary start singleLineEllipsis text text2Normal label"
+    data-testid="text"
+  >
+    small chip
+  </div>
+  <button
+    aria-busy={false}
+    aria-disabled={false}
+    aria-label="Remove"
+    className="icon close button sizeMedium kindTertiary colorOnPrimaryColor noSidePadding"
+    data-testid="chip-close"
+    data-vibe="Button"
+    onBlur={[Function]}
+    onClick={[Function]}
+    onFocus={[Function]}
+    onMouseDown={[Function]}
+    onMouseUp={[Function]}
+    style={
+      {
+        "alignItems": "center",
+        "height": "16px",
+        "justifyContent": "center",
+        "padding": 0,
+        "width": "16px",
+      }
+    }
+    type="button"
+  >
+    <svg
+      aria-hidden={true}
+      className="icon noFocusStyle"
+      data-testid="icon"
+      data-vibe="Icon"
+      fill="currentColor"
+      height="16"
+      viewBox="0 0 20 20"
+      width="16"
+    >
+      <path
+        d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
+      />
+    </svg>
+  </button>
+</div>
+`;
+
 exports[`Chips renders correctly > renders correctly with text 1`] = `
 <div
   aria-label="text"

--- a/packages/core/src/components/Chips/index.ts
+++ b/packages/core/src/components/Chips/index.ts
@@ -1,1 +1,2 @@
 export { default as Chips, type ChipsProps } from "./Chips";
+export * from "./Chips.types";

--- a/packages/docs/src/pages/components/Chips/Chips.stories.tsx
+++ b/packages/docs/src/pages/components/Chips/Chips.stories.tsx
@@ -133,6 +133,51 @@ export const Clickable = {
   name: "Clickable"
 };
 
+export const Sizes = {
+  render: () => (
+    <Flex direction="column" gap="medium" align="start">
+      <Flex gap="medium" align="center">
+        <Chips id="size-medium" aria-label="Medium chip" label="Medium chip" readOnly />
+        <Chips id="size-medium-icon" aria-label="Medium chip with icon" label="With icon" leftIcon={Email} readOnly />
+        <Chips
+          id="size-medium-avatar"
+          aria-label="Medium chip with avatar"
+          label="With avatar"
+          leftAvatar={person1}
+          readOnly
+        />
+      </Flex>
+      <Flex gap="medium" align="center">
+        <Chips id="size-small" aria-label="Small chip" label="Small chip" size="small" readOnly />
+        <Chips
+          id="size-small-icon"
+          aria-label="Small chip with icon"
+          label="With icon"
+          size="small"
+          leftIcon={Email}
+          readOnly
+        />
+        <Chips
+          id="size-small-avatar"
+          aria-label="Small chip with avatar"
+          label="With avatar"
+          size="small"
+          leftAvatar={person1}
+          readOnly
+        />
+      </Flex>
+    </Flex>
+  ),
+  parameters: {
+    docs: {
+      liveEdit: {
+        scope: { Email, person1 }
+      }
+    }
+  },
+  name: "Sizes"
+};
+
 export const ChipsPalette = {
   render: () => {
     const excludedColors = ["dark_indigo", "blackish"];


### PR DESCRIPTION
## Summary
- Add a `size` prop to the Chips component (`"small" | "medium"`, default `"medium"`)
- Small variant: 20px height, 4px horizontal padding, 2px element spacing
- Non-breaking change — existing consumers are unaffected

## Test plan
- [x] Unit tests for size class application (default medium, explicit small)
- [x] Snapshot test for small size rendering
- [x] Lint passes
- [x] TypeScript type-checks cleanly
- [x] Storybook "Sizes" story added showing both variants with icons and avatars

https://monday.monday.com/boards/3532714909/pulses/12358674962