### PR TITLE
perf(Typography): skip Tooltip render when text is not overflowing

### DIFF
--- a/packages/components/typography/src/Typography/Typography.tsx
+++ b/packages/components/typography/src/Typography/Typography.tsx
@@ -84,23 +84,25 @@ const Typography = forwardRef(
 
     const overrideAlign = align === "inherit" ? "alignInherit" : align;
 
-    return (
-      <Tooltip {...overrideTooltipProps}>
-        {React.createElement(
-          element,
-          {
-            id,
-            style: ellipsisStyle,
-            "data-testid": dataTestId,
-            className: cx(styles.typography, styles[color], styles[overrideAlign], ellipsisClass, className),
-            ref: mergedRef,
-            role,
-            ...htmlAttributes
-          },
-          children
-        )}
-      </Tooltip>
+    const baseElement = React.createElement(
+      element,
+      {
+        id,
+        style: ellipsisStyle,
+        "data-testid": dataTestId,
+        className: cx(styles.typography, styles[color], styles[overrideAlign], ellipsisClass, className),
+        ref: mergedRef,
+        role,
+        ...htmlAttributes
+      },
+      children
     );
+
+    if (!overrideTooltipProps.content) {
+      return baseElement;
+    }
+
+    return <Tooltip {...overrideTooltipProps}>{baseElement}</Tooltip>;
   }
 );
 

--- a/packages/components/typography/src/Typography/TypographyHooks.tsx
+++ b/packages/components/typography/src/Typography/TypographyHooks.tsx
@@ -32,7 +32,7 @@ export function useTooltipProps(
   overflowTolerance: number
 ) {
   const isOverflowing = useIsOverflowing({
-    ref: ellipsis ? ref : null,
+    ref: ellipsis && !withoutTooltip ? ref : null,
     ignoreHeightOverflow,
     tolerance: overflowTolerance
   });


### PR DESCRIPTION
## Motivation

Every `Text` and `Heading` element (which both go through `Typography`) unconditionally rendered a `<Tooltip>` wrapper even when the text was not overflowing, `withoutTooltip=true`, or `ellipsis=false`. Because `Tooltip` mounts `Dialog` internally — which carries ~49 hooks — a page with 50–100 text elements paid that cost on every render even though no tooltip was ever needed.

This is a follow-up to #3416 (Tooltip early-return optimisation) and applies the same principle at the Typography layer.

## Changes

### `Typography.tsx`
- Extract the base DOM element into a variable (`baseElement`).
- Guard: if `overrideTooltipProps.content` is falsy (no overflow detected, `withoutTooltip=true`, `ellipsis=false`, etc.) return the element directly — **no Tooltip mount**.
- Otherwise wrap normally with `<Tooltip>`.

### `TypographyHooks.tsx`
- In `useTooltipProps`, the `useIsOverflowing` call now passes `ref: ellipsis && !withoutTooltip ? ref : null`. Previously a `ResizeObserver` was created whenever `ellipsis=true`, even when `withoutTooltip=true` made the result irrelevant. This eliminates that unnecessary observer.

## Safety

- All existing overflow-tooltip behaviour is fully preserved: when text overflows an ellipsised container the Tooltip still appears exactly as before.
- The guard is on `overrideTooltipProps.content`, which is only truthy when `useTooltipProps` returns `{ ...tooltipProps, content: children }` — i.e. when `!withoutTooltip && ellipsis && isOverflowing`.
- All 20 existing snapshot tests pass unchanged.

## Test plan

- [ ] `yarn workspace @vibe/typography test` — all 20 tests green
- [ ] Open Storybook for `Text` / `Heading`, verify ellipsis tooltip still appears when text is long enough to overflow
- [ ] Verify no tooltip appears (and no Tooltip DOM node) on short non-overflowing text

🤖 Generated with [Claude Code](https://claude.com/claude-code)