### PR TITLE
perf(BaseItem): skip Tooltip render when no tooltip content

### DIFF
--- a/packages/core/src/components/BaseItem/BaseItem.tsx
+++ b/packages/core/src/components/BaseItem/BaseItem.tsx
@@ -58,36 +58,39 @@ const BaseItem = forwardRef(
     const textVariant: TextType = listItemProps.size === "small" ? "text2" : "text1";
     const Element = listItemProps.component as React.ElementType;
 
-    return (
-      <Tooltip
-        {...tooltipProps}
-        content={tooltipProps?.content}
-        position={dir === "rtl" ? "right" : "left"}
-        containerSelector="body"
+    const innerElement = (
+      <Element
+        id={listItemProps.id}
+        ref={mergedRef}
+        className={listItemClassNames}
+        role={listItemProps.role}
+        aria-selected={selected}
+        aria-disabled={disabled || undefined}
+        {...listItemProps.itemProps}
       >
-        <Element
-          id={listItemProps.id}
-          ref={mergedRef}
-          className={listItemClassNames}
-          role={listItemProps.role}
-          aria-selected={selected}
-          aria-disabled={disabled || undefined}
-          {...listItemProps.itemProps}
-        >
-          {itemRenderer ? (
-            itemRenderer(item)
-          ) : (
-            <>
-              {startElement && renderSideElement(startElement, disabled, textVariant)}
-              <Text type={textVariant} color="inherit" tooltipProps={{ containerSelector: "body" }}>
-                {label}
-              </Text>
-              {endElement && (
-                <div className={styles.endElement}>{renderSideElement(endElement, disabled, textVariant)}</div>
-              )}
-            </>
-          )}
-        </Element>
+        {itemRenderer ? (
+          itemRenderer(item)
+        ) : (
+          <>
+            {startElement && renderSideElement(startElement, disabled, textVariant)}
+            <Text type={textVariant} color="inherit" tooltipProps={{ containerSelector: "body" }}>
+              {label}
+            </Text>
+            {endElement && (
+              <div className={styles.endElement}>{renderSideElement(endElement, disabled, textVariant)}</div>
+            )}
+          </>
+        )}
+      </Element>
+    );
+
+    if (!tooltipProps?.content) {
+      return innerElement;
+    }
+
+    return (
+      <Tooltip {...tooltipProps} position={dir === "rtl" ? "right" : "left"} containerSelector="body">
+        {innerElement}
       </Tooltip>
     );
   }


### PR DESCRIPTION
## Motivation

`BaseItem` is the rendering primitive for every Dropdown option and List item. It defaults `tooltipProps` to `{}`, so `tooltipProps.content` is always `undefined` — yet it unconditionally wraps every item in `<Tooltip>`. `<Tooltip>` mounts `<Dialog>` internally, which runs 49+ hooks per instance. This means every Dropdown list and every List component pays a significant mount cost even when no tooltip is needed.

PR #3416 applied the same guard to `Tooltip` itself (early `<>{children}</>` return when `content` is falsy). This PR applies the equivalent guard one level up in `BaseItem`, so Dialog is never instantiated at all.

## Changes

- **`packages/core/src/components/BaseItem/BaseItem.tsx`**: Extract the inner `<Element>` JSX into `innerElement`. When `tooltipProps?.content` is falsy, return `innerElement` directly. When truthy, wrap with `<Tooltip>` as before.
- Also removes the redundant `content={tooltipProps?.content}` prop (already covered by `{...tooltipProps}`).

## Safety

- The guard only skips `<Tooltip>` when `content` is falsy (`undefined`, `null`, `""`, `0`, `false`). Any item that carries a tooltip content string still wraps in `<Tooltip>` exactly as before.
- All other props (`position`, `containerSelector`, and any custom `tooltipProps`) continue to be forwarded when the tooltip renders.
- No changes to the DOM structure of the inner element.

## Test plan

- [x] All 13 existing `BaseItem` unit tests pass (`yarn workspace @vibe/core test -- BaseItem`)
- [ ] Verify Dropdown renders correctly in Storybook (no visual regressions)
- [ ] Verify List renders correctly in Storybook (no visual regressions)
- [ ] Verify that a Dropdown/List item with `tooltipProps.content` set still shows the tooltip on hover

🤖 Generated with [Claude Code](https://claude.com/claude-code)