### PR TITLE
ci(bundle-check): exclude peer deps from size measurements

### DIFF
--- a/packages/core/src/components/Accordion/Accordion/Accordion.tsx
+++ b/packages/core/src/components/Accordion/Accordion/Accordion.tsx
@@ -1,8 +1,8 @@
 import cx from "classnames";
 import React, { forwardRef, type ReactElement, useCallback, useMemo, useRef, useState } from "react";
 import { useMergeRef } from "@vibe/shared";
-import { type VibeComponentProps } from "../../../types";
 import styles from "./Accordion.module.scss";
+import { type VibeComponentProps } from "../../../types";
 import { ComponentVibeId } from "../../../tests/constants";
 
 const COMPONENT_ID = "monday-accordion";

--- a/scripts/bundle-check/generate-size-limit-config.js
+++ b/scripts/bundle-check/generate-size-limit-config.js
@@ -20,7 +20,8 @@ function generateSizeLimitConfig() {
       const relativePath = match[1];
       const fullPath = path.join("packages/core/dist/src/", relativePath).replace(/\\/g, "/");
       allComponents.push({
-        path: fullPath
+        path: fullPath,
+        ignore: ["react", "react-dom"]
       });
     }
     console.log(`Found ${allComponents.length} core components.`);
@@ -39,7 +40,8 @@ function generateSizeLimitConfig() {
       const relativePath = match[1];
       const fullPath = path.join("packages/core/dist/src/components/", relativePath).replace(/\\/g, "/");
       allComponents.push({
-        path: fullPath
+        path: fullPath,
+        ignore: ["react", "react-dom"]
       });
       nextComponentsCount++;
     }
@@ -60,7 +62,8 @@ function generateSizeLimitConfig() {
       if (fs.existsSync(packageDistPath)) {
         const relativePath = path.join("packages/components", packageName, "dist/index.js").replace(/\\/g, "/");
         allComponents.push({
-          path: relativePath
+          path: relativePath,
+          ignore: ["react", "react-dom"]
         });
         console.log(`Added component package: ${packageName}`);
       } else {


### PR DESCRIPTION
## Summary

- Add `ignore: ["react", "react-dom"]` to all size-limit entries in the generated config
- These are peerDependencies provided by consumers — they should not count toward component bundle size

## Problem

The size-limit check was bundling `react` and `react-dom` into every component measurement. This was a latent bug that went unnoticed because both base and PR branches always resolved the same React version. Any PR that changes the React `devDependency` version (e.g., upgrading from 16 to 18) would show a false **+3.5KB on every single component**.

## Impact

Reported sizes drop from ~70KB to ~33KB per component (the ~39KB of react/react-dom is correctly excluded). Relative comparisons between PRs become accurate regardless of dev dependency changes.

## Test plan

- [x] Verified locally: Toggle goes from 71.8KB → 32.69KB with the fix
- [ ] CI bundle check runs clean

🤖 Generated with [Claude Code](https://claude.ai/code)