### PR TITLE
ci: pin size-limit to v12 to fix bundle check on Node 20

### DIFF
--- a/.github/workflows/bundle-size.yml
+++ b/.github/workflows/bundle-size.yml
@@ -50,7 +50,7 @@ jobs:
           git checkout $BASE
           yarn install --frozen-lockfile
           yarn build
-          yarn add --dev -W size-limit @size-limit/preset-small-lib
+          yarn add --dev -W size-limit@12 @size-limit/preset-small-lib@12
           ./node_modules/.bin/size-limit --json > scripts/bundle-check/reports/base.json
         continue-on-error: true
 


### PR DESCRIPTION
https://monday.monday.com/boards/3532714909/views/80492480/pulses/12636313768

## Summary
- `size-limit@13.0.1` was published on 2026-07-24 and pulls `nanoid@6.0.0`, which requires Node `>=22`
- CI runs on Node 20.12.2, causing the \"Run size-limit on base commit\" step to fail silently (`continue-on-error: true`)
- This leaves `base.json` unwritten, so the \"Compare sizes\" step crashes with `ENOENT` on all open PRs
- Pins `size-limit` and `@size-limit/preset-small-lib` to `@12` to stay on the last Node-20-compatible major

## Test plan
- [ ] Bundle Size Analysis passes on this PR
- [ ] Bundle Size Analysis passes on other open PRs after this merges

🤖 Generated with [Claude Code](https://claude.com/claude-code)