### PR TITLE
fix(Tooltip): skip Dialog render when content is falsy

### DIFF
--- a/packages/components/tooltip/src/Tooltip/Tooltip.tsx
+++ b/packages/components/tooltip/src/Tooltip/Tooltip.tsx
@@ -328,6 +328,10 @@ export default class Tooltip extends PureComponent<TooltipProps> {
       return this.renderTooltipContent();
     }
 
+    if (!this.props.content) {
+      return <>{children}</>;
+    }
+
     const content = this.renderTooltipContent;
     const dialogProps = {
       ...this.props,


### PR DESCRIPTION
## Summary
- When `Tooltip` receives no `content` prop (e.g. a `Text`/`Heading` whose text isn't overflowing), bypass `Dialog` entirely and return `children` directly
- Avoids mounting Dialog's 30+ hooks on every render for tooltips that will never show
- Backport of #<!-- master PR --> to `version3`

## Changes
`packages/components/tooltip/src/Tooltip/Tooltip.tsx` — 4 lines added in the `render` method, after the `withoutDialog` guard and before Dialog setup

## Test plan
- [ ] Verify tooltips with content still appear correctly
- [ ] Verify tooltips with no content (non-overflowing text) render children without mounting Dialog
- [ ] Check no regressions in existing Tooltip stories