### PR TITLE
perf(TextField): skip Tooltip render on icons when no tooltip content

### DIFF
--- a/packages/core/src/components/TextField/TextField.tsx
+++ b/packages/core/src/components/TextField/TextField.tsx
@@ -417,11 +417,28 @@ const TextField = forwardRef(
                 </div>
               </div>
             )}
-            {iconName && (
-              <Tooltip
-                content={isPrimary ? iconTooltipContent : undefined}
-                referenceWrapperClassName={styles.tooltipContainer}
-              >
+            {iconName &&
+              (isPrimary && iconTooltipContent ? (
+                <Tooltip content={iconTooltipContent} referenceWrapperClassName={styles.tooltipContainer}>
+                  <Clickable
+                    className={cx(styles.iconContainer, {
+                      [styles.iconContainerHasIcon]: hasIcon,
+                      [styles.iconContainerActive]: isPrimary,
+                      [styles.iconContainerClickable]: isIconContainerClickable
+                    })}
+                    onClick={onIconClickCallback}
+                    tabIndex={shouldFocusOnPrimaryIcon ? 0 : -1}
+                    aria-label={primaryIconAriaLabel}
+                  >
+                    <Icon
+                      icon={iconName}
+                      className={cx(styles.icon)}
+                      type="font"
+                      size={size === "small" ? "16px" : "18px"}
+                    />
+                  </Clickable>
+                </Tooltip>
+              ) : (
                 <Clickable
                   className={cx(styles.iconContainer, {
                     [styles.iconContainerHasIcon]: hasIcon,
@@ -439,14 +456,34 @@ const TextField = forwardRef(
                     size={size === "small" ? "16px" : "18px"}
                   />
                 </Clickable>
-              </Tooltip>
-            )}
-            {secondaryIconName && (
-              <Tooltip
-                content={isSecondary ? secondaryTooltipContent : undefined}
-                addKeyboardHideShowTriggersByDefault
-                referenceWrapperClassName={styles.tooltipContainer}
-              >
+              ))}
+            {secondaryIconName &&
+              (isSecondary && secondaryTooltipContent ? (
+                <Tooltip
+                  content={secondaryTooltipContent}
+                  addKeyboardHideShowTriggersByDefault
+                  referenceWrapperClassName={styles.tooltipContainer}
+                >
+                  <Clickable
+                    className={cx(styles.iconContainer, {
+                      [styles.iconContainerHasIcon]: hasIcon,
+                      [styles.iconContainerActive]: isSecondary,
+                      [styles.iconContainerClickable]: isIconContainerClickable
+                    })}
+                    onClick={onIconClickCallback}
+                    tabIndex={shouldFocusOnSecondaryIcon ? 0 : -1}
+                    data-testid={secondaryDataTestId || getTestId(ComponentDefaultTestId.TEXT_FIELD_SECONDARY_BUTTON, id)}
+                    aria-label={secondaryIconAriaLabel}
+                  >
+                    <Icon
+                      icon={secondaryIconName}
+                      className={cx(styles.icon)}
+                      type="font"
+                      size={size === "small" ? "16px" : "18px"}
+                    />
+                  </Clickable>
+                </Tooltip>
+              ) : (
                 <Clickable
                   className={cx(styles.iconContainer, {
                     [styles.iconContainerHasIcon]: hasIcon,
@@ -465,8 +502,7 @@ const TextField = forwardRef(
                     size={size === "small" ? "16px" : "18px"}
                   />
                 </Clickable>
-              </Tooltip>
-            )}
+              ))}
           </div>
           {shouldShowExtraText && (
             <Text type="text2" color="secondary" className={cx(styles.subTextContainer)}>


### PR DESCRIPTION
## Motivation

`TextField` has two icon slots — primary (`icon`) and secondary (`secondaryIconName`). Each icon was always wrapped in a `<Tooltip>` even when no tooltip content was configured:

```tsx
// before — Tooltip always mounts, even when content is undefined
<Tooltip content={isPrimary ? iconTooltipContent : undefined}>
  <Clickable ...>...</Clickable>
</Tooltip>
```

Because `Tooltip` delegates to `Dialog`, this silently runs Dialog's 49+ internal hooks on every render of every `TextField` with an icon — regardless of whether a tooltip will ever appear. PR #3416 added a `<>{children}</>` early-return guard inside `Tooltip` itself; this PR takes the optimisation one step further by not mounting `Tooltip` at all.

## Changes

**`packages/core/src/components/TextField/TextField.tsx`**

Both icon rendering blocks now use a ternary: `<Tooltip>` is mounted only when its effective content is truthy; otherwise the `<Clickable>` is rendered directly.

```tsx
// after — Tooltip only mounts when there is tooltip content
{iconName &&
  (isPrimary && iconTooltipContent ? (
    <Tooltip content={iconTooltipContent} ...>
      <Clickable ...>...</Clickable>
    </Tooltip>
  ) : (
    <Clickable ...>...</Clickable>
  ))}
```

All click handlers, icon names, `tabIndex`, `aria-label`, `data-testid`, and every other prop are identical in both branches.

## Safety

- No behaviour change when `iconTooltipContent` / `secondaryTooltipContent` are provided.
- No change to accessibility attributes (`aria-label`, `tabIndex`).
- The `addKeyboardHideShowTriggersByDefault` prop on the secondary-icon Tooltip is preserved in the tooltip branch.
- Pure render-path optimisation — no state, no side-effects.

## Test plan

- [x] All 60 existing TextField unit tests pass (`TextField.test.tsx`, `TextField-tests.test.tsx`, `TextField.snapshot.test.tsx`)
- [ ] Smoke-test in Storybook: icon with tooltip still shows tooltip; icon without tooltip still renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)