### PR TITLE
fix(mcp): always use @vibe/core as import path in metadata

### DIFF
--- a/packages/core/src/scripts/generate-metadata.ts
+++ b/packages/core/src/scripts/generate-metadata.ts
@@ -416,9 +416,7 @@ function mergeResults(aggregator: AggregatorRecord[], docgen: DocgenResult[]): F
         }
       }
 
-      // Determine correct import path: if file is from packages/components/{pkg}/, use @vibe/{pkg}
-      const pkgMatch = agg.filePath.match(/\/components\/([^/]+)\/src\//);
-      const importPath = pkgMatch ? `@vibe/${pkgMatch[1]}` : `@vibe/core${agg.aggregator === "next" ? "/next" : ""}`;
+      const importPath = `@vibe/core${agg.aggregator === "next" ? "/next" : ""}`;
 
       return {
         filePath: toRelativePath(agg.filePath),


### PR DESCRIPTION
## Summary
- Port of #3358 to `version3` branch
- Fix incorrect `import` field in `metadata.json` for components that live in sub-packages (`@vibe/button`, `@vibe/typography`, `@vibe/layout`, etc.)
- The metadata generation script was resolving the import path based on the component's source file location, pointing to internal sub-packages instead of `@vibe/core`
- Since this metadata is generated for `@vibe/core` and all components are re-exported from it, the import should always reference `@vibe/core`

**Before:** `import { Button } from "@vibe/button"`  
**After:** `import { Button } from "@vibe/core"`

## Test plan
- [ ] Run `build:metadata` locally — all components should now have `@vibe/core` imports
- [ ] Verify `@vibe/mcp` `list-vibe-public-components` returns correct imports after publish