### PR TITLE
perf(MenuButton): skip Tooltip render when no tooltip content

### DIFF
--- a/packages/core/src/components/MenuButton/MenuButton.tsx
+++ b/packages/core/src/components/MenuButton/MenuButton.tsx
@@ -400,19 +400,24 @@ const MenuButton = forwardRef(
       </Dialog>
     );
 
-    const tooltipNode = (tooltipChildren: React.ReactElement) => (
-      <Tooltip
-        content={tooltipContent}
-        position={tooltipPosition}
-        showTrigger="mouseenter"
-        hideTrigger={tooltipTriggers}
-        referenceWrapperClassName={tooltipReferenceClassName}
-        hideWhenReferenceHidden={hideWhenReferenceHidden}
-        {...tooltipProps}
-      >
-        {tooltipChildren}
-      </Tooltip>
-    );
+    const tooltipNode = (tooltipChildren: React.ReactElement) => {
+      if (!tooltipContent) {
+        return tooltipChildren;
+      }
+      return (
+        <Tooltip
+          content={tooltipContent}
+          position={tooltipPosition}
+          showTrigger="mouseenter"
+          hideTrigger={tooltipTriggers}
+          referenceWrapperClassName={tooltipReferenceClassName}
+          hideWhenReferenceHidden={hideWhenReferenceHidden}
+          {...tooltipProps}
+        >
+          {tooltipChildren}
+        </Tooltip>
+      );
+    };
 
     if (showTooltipOnlyOnTriggerElement) {
       return dialogNode(tooltipNode(triggerElementNode));


### PR DESCRIPTION
## Motivation

Most `MenuButton` instances don't supply a `tooltipContent` prop, yet the component unconditionally wrapped its children in `<Tooltip>`. Because `Tooltip` renders a `Dialog` underneath, this caused Dialog (which runs 49+ hooks on every render) to mount even when there is nothing to show.

This is the same optimisation applied to `Tooltip` directly in PR #3416.

## Change

In `tooltipNode`, add an early-return guard:

```tsx
const tooltipNode = (tooltipChildren: React.ReactElement) => {
  if (!tooltipContent) {
    return tooltipChildren;
  }
  return <Tooltip ...>{tooltipChildren}</Tooltip>;
};
```

When `tooltipContent` is falsy the helper returns the children unwrapped — no `Tooltip`, no `Dialog`, no extra hooks. When `tooltipContent` is truthy, behaviour is identical to before.

Both call-sites (`showTooltipOnlyOnTriggerElement` path and the default path) benefit automatically.

## Safety

- No changes to the `tooltipContent` type or default value — it remains `undefined` by default.
- All existing tooltip functionality (position, triggers, reference className, extra props) is preserved for the truthy case.
- The `Tooltip` import is kept; no tree-shaking regression for callers that do pass content.

## Test plan

- [ ] Render a `MenuButton` without `tooltipContent` and confirm no Tooltip/Dialog is present in the DOM.
- [ ] Render a `MenuButton` with `tooltipContent="Help text"`, hover over it, confirm the tooltip appears.
- [ ] Verify `showTooltipOnlyOnTriggerElement` still works correctly in both cases.
- [ ] Existing unit tests pass (pre-existing env issue with `react-inlinesvg` ESM resolution unrelated to this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)