### PR TITLE
fix(MultiStepIndicator): fix invisible text on dark type pending hover in light mode

### DIFF
--- a/packages/core/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
+++ b/packages/core/src/components/MultiStepIndicator/components/StepIndicator/StepIndicator.module.scss
@@ -226,7 +226,8 @@
 }
 
 .statusPendingNumberContainer.typeDarkNumberContainer:hover {
-  background-color: var(--text-color-on-inverted);
+  background-color: var(--inverted-color-background);
+  color: var(--text-color-on-inverted);
 }
 
 @include keyframe(step-indicatior-circle-pop-elastic) {


### PR DESCRIPTION
Backport of #3412 to `version3`.

## Summary
- In light mode, hovering a pending step with `type="dark"` caused the step number to become invisible: the background was set to `--text-color-on-inverted` (white in light mode) while the text color inherited `--text-color-on-primary` (also white) from the general pending hover rule
- Fixed by switching to the correct inverted color pair: `--inverted-color-background` as background and `--text-color-on-inverted` as text color

## Test plan
- [ ] In light mode: hover a pending step with `type="dark"` — number should be visible (white text on dark background)
- [ ] In dark mode: hover a pending step with `type="dark"` — number should be visible
- [ ] Other step statuses (fulfilled, active) and other types (primary, danger, success) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)