### PR TITLE
perf(SliderThumb): skip Tooltip render when showValue is true

### DIFF
--- a/packages/core/src/components/Slider/SliderBase/SliderThumb.tsx
+++ b/packages/core/src/components/Slider/SliderBase/SliderThumb.tsx
@@ -85,55 +85,65 @@ const SliderThumb: FC<SliderThumbProps> = ({ className, index = 0, onMove = NOOP
     }
   }, [focused, index]);
 
+  const tooltipContent = showValue ? null : valueText;
+
+  const thumb = (
+    <div
+      aria-label={ariaLabel}
+      aria-labelledby={ariaLabelledby}
+      aria-valuemax={max}
+      aria-valuemin={min}
+      aria-valuenow={value}
+      aria-valuetext={valueText}
+      aria-disabled={disabled}
+      className={cx(
+        styles.thumb,
+        getStyle(styles, color),
+        getStyle(styles, size),
+        {
+          [styles.dragging]: dragging === index,
+          [styles.focused]: focused,
+          [styles.notDisabledThumb]: !disabled
+        },
+        className
+      )}
+      data-testid={shapeTestId(`thumb-${index}`)}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onPointerDown={handlePointerDown}
+      onPointerLeave={handlePointerLeave}
+      ref={ref}
+      role="slider"
+      style={{ left: `${position}%` }}
+      tabIndex={disabled ? -1 : 0}
+    >
+      {showValue && (
+        <label
+          className={cx(
+            styles.label,
+            getStyle(styles, camelCase("color-" + valueLabelColor)),
+            getStyle(styles, camelCase("position-" + valueLabelPosition))
+          )}
+        >
+          {valueText}
+        </label>
+      )}
+    </div>
+  );
+
+  if (!tooltipContent) {
+    return thumb;
+  }
+
   return (
     <Tooltip
       open={active === index || dragging === index}
-      content={showValue ? null : valueText}
+      content={tooltipContent}
       position="top"
       showDelay={TOOLTIP_SHOW_DELAY}
       addKeyboardHideShowTriggersByDefault={false}
     >
-      <div
-        aria-label={ariaLabel}
-        aria-labelledby={ariaLabelledby}
-        aria-valuemax={max}
-        aria-valuemin={min}
-        aria-valuenow={value}
-        aria-valuetext={valueText}
-        aria-disabled={disabled}
-        className={cx(
-          styles.thumb,
-          getStyle(styles, color),
-          getStyle(styles, size),
-          {
-            [styles.dragging]: dragging === index,
-            [styles.focused]: focused,
-            [styles.notDisabledThumb]: !disabled
-          },
-          className
-        )}
-        data-testid={shapeTestId(`thumb-${index}`)}
-        onFocus={handleFocus}
-        onBlur={handleBlur}
-        onPointerDown={handlePointerDown}
-        onPointerLeave={handlePointerLeave}
-        ref={ref}
-        role="slider"
-        style={{ left: `${position}%` }}
-        tabIndex={disabled ? -1 : 0}
-      >
-        {showValue && (
-          <label
-            className={cx(
-              styles.label,
-              getStyle(styles, camelCase("color-" + valueLabelColor)),
-              getStyle(styles, camelCase("position-" + valueLabelPosition))
-            )}
-          >
-            {valueText}
-          </label>
-        )}
-      </div>
+      {thumb}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Motivation

When `showValue=true`, `SliderThumb` renders the current value as an inline label inside the thumb element. In this mode, the tooltip content is `null` — but `<Tooltip>` (and the underlying `<Dialog>`) was still mounted, causing 49+ hooks to run on every render for no benefit.

This mirrors the guard added to `Tooltip` itself in PR #3416.

## Changes

- Extract `tooltipContent = showValue ? null : valueText`
- Extract the thumb `<div>` into a local `thumb` variable
- When `tooltipContent` is falsy, return `thumb` directly (no `<Tooltip>` mounted)
- When `tooltipContent` is truthy, wrap `{thumb}` with `<Tooltip>` as before, preserving the `open={active === index || dragging === index}` controlled-open behavior

**File changed**: `packages/core/src/components/Slider/SliderBase/SliderThumb.tsx`

## Safety

- The `open` prop (active/dragging state → tooltip visible) only applies when `tooltipContent` is truthy, i.e. `showValue=false`. In that scenario nothing has changed.
- When `showValue=true` the tooltip was already invisible (null content); we now avoid mounting Dialog entirely.
- All 70 Slider tests pass.

## Test Plan

- [ ] `yarn workspace @vibe/core test Slider` — 70 tests, all passing
- [ ] Verify Slider with `showValue=false`: tooltip still appears on hover/drag showing the value
- [ ] Verify Slider with `showValue=true`: inline label renders correctly, no tooltip mounted

🤖 Generated with [Claude Code](https://claude.com/claude-code)