### PR TITLE
fix(mcp): fetch component examples and accessibility from unpkg

### DIFF
--- a/packages/mcp/src/__tests__/get-vibe-component-accessibility.test.ts
+++ b/packages/mcp/src/__tests__/get-vibe-component-accessibility.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../server/version-detector.js", () => ({
+  detectVibeVersion: vi.fn().mockResolvedValue(4)
+}));
+
+const curlMock = vi.fn();
+
+vi.mock("child_process", () => {
+  const exec = vi.fn() as any;
+  exec[Symbol.for("nodejs.util.promisify.custom")] = curlMock;
+  return { exec };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("getVibeComponentAccessibility", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("fetches accessibility from unpkg and returns content", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => "## Accessibility\n\nUse aria-label..."
+    });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    const result = await getVibeComponentAccessibility.execute({ componentName: "Checkbox" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://unpkg.com/@vibe/core@4/dist/metadata/accessibility/Checkbox.md"
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toContain("Accessibility");
+  });
+
+  it("caches result and does not fetch again on second call", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => "## Accessibility"
+    });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    await getVibeComponentAccessibility.execute({ componentName: "Button" });
+    await getVibeComponentAccessibility.execute({ componentName: "Button" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to curl when fetch fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    curlMock.mockResolvedValueOnce({ stdout: "## Checkbox accessibility from curl", stderr: "" });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    const result = await getVibeComponentAccessibility.execute({ componentName: "Checkbox" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].text).toBe("## Checkbox accessibility from curl");
+  });
+
+  it("returns error when both fetch and curl fail", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    curlMock.mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    const result = await getVibeComponentAccessibility.execute({ componentName: "Checkbox" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Error retrieving accessibility requirements");
+  });
+
+  it("returns error when component not found (404)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found"
+    });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    const result = await getVibeComponentAccessibility.execute({ componentName: "NonExistent" });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("returns error when componentName is missing", async () => {
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    const result = await getVibeComponentAccessibility.execute({ componentName: "" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toBe("Error: componentName is required");
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  it("uses correct unpkg url for v3", async () => {
+    const { detectVibeVersion } = await import("../server/version-detector.js");
+    vi.mocked(detectVibeVersion).mockResolvedValueOnce(3);
+
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => "content" });
+
+    const { getVibeComponentAccessibility } = await import("../server/tools/get-vibe-component-accessibility.js");
+    await getVibeComponentAccessibility.execute({ componentName: "Button" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://unpkg.com/@vibe/core@3/dist/metadata/accessibility/Button.md"
+    );
+  });
+});

--- a/packages/mcp/src/__tests__/get-vibe-component-examples.test.ts
+++ b/packages/mcp/src/__tests__/get-vibe-component-examples.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("../server/version-detector.js", () => ({
+  detectVibeVersion: vi.fn().mockResolvedValue(4)
+}));
+
+const curlMock = vi.fn();
+
+vi.mock("child_process", () => {
+  const exec = vi.fn() as any;
+  exec[Symbol.for("nodejs.util.promisify.custom")] = curlMock;
+  return { exec };
+});
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+describe("getVibeComponentExamples", () => {
+  beforeEach(async () => {
+    vi.resetModules();
+    vi.clearAllMocks();
+    mockFetch.mockReset();
+  });
+
+  it("fetches examples from unpkg and returns content", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => "## Button examples\n\n```tsx\n<Button>Click</Button>\n```"
+    });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    const result = await getVibeComponentExamples.execute({ componentName: "Button" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://unpkg.com/@vibe/core@4/dist/metadata/examples/Button.md"
+    );
+    expect(result.isError).toBeFalsy();
+    expect(result.content[1].text).toContain("Button examples");
+  });
+
+  it("caches result and does not fetch again on second call", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      text: async () => "## Checkbox examples"
+    });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    await getVibeComponentExamples.execute({ componentName: "Checkbox" });
+    await getVibeComponentExamples.execute({ componentName: "Checkbox" });
+
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it("falls back to curl when fetch fails", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    curlMock.mockResolvedValueOnce({ stdout: "## Button from curl", stderr: "" });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    const result = await getVibeComponentExamples.execute({ componentName: "Button" });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[1].text).toBe("## Button from curl");
+  });
+
+  it("returns error when both fetch and curl fail", async () => {
+    mockFetch.mockRejectedValueOnce(new Error("network error"));
+    curlMock.mockResolvedValueOnce({ stdout: "", stderr: "" });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    const result = await getVibeComponentExamples.execute({ componentName: "Button" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Error in getComponentExampleCode");
+  });
+
+  it("returns error when component not found (404)", async () => {
+    mockFetch.mockResolvedValueOnce({
+      ok: false,
+      status: 404,
+      statusText: "Not Found"
+    });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    const result = await getVibeComponentExamples.execute({ componentName: "NonExistent" });
+
+    expect(result.isError).toBe(true);
+  });
+
+  it("uses correct unpkg url for v3", async () => {
+    const { detectVibeVersion } = await import("../server/version-detector.js");
+    vi.mocked(detectVibeVersion).mockResolvedValueOnce(3);
+
+    mockFetch.mockResolvedValueOnce({ ok: true, text: async () => "content" });
+
+    const { getVibeComponentExamples } = await import("../server/tools/get-vibe-component-examples.js");
+    await getVibeComponentExamples.execute({ componentName: "Button" });
+
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://unpkg.com/@vibe/core@3/dist/metadata/examples/Button.md"
+    );
+  });
+});

--- a/packages/mcp/src/server/tools/get-vibe-component-accessibility.ts
+++ b/packages/mcp/src/server/tools/get-vibe-component-accessibility.ts
@@ -1,17 +1,45 @@
 import { z } from "zod";
+import { exec } from "child_process";
+import { promisify } from "util";
 import { getErrorMessage, MCPTool } from "../index.js";
-import fs from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
+import { detectVibeVersion } from "../version-detector.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const execAsync = promisify(exec);
+
+const cache = new Map<string, string>();
 
 const ComponentNameParamsSchema = z.object({
   componentName: z
     .string()
     .describe("The name of the component to get accessibility requirements for (e.g., Button, Checkbox, TextField)")
 });
+
+async function fetchAccessibility(componentName: string, version: number): Promise<string> {
+  const cacheKey = `${version}:${componentName}`;
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey)!;
+  }
+
+  const url = `https://unpkg.com/@vibe/core@${version}/dist/metadata/accessibility/${componentName}.md`;
+
+  let content: string;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    content = await response.text();
+  } catch (fetchError) {
+    const { stdout } = await execAsync(`curl -s -L "${url}"`);
+    if (!stdout.trim()) {
+      throw fetchError;
+    }
+    content = stdout;
+  }
+
+  cache.set(cacheKey, content);
+  return content;
+}
 
 export const getVibeComponentAccessibility: MCPTool<typeof ComponentNameParamsSchema.shape> = {
   name: "get-vibe-component-accessibility",
@@ -23,44 +51,19 @@ export const getVibeComponentAccessibility: MCPTool<typeof ComponentNameParamsSc
 
     if (!componentName) {
       return {
-        content: [
-          {
-            type: "text",
-            text: "Error: componentName is required"
-          }
-        ],
+        content: [{ type: "text", text: "Error: componentName is required" }],
         isError: true
       };
     }
 
     try {
-      // Read from pre-generated accessibility file
-      const accessibilityFilePath = path.resolve(
-        __dirname,
-        "../../../dist/generated/accessibility/",
-        `${componentName}.md`
-      );
-
-      let accessibilityContent: string;
-      try {
-        accessibilityContent = await fs.readFile(accessibilityFilePath, "utf-8");
-      } catch (readError) {
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Error: Could not find accessibility documentation for component "${componentName}". Expected file: ${accessibilityFilePath}`
-            }
-          ],
-          isError: true
-        };
-      }
-
+      const version = await detectVibeVersion();
+      const content = await fetchAccessibility(componentName, version);
       return {
         content: [
           {
             type: "text",
-            text: accessibilityContent
+            text: content
           }
         ]
       };

--- a/packages/mcp/src/server/tools/get-vibe-component-examples.ts
+++ b/packages/mcp/src/server/tools/get-vibe-component-examples.ts
@@ -1,11 +1,12 @@
 import { z } from "zod";
+import { exec } from "child_process";
+import { promisify } from "util";
 import { getErrorMessage, MCPTool } from "../index.js";
-import fs from "fs/promises";
-import path from "path";
-import { fileURLToPath } from "url";
+import { detectVibeVersion } from "../version-detector.js";
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const execAsync = promisify(exec);
+
+const cache = new Map<string, string>();
 
 const ComponentNameParamsSchema = z.object({
   componentName: z
@@ -16,6 +17,33 @@ const ComponentNameParamsSchema = z.object({
     )
 });
 
+async function fetchExamples(componentName: string, version: number): Promise<string> {
+  const cacheKey = `${version}:${componentName}`;
+  if (cache.has(cacheKey)) {
+    return cache.get(cacheKey)!;
+  }
+
+  const url = `https://unpkg.com/@vibe/core@${version}/dist/metadata/examples/${componentName}.md`;
+
+  let content: string;
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      throw new Error(`HTTP ${response.status}: ${response.statusText}`);
+    }
+    content = await response.text();
+  } catch (fetchError) {
+    const { stdout } = await execAsync(`curl -s -L "${url}"`);
+    if (!stdout.trim()) {
+      throw fetchError;
+    }
+    content = stdout;
+  }
+
+  cache.set(cacheKey, content);
+  return content;
+}
+
 export const getVibeComponentExamples: MCPTool<typeof ComponentNameParamsSchema.shape> = {
   name: "get-vibe-component-examples",
   description:
@@ -24,16 +52,16 @@ export const getVibeComponentExamples: MCPTool<typeof ComponentNameParamsSchema.
   execute: async (input: z.infer<typeof ComponentNameParamsSchema>) => {
     const { componentName } = input;
     try {
-      const contextFilePath = path.resolve(__dirname, "../../../dist/generated/", `${componentName}.md`);
-      const contextFileContents = await fs.readFile(contextFilePath, "utf-8");
+      const version = await detectVibeVersion();
+      const content = await fetchExamples(componentName ?? "", version);
       return {
         content: [
           { type: "text", text: componentName ?? "" },
-          { type: "text", text: contextFileContents }
+          { type: "text", text: content }
         ]
       };
     } catch (e) {
-      const message = (e instanceof Error ? e.message : e) || "Failed to get code samples";
+      const message = getErrorMessage(e) || "Failed to get code samples";
       return {
         content: [
           {


### PR DESCRIPTION
## Summary

- `get-vibe-component-examples` and `get-vibe-component-accessibility` were reading from `dist/generated/` which was never populated in the published `@vibe/mcp` npm package, causing `ENOENT` errors for all consumers
- Migrated both tools to fetch from `unpkg.com/@vibe/core@{version}/dist/metadata/examples/` and `.../accessibility/` — the same architecture used by `metadata-service` for component metadata
- Added session-level per-component caching (`Map<version:componentName, content>`) and curl fallback for corporate proxy environments
- Adds test coverage for fetch, cache hit, curl fallback, 404, and error paths

## Ticket
https://monday.monday.com/boards/3532714909/pulses/12465284365

## Test plan
- [ ] `yarn workspace @vibe/mcp test` passes (30 tests)
- [ ] `yarn workspace @vibe/mcp build` compiles cleanly
- [ ] Verify `get-vibe-component-examples` returns content for a v4 component (e.g. Button)
- [ ] Verify `get-vibe-component-accessibility` returns content for a v4 component (e.g. Checkbox)