### PR TITLE
perf(BreadcrumbItem): skip Tooltip render when text is not overflowing

### DIFF
--- a/packages/core/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.tsx
+++ b/packages/core/src/components/BreadcrumbsBar/BreadcrumbItem/BreadcrumbItem.tsx
@@ -59,34 +59,44 @@ const BreadcrumbItem: React.FC<BreadcrumbItemProps> = ({
   const componentRef = useRef<HTMLSpanElement>(null);
   const isOverflowing = useIsOverflowing({ ref: componentRef });
 
+  const tooltipContent = (isOverflowing || !showText) ? text : null;
+
+  const liElement = (
+    <li
+      id={id}
+      data-testid={dataTestId || getTestId(ComponentDefaultTestId.BREADCRUMB_ITEM, id)}
+      className={cx(styles.breadcrumbItemWrapper, className, {
+        [styles.disabled]: disabled
+      })}
+    >
+      <BreadcrumbContent
+        ref={componentRef}
+        isClickable={isClickable}
+        link={link}
+        onClick={onClick}
+        text={text}
+        icon={icon}
+        isCurrent={isCurrent}
+        disabled={disabled}
+        showText={showText}
+      />
+    </li>
+  );
+
+  if (!tooltipContent) {
+    return liElement;
+  }
+
   return (
     <Tooltip
       disableDialogSlide={true}
       withoutDialog={false}
-      content={(isOverflowing || !showText) && text}
+      content={tooltipContent}
       showTrigger={["mouseenter"]}
       hideTrigger={["mouseleave"]}
       addKeyboardHideShowTriggersByDefault={!showText}
     >
-      <li
-        id={id}
-        data-testid={dataTestId || getTestId(ComponentDefaultTestId.BREADCRUMB_ITEM, id)}
-        className={cx(styles.breadcrumbItemWrapper, className, {
-          [styles.disabled]: disabled
-        })}
-      >
-        <BreadcrumbContent
-          ref={componentRef}
-          isClickable={isClickable}
-          link={link}
-          onClick={onClick}
-          text={text}
-          icon={icon}
-          isCurrent={isCurrent}
-          disabled={disabled}
-          showText={showText}
-        />
-      </li>
+      {liElement}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Motivation

`BreadcrumbItem` computed its tooltip content inline:

```tsx
content={(isOverflowing || !showText) && text}
```

In the common case (`isOverflowing=false`, `showText=true`) this evaluates to `false`. Despite having a falsy `content`, `Tooltip` was still mounted, which in turn mounts `Dialog` and runs its **49+ hooks** on every render.

This mirrors the guard added directly inside `Tooltip` by PR #3416 — but that guard fires *inside* the Tooltip component after it has already mounted. This fix prevents mounting altogether when there is nothing to show.

## Changes

- Compute `tooltipContent` explicitly: `(isOverflowing || !showText) ? text : null`
- When `tooltipContent` is falsy, return the `<li>` directly, bypassing `Tooltip` / `Dialog` entirely
- When `tooltipContent` is truthy (overflow detected, or icon-only breadcrumb), wrap with `<Tooltip>` as before — all props unchanged

## Safety

- Overflow detection (`useIsOverflowing`) still runs unconditionally so the ref is always observed; Tooltip mounts as soon as overflow is detected
- `showText=false` (icon-only breadcrumb) still produces a truthy `tooltipContent` and includes `addKeyboardHideShowTriggersByDefault={true}`
- No props were added, removed, or renamed; the external API is unchanged

## Test plan

- [ ] Render a `BreadcrumbsBar` in Storybook — verify no tooltip appears on a short, non-overflowing breadcrumb
- [ ] Truncate the container to force overflow — verify tooltip appears on hover
- [ ] Render with `showText=false` — verify tooltip appears on hover and keyboard focus
- [ ] Run existing unit tests: `yarn workspace @vibe/core test --testPathPattern="BreadcrumbItem|Breadcrumb"` — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)