### PR TITLE
perf(ColorPickerItemComponent): skip Tooltip render when showColorNameTooltip is false

### DIFF
--- a/packages/core/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.tsx
+++ b/packages/core/src/components/ColorPicker/components/ColorPickerItemComponent/ColorPickerItemComponent.tsx
@@ -116,47 +116,52 @@ const ColorPickerItemComponent = forwardRef(
 
     const shouldRenderIcon = isSelected || ColorIndicatorIcon;
     const colorIndicatorWrapperStyle = shouldRenderIndicatorWithoutBackground ? { color: colorAsStyle } : {};
-    return (
-      <Tooltip content={tooltipContent}>
-        <li
-          id={id}
-          role="option"
-          aria-selected={isSelected}
-          className={cx(styles.itemWrapper, {
-            [styles.selectedColor]: isSelected,
-            [styles.active]: isActive,
-            [styles.circle]: colorShape === "circle"
+
+    const liElement = (
+      <li
+        id={id}
+        role="option"
+        aria-selected={isSelected}
+        className={cx(styles.itemWrapper, {
+          [styles.selectedColor]: isSelected,
+          [styles.active]: isActive,
+          [styles.circle]: colorShape === "circle"
+        })}
+        data-testid={dataTestId || getTestId(ComponentDefaultTestId.COLOR_PICKER_ITEM, color)}
+      >
+        <div className={cx(styles.feedbackIndicator)} />
+        <Clickable
+          ref={itemRef}
+          role="presentation"
+          aria-label={colorAriaLabel}
+          className={cx(styles.colorItem, getStyle(styles, camelCase("color-item-size-" + colorSize)), {
+            [styles.colorItemTextMode]: shouldRenderIndicatorWithoutBackground
           })}
-          data-testid={dataTestId || getTestId(ComponentDefaultTestId.COLOR_PICKER_ITEM, color)}
+          style={{ background: shouldRenderIndicatorWithoutBackground ? "transparent" : colorAsStyle }}
+          onClick={onClick}
+          tabIndex={-1}
+          onMouseDown={e => e.preventDefault()} // this is for quill to not lose the selection
         >
-          <div className={cx(styles.feedbackIndicator)} />
-          <Clickable
-            ref={itemRef}
-            role="presentation"
-            aria-label={colorAriaLabel}
-            className={cx(styles.colorItem, getStyle(styles, camelCase("color-item-size-" + colorSize)), {
-              [styles.colorItemTextMode]: shouldRenderIndicatorWithoutBackground
-            })}
-            style={{ background: shouldRenderIndicatorWithoutBackground ? "transparent" : colorAsStyle }}
-            onClick={onClick}
-            tabIndex={-1}
-            onMouseDown={e => e.preventDefault()} // this is for quill to not lose the selection
-          >
-            <div className={cx(styles.colorIndicatorWrapper)} style={colorIndicatorWrapperStyle}>
-              {shouldRenderIcon && (
-                <Icon
-                  icon={isSelected ? SelectedIndicatorIcon : ColorIndicatorIcon}
-                  className={cx({
-                    [styles.colorIconWhite]: !shouldRenderIndicatorWithoutBackground
-                  })}
-                  ignoreFocusStyle
-                />
-              )}
-            </div>
-          </Clickable>
-        </li>
-      </Tooltip>
+          <div className={cx(styles.colorIndicatorWrapper)} style={colorIndicatorWrapperStyle}>
+            {shouldRenderIcon && (
+              <Icon
+                icon={isSelected ? SelectedIndicatorIcon : ColorIndicatorIcon}
+                className={cx({
+                  [styles.colorIconWhite]: !shouldRenderIndicatorWithoutBackground
+                })}
+                ignoreFocusStyle
+              />
+            )}
+          </div>
+        </Clickable>
+      </li>
     );
+
+    if (!tooltipContent) {
+      return liElement;
+    }
+
+    return <Tooltip content={tooltipContent}>{liElement}</Tooltip>;
   }
 );
 


### PR DESCRIPTION
## Motivation

`ColorPickerItemComponent` wraps every color swatch in `<Tooltip content={tooltipContent}>` regardless of whether `tooltipContent` has a value. When `showColorNameTooltip` is `false` (the default), `tooltipContent` is `undefined` for every swatch, yet each one still mounts `Tooltip` → `Dialog` with its ~49 hooks.

A ColorPicker grid typically renders 20–60 swatches, so in the default configuration this mounts up to 60 needless Dialog trees on every render.

This is the same guard applied to `Tooltip` itself in PR #3416 — extend the pattern down one level.

## Changes

- Extract the `<li>` element into a `liElement` variable.
- When `tooltipContent` is falsy, return `liElement` directly (no Tooltip/Dialog mount).
- When `tooltipContent` is truthy, return `<Tooltip content={tooltipContent}>{liElement}</Tooltip>` as before.
- No changes to props, types, styles, or external API.

## Safety

- Behavior is **identical** when `tooltipContent` is provided — the Tooltip wraps the swatch exactly as before.
- The `Tooltip` import is retained; it is still used when needed.
- All existing ColorPicker tests pass (10/10).

## Test plan

- [x] `yarn workspace @vibe/core test ColorPicker` — 10/10 tests pass
- [ ] Storybook: verify color name tooltips still appear when `showColorNameTooltip={true}`
- [ ] Storybook: verify no visual regression when `showColorNameTooltip={false}` (default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)