### PR TITLE
perf(AlertBannerText): skip Tooltip render when text is not overflowing

### DIFF
--- a/packages/core/src/components/AlertBanner/AlertBannerText/AlertBannerText.tsx
+++ b/packages/core/src/components/AlertBanner/AlertBannerText/AlertBannerText.tsx
@@ -34,22 +34,31 @@ const AlertBannerText: FC<AlertBannerTextProps> = ({
     [styles.marginLeft]: marginLeft
   });
   const isOverflowing = useIsOverflowing({ ref: componentRef });
+  const tooltipContent = isOverflowing ? text : null;
+
+  const textElement = (
+    <div
+      ref={componentRef}
+      className={classNames}
+      id={id}
+      data-testid={dataTestId || getTestId(ComponentDefaultTestId.ALERT_BANNER_TEXT, id)}
+    >
+      <span aria-live={ariaLive}>{text}</span>
+    </div>
+  );
+
+  if (!tooltipContent) {
+    return textElement;
+  }
 
   return (
     <Tooltip
       position="bottom"
-      content={isOverflowing && text}
+      content={tooltipContent}
       showTrigger={["mouseenter"]}
       hideTrigger={["mouseleave"]}
     >
-      <div
-        ref={componentRef}
-        className={classNames}
-        id={id}
-        data-testid={dataTestId || getTestId(ComponentDefaultTestId.ALERT_BANNER_TEXT, id)}
-      >
-        <span aria-live={ariaLive}>{text}</span>
-      </div>
+      {textElement}
     </Tooltip>
   );
 };


### PR DESCRIPTION
## Motivation

`AlertBannerText` renders a `<Tooltip>` with `content={isOverflowing && text}`. When `isOverflowing` is `false` (the common case — text fits without truncation), this short-circuit expression evaluates to `false`. The Tooltip component was being mounted with a falsy `content` prop, which caused the entire Dialog subtree (~49 hooks) to run on every render even though no tooltip would ever appear.

PR #3416 added an early-return guard inside Tooltip itself for this case. This PR applies the same pattern at the call site in `AlertBannerText`, avoiding the Tooltip mount entirely.

## Changes

- Compute `tooltipContent = isOverflowing ? text : null` explicitly.
- When `tooltipContent` is falsy, return the text `<div>` directly without `<Tooltip>`.
- When `tooltipContent` is truthy (text is truncated), wrap with `<Tooltip content={tooltipContent} ...>` as before.
- All other props (`position`, `showTrigger`, `hideTrigger`) are unchanged.

## Safety

- Behaviour is identical to before: tooltip appears if and only if the text overflows.
- No API changes — this is purely an internal render optimisation.
- `isOverflowing` starts as `false` (the hook default before measurement), so the guard fires on the first render and any render where the text fits.

## Test plan

- [x] `yarn workspace @vibe/core test AlertBanner` — all 10 tests pass
- [ ] Manual: render an `AlertBanner` with short text → no tooltip shown; with long text that overflows → tooltip appears on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)