### PR TITLE
perf(ComboboxOption): skip Tooltip render when text is not overflowing

### DIFF
--- a/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
+++ b/packages/core/src/components/Combobox/components/ComboboxOption/ComboboxOption.tsx
@@ -168,30 +168,38 @@ const ComboboxOption = ({
     </>
   );
 
+  const optionDiv = (
+    <div
+      ref={ref}
+      key={id || label}
+      aria-level={belongToCategory ? 2 : 1}
+      aria-selected={isActive}
+      aria-label={ariaLabel || label}
+      id={getOptionId(id, index)}
+      data-testid={getTestId(ComponentDefaultTestId.COMBOBOX_OPTION, index)}
+      onMouseEnter={onMouseEnter}
+      onClick={onClick}
+      onKeyDown={onKeyDown}
+      onMouseLeave={onMouseLeave}
+      className={cx(styles.comboboxOption, className, {
+        [styles.disabled]: disabled,
+        [styles.selected]: selected,
+        [styles.active]: isActive,
+        [styles.activeOutline]: visualFocus
+      })}
+      style={{ height: optionLineHeight }}
+    >
+      {optionRendererValue || optionValue}
+    </div>
+  );
+
+  if (!tooltipContent) {
+    return optionDiv;
+  }
+
   return (
     <Tooltip {...option.tooltipProps} content={tooltipContent} hideWhenReferenceHidden>
-      <div
-        ref={ref}
-        key={id || label}
-        aria-level={belongToCategory ? 2 : 1}
-        aria-selected={isActive}
-        aria-label={ariaLabel || label}
-        id={getOptionId(id, index)}
-        data-testid={getTestId(ComponentDefaultTestId.COMBOBOX_OPTION, index)}
-        onMouseEnter={onMouseEnter}
-        onClick={onClick}
-        onKeyDown={onKeyDown}
-        onMouseLeave={onMouseLeave}
-        className={cx(styles.comboboxOption, className, {
-          [styles.disabled]: disabled,
-          [styles.selected]: selected,
-          [styles.active]: isActive,
-          [styles.activeOutline]: visualFocus
-        })}
-        style={{ height: optionLineHeight }}
-      >
-        {optionRendererValue || optionValue}
-      </div>
+      {optionDiv}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Motivation

PR #3416 added an early-return guard inside `Tooltip` itself: when `content` is falsy it renders `<>{children}</>` and skips mounting `Dialog` (which runs 49+ hooks). That guard helps, but the wasted work still happens at the `ComboboxOption` call site — the `<Tooltip>` component is mounted, its hooks run, and only then does it bail.

A Combobox showing 50 options with non-overflowing text currently mounts **50 `<Tooltip>` trees** (each one a `<Dialog>` candidate). In the common case — label fits — `tooltipContent` is always `null`, so every one of those mounts is pure waste.

## Changes

- **`ComboboxOption.tsx`**: extract the option `<div>` into a local `optionDiv` variable, then:
  - if `tooltipContent` is falsy → return `optionDiv` directly (no `<Tooltip>` mounted at all)
  - if `tooltipContent` is truthy → wrap with `<Tooltip>` exactly as before

This is the same pattern used in the Tooltip guard in #3416, applied one level up.

## Safety

- All existing props/behavior are unchanged; the `<Tooltip>` path (including `option.tooltipProps`) is still exercised when content is present.
- `tooltipContent` is either an explicit `option.tooltipContent` string or `isOverflowing ? label : null` — both are stable values already computed before the guard.
- No changes to the overflowing / explicit-tooltip-content paths.

## Test plan

- [x] All 143 `@vibe/core` test files pass (1382 tests, 7 skipped) — including `Combobox.test.tsx` and `Combobox.snapshot.test.tsx`
- [ ] Manually open a Combobox story with many options and confirm options render correctly without tooltips
- [ ] Resize a Combobox to force overflow and confirm the tooltip still appears on the overflowing option

🤖 Generated with [Claude Code](https://claude.com/claude-code)