### PR TITLE
perf(IconButton): skip Tooltip render when hideTooltip is true

### DIFF
--- a/packages/components/icon-button/src/IconButton/IconButton.tsx
+++ b/packages/components/icon-button/src/IconButton/IconButton.tsx
@@ -201,42 +201,50 @@ const IconButton = forwardRef(
       return wrapperClassName ? { className: cx(wrapperClassName, styles.wrapper) } : {};
     }, [wrapperClassName]);
 
+    const button = (
+      <Button
+        onClick={onClick}
+        disabled={disabled}
+        color={color}
+        kind={kind}
+        aria-labelledby={ariaLabelledBy}
+        aria-label={buttonAriaLabel}
+        aria-haspopup={ariaHasPopup}
+        aria-expanded={ariaExpanded}
+        aria-controls={ariaControls}
+        aria-describedby={ariaDescribedBy}
+        aria-hidden={ariaHidden}
+        aria-pressed={ariaPressed}
+        ref={mergedRef}
+        id={id}
+        data-testid={dataTestId || getTestId(ComponentDefaultTestId.ICON_BUTTON, id)}
+        data-vibe={ComponentVibeId.ICON_BUTTON}
+        noSidePadding
+        active={active}
+        className={className}
+        style={overrideStyle}
+        insetFocus={insetFocus}
+        tabIndex={tabIndex}
+        loading={loading}
+        loaderClassName={cx(styles.loader, getStyle(styles, size))}
+      >
+        <Icon icon={icon} type="svg" size={iconSize} ignoreFocusStyle className={iconClassName} />
+      </Button>
+    );
+
     return (
       <IconButtonWrapper {...iconButtonWrapperProps}>
-        <Tooltip
-          {...tooltipProps}
-          content={calculatedTooltipContent}
-          referenceWrapperClassName={styles.referenceWrapper}
-        >
-          <Button
-            onClick={onClick}
-            disabled={disabled}
-            color={color}
-            kind={kind}
-            aria-labelledby={ariaLabelledBy}
-            aria-label={buttonAriaLabel}
-            aria-haspopup={ariaHasPopup}
-            aria-expanded={ariaExpanded}
-            aria-controls={ariaControls}
-            aria-describedby={ariaDescribedBy}
-            aria-hidden={ariaHidden}
-            aria-pressed={ariaPressed}
-            ref={mergedRef}
-            id={id}
-            data-testid={dataTestId || getTestId(ComponentDefaultTestId.ICON_BUTTON, id)}
-            data-vibe={ComponentVibeId.ICON_BUTTON}
-            noSidePadding
-            active={active}
-            className={className}
-            style={overrideStyle}
-            insetFocus={insetFocus}
-            tabIndex={tabIndex}
-            loading={loading}
-            loaderClassName={cx(styles.loader, getStyle(styles, size))}
+        {calculatedTooltipContent ? (
+          <Tooltip
+            {...tooltipProps}
+            content={calculatedTooltipContent}
+            referenceWrapperClassName={styles.referenceWrapper}
           >
-            <Icon icon={icon} type="svg" size={iconSize} ignoreFocusStyle className={iconClassName} />
-          </Button>
-        </Tooltip>
+            {button}
+          </Tooltip>
+        ) : (
+          button
+        )}
       </IconButtonWrapper>
     );
   }


### PR DESCRIPTION
## Motivation

Every `IconButton` with `hideTooltip={true}` was still mounting a full `<Tooltip>` (which internally mounts `Dialog`, running 49+ hooks). When `hideTooltip` is set, `calculatedTooltipContent` is explicitly `null`, so wrapping with `Tooltip` has no benefit and only wastes work.

This follows the same pattern as PR #3416, which applied the identical early-return guard to `Tooltip` itself.

## Change

`packages/components/icon-button/src/IconButton/IconButton.tsx`

- Extract the `<Button>` subtree into a `button` variable.
- In the return, conditionally wrap with `<Tooltip>` only when `calculatedTooltipContent` is truthy; otherwise render `button` directly.
- All Button props and ARIA attributes are unchanged.

## Callers using `hideTooltip` (known sites where this lands)

| Location | Component |
|---|---|
| `Chips` close button | `IconButton hideTooltip` |
| `Dropdown` chevron button | `IconButton hideTooltip` |
| `Dropdown` clear button | `IconButton hideTooltip` |
| `Tipseen` dismiss button | `IconButton hideTooltip` |
| `Toast` close button | `IconButton hideTooltip` |
| `AttentionBox` close button | `IconButton hideTooltip` |
| `AlertBanner` dismiss button | `IconButton hideTooltip` |
| `NumberField` spin-up button | `IconButton hideTooltip` |
| `NumberField` spin-down button | `IconButton hideTooltip` |
| Various story/playground usages | `IconButton hideTooltip` |

Any page rendering one of these components will now avoid mounting Dialog+49 hooks per icon button.

## Test plan

- [x] `yarn workspace @vibe/icon-button test` — 21/21 tests pass
- [ ] Visually verify tooltip still appears when `hideTooltip` is not set (tooltipContent provided)
- [ ] Visually verify no tooltip and no layout change when `hideTooltip={true}`
- [ ] Smoke-test Chips, Dropdown, Toast, AttentionBox close buttons — no visual regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)