### PR TITLE
perf(RadioButton): skip Tooltip render when button is enabled

### DIFF
--- a/packages/core/src/components/RadioButton/RadioButton.tsx
+++ b/packages/core/src/components/RadioButton/RadioButton.tsx
@@ -128,55 +128,59 @@ const RadioButton = forwardRef(
 
     const tooltipContent = disabled ? disabledReason : null;
 
-    return (
-      <Tooltip content={tooltipContent}>
-        <label
-          data-testid={dataTestId || getTestId(ComponentDefaultTestId.RADIO_BUTTON, id)}
-          data-vibe={ComponentVibeId.RADIO_BUTTON}
-          className={cx(styles.radioButton, className, {
-            [styles.disabled]: disabled,
-            disabled: disabled
-          })}
-        >
-          <span className={cx(styles.inputContainer)}>
-            <input
-              className={cx(styles.input)}
-              type="radio"
-              value={value}
-              name={name}
-              autoFocus={autoFocus}
-              disabled={disabled}
-              {...checkedProps}
-              aria-label={ariaLabel}
-              aria-describedby={ariaDescribedby}
-              onChange={onSelect}
-              ref={mergedRef}
-            />
-            <span
-              data-testid={getTestId(ComponentDefaultTestId.RADIO_BUTTON_CONTROL, id)}
-              className={cx(styles.control, radioButtonClassName, {
-                [styles.labelAnimation]: !noLabelAnimation
-              })}
-            />
-          </span>
-          {text && (
-            <Text
-              element="span"
-              type="text2"
-              className={labelClassName}
-              data-testid={getTestId(ComponentDefaultTestId.RADIO_BUTTON_LABEL, id)}
-            >
-              {text}
-            </Text>
-          )}
-          {children && (
-            <Clickable onClick={onChildClick} tabIndex={childrenTabIndex}>
-              {children}
-            </Clickable>
-          )}
-        </label>
-      </Tooltip>
+    const labelElement = (
+      <label
+        data-testid={dataTestId || getTestId(ComponentDefaultTestId.RADIO_BUTTON, id)}
+        data-vibe={ComponentVibeId.RADIO_BUTTON}
+        className={cx(styles.radioButton, className, {
+          [styles.disabled]: disabled,
+          disabled: disabled
+        })}
+      >
+        <span className={cx(styles.inputContainer)}>
+          <input
+            className={cx(styles.input)}
+            type="radio"
+            value={value}
+            name={name}
+            autoFocus={autoFocus}
+            disabled={disabled}
+            {...checkedProps}
+            aria-label={ariaLabel}
+            aria-describedby={ariaDescribedby}
+            onChange={onSelect}
+            ref={mergedRef}
+          />
+          <span
+            data-testid={getTestId(ComponentDefaultTestId.RADIO_BUTTON_CONTROL, id)}
+            className={cx(styles.control, radioButtonClassName, {
+              [styles.labelAnimation]: !noLabelAnimation
+            })}
+          />
+        </span>
+        {text && (
+          <Text
+            element="span"
+            type="text2"
+            className={labelClassName}
+            data-testid={getTestId(ComponentDefaultTestId.RADIO_BUTTON_LABEL, id)}
+          >
+            {text}
+          </Text>
+        )}
+        {children && (
+          <Clickable onClick={onChildClick} tabIndex={childrenTabIndex}>
+            {children}
+          </Clickable>
+        )}
+      </label>
     );
+
+    if (!tooltipContent) {
+      return labelElement;
+    }
+
+    return <Tooltip content={tooltipContent}>{labelElement}</Tooltip>;
   }
 );
 


### PR DESCRIPTION
## Motivation

Every `RadioButton` was unconditionally mounting a `<Tooltip>`, which in turn mounts a `Dialog` that runs 49+ internal hooks. For **enabled** radio buttons `tooltipContent` is always `null` — the Tooltip serves no purpose but still pays the full mount cost. In a typical radio group of 5–10 buttons all of them mount unnecessary Dialogs on every render.

This is the same guard applied to `Tooltip` itself in PR #3416 (early return `<>{children}</>` when `content` is falsy), brought down one level to `RadioButton`.

## Changes

- **`packages/core/src/components/RadioButton/RadioButton.tsx`**
  - Extract the `<label>` subtree into a local `labelElement` variable.
  - When `tooltipContent` is falsy (button is enabled, or disabled with no `disabledReason`), return `labelElement` directly — no Tooltip mounted.
  - When `tooltipContent` is truthy (disabled + `disabledReason` provided), wrap as `<Tooltip content={tooltipContent}>{labelElement}</Tooltip>`.
  - All other props and rendering logic are unchanged.

## Safety

- Tooltip was only ever visible for disabled buttons with a `disabledReason`; the new branch preserves that behaviour exactly.
- No public API changes — `RadioButtonProps` is unmodified.
- Snapshot and unit tests all pass (15/15).

## Test plan

- [x] `yarn workspace @vibe/core test RadioButton` — 15/15 tests pass
- [ ] Manually verify a disabled RadioButton with `disabledReason` still shows the tooltip on hover
- [ ] Verify an enabled RadioButton renders without a wrapping Tooltip in the DOM

🤖 Generated with [Claude Code](https://claude.com/claude-code)