### PR TITLE
fix(Tooltip): skip Dialog render when content is falsy

### DIFF
--- a/packages/components/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip/Tooltip.tsx
@@ -250,6 +250,10 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       return this.renderTooltipContent();
     }
 
+    if (!this.props.content) {
+      return <>{children}</>;
+    }
+
     const content = this.renderTooltipContent;
     const dialogProps = {
       ...this.props,


### PR DESCRIPTION
## Summary
- When `Tooltip` receives no `content` prop (falsy), it now returns `<>{children}</>` immediately — bypassing `Dialog` entirely
- This eliminates execution of Dialog's 30+ hooks for every non-overflowing Typography component on screen
- Common case: pages with many `Text`/`Heading` components where most are not overflowing (no tooltip needed)

## Motivation
Typography components use `useIsOverflowing` + `useResizeObserver` to detect overflow and conditionally pass `content` to `Tooltip`. When text is NOT overflowing, `content` is `undefined` — but Dialog was still being mounted and its hooks executed on every render. With 100+ Typography components visible, this created measurable overhead.

## Changes
- Added a 4-line early return in `Tooltip.render()` after the `withoutDialog` check: if `content` is falsy, return `<>{children}</>`

## Safety
- Placed **after** the `withoutDialog` check to preserve its semantics (renders tooltip content only, no children passthrough)
- `renderTooltipContent()` already returns `null` when content is falsy — this optimization just avoids mounting Dialog to discover that
- Verified all consumers across the codebase (IconButton, SliderThumb, Tipseen, ComboboxOption, Tab, TextWithHighlight, etc.)
- All existing Tooltip tests pass (13/13)

## Effect
<img width="723" height="485" alt="Screenshot 2026-07-12 at 13 40 31" src="https://github.com/user-attachments/assets/b81af89d-d7fa-45e6-b5c4-b73724678f7a" />

## Test plan
- [x] Verify tooltip still shows on hover when text is overflowing (ellipsis)
- [x] Verify no tooltip renders when text fits (no overflow)
- [x] Verify SliderThumb tooltip works (controlled `open` prop with conditional content)
- [x] Verify Tipseen renders correctly (always passes JSX content)
- [x] Run `yarn workspace @vibe/tooltip test` — all 13 tests pass