### PR TITLE
perf(Avatar): skip Tooltip render when no tooltip content

### DIFF
--- a/packages/core/src/components/Avatar/Avatar.tsx
+++ b/packages/core/src/components/Avatar/Avatar.tsx
@@ -214,6 +214,35 @@ const Avatar = ({
     [onClick, id]
   );
 
+  const circleElement = (
+    <div
+      className={cx(
+        styles.circle,
+        getStyle(styles, camelCase("circle--" + type)),
+        {
+          [styles.disabled]: disabled,
+          [styles.square]: square,
+          [styles.withoutBorder]: withoutBorder
+        },
+        avatarContentWrapperClassName
+      )}
+      aria-hidden={ariaHidden}
+      tabIndex={overrideTabIndex}
+      style={{ ...backgroundColorStyle }}
+    >
+      <AvatarContent
+        type={type}
+        size={size}
+        src={src}
+        icon={icon}
+        text={text}
+        aria-label={ariaLabel}
+        role={role}
+        textClassName={textClassName}
+      />
+    </div>
+  );
+
   return (
     <div
       id={id}
@@ -230,35 +259,17 @@ const Avatar = ({
           className: styles.clickableWrapper
         }}
       >
-        <Tooltip showTrigger={["focus", "mouseenter"]} hideTrigger={["blur", "mouseleave"]} {...overrideTooltipProps}>
-          <div
-            className={cx(
-              styles.circle,
-              getStyle(styles, camelCase("circle--" + type)),
-              {
-                [styles.disabled]: disabled,
-                [styles.square]: square,
-                [styles.withoutBorder]: withoutBorder
-              },
-              avatarContentWrapperClassName
-            )}
-            aria-hidden={ariaHidden}
-            tabIndex={overrideTabIndex}
-            style={{ ...backgroundColorStyle }}
-          >
-            <AvatarContent
-              type={type}
-              size={size}
-              src={src}
-              icon={icon}
-              text={text}
-              aria-label={ariaLabel}
-              role={role}
-              textClassName={textClassName}
-            />
-          </div>
-          {badgesContainer}
-        </Tooltip>
+        {overrideTooltipProps?.content ? (
+          <Tooltip showTrigger={["focus", "mouseenter"]} hideTrigger={["blur", "mouseleave"]} {...overrideTooltipProps}>
+            {circleElement}
+            {badgesContainer}
+          </Tooltip>
+        ) : (
+          <>
+            {circleElement}
+            {badgesContainer}
+          </>
+        )}
       </ClickableWrapper>
     </div>
   );


### PR DESCRIPTION
## Motivation

`Avatar` always mounted `<Tooltip>` (and therefore `<Dialog>` with 49+ hooks) even when there was no tooltip content to show — i.e. when `withoutTooltip=true` or when `aria-label` is not provided (the only default source of `content`).

Avatars appear in `AvatarGroup` lists (10–100 per view), user pickers, and table rows. Every one of those mounts an unnecessary `Dialog` subtree.

This is the same guard introduced for `Tooltip` itself in #3416 (`<>{children}</>` early return), but applied one level up: Avatar now skips the `<Tooltip>` component entirely when there is no content.

## Changes

- Extract the avatar circle `<div>` into a `circleElement` variable.
- Conditionally render `<Tooltip>` only when `overrideTooltipProps?.content` is truthy; otherwise render `circleElement` + `badgesContainer` in a plain fragment.
- No change to existing behavior: `defaultTabIndex`, click handlers, badge rendering, and accessibility props are all preserved.

## Why `circleElement` (not a fragment)

Dialog's `Refable` helper uses `React.cloneElement` on its first child to inject trigger event handlers. Passing a React fragment as the first child causes `Refable` to wrap it in a `<span>` instead of cloning the native `div`. Extracting only the circle `<div>` and leaving `{badgesContainer}` as a sibling keeps the same DOM structure as before when a tooltip IS rendered.

## Test plan

- [x] `yarn workspace @vibe/core test Avatar` — all 23 tests pass (Avatar, AvatarGroup, ListItemAvatar snapshots + unit)
- [ ] Visual check: Avatar with `aria-label` still shows tooltip on hover
- [ ] Visual check: Avatar without `aria-label` renders correctly with no extra wrapper
- [ ] Visual check: AvatarGroup with many items — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)