### PR TITLE
fix(MultiStepIndicator): fix invisible text on dark type pending hover

### DIFF
--- a/packages/core/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
+++ b/packages/core/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
@@ -227,7 +227,8 @@
 }
 
 .statusPendingNumberContainer.typeDarkNumberContainer:hover {
-  background-color: var(--text-color-on-inverted);
+  background-color: var(--inverted-color-background);
+  color: var(--text-color-on-inverted);
 }
 
 @include keyframe(step-indicatior-circle-pop-elastic) {


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/113184182/pulses/12423304814

## Summary
- In light mode, hovering a pending step with `type="dark"` caused the step number to become invisible: the background was set to `--text-color-on-inverted` (white in light mode) while the text color inherited `--text-color-on-primary` (also white) from the general pending hover rule
- Fixed by switching to the semantically correct inverted color pair: `--inverted-color-background` as background and `--text-color-on-inverted` as text color

## Root Cause
```scss
/* Before */
.statusPendingNumberContainer.typeDarkNumberContainer:hover {
  background-color: var(--text-color-on-inverted); /* white in light mode */
  /* text inherits --text-color-on-primary = white → white on white */
}

/* After */
.statusPendingNumberContainer.typeDarkNumberContainer:hover {
  background-color: var(--inverted-color-background); /* dark charcoal in light mode */
  color: var(--text-color-on-inverted);               /* white in light mode */
}
```

## Test plan
- [ ] In light mode: hover a pending step with `type="dark"` — number should be visible (white text on dark background)
- [ ] In dark mode: hover a pending step with `type="dark"` — number should be visible
- [ ] Other step statuses (fulfilled, active) and other types (primary, danger, success) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)