### PR TITLE
feat(shared): add NavDirections and useLastNavigationDirection

### DIFF
--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -1,2 +1,3 @@
 export * from "./keyCodes";
+export * from "./navDirections";
 export * from "./sizes";

--- a/packages/shared/src/constants/navDirections.ts
+++ b/packages/shared/src/constants/navDirections.ts
@@ -1,0 +1,11 @@
+export enum NavDirections {
+  UP = "up",
+  DOWN = "down",
+  LEFT = "left",
+  RIGHT = "right"
+}
+
+export const ARROW_DOWN_KEYS = ["ArrowDown"];
+export const ARROW_UP_KEYS = ["ArrowUp"];
+export const ARROW_RIGHT_KEYS = ["ArrowRight"];
+export const ARROW_LEFT_KEYS = ["ArrowLeft"];

--- a/packages/shared/src/hooks/index.ts
+++ b/packages/shared/src/hooks/index.ts
@@ -1,6 +1,7 @@
 export * from "./useMergeRef";
 export * from "./useKeyEvent";
 export * from "./useEventListener";
+export * from "./useLastNavigationDirection";
 export * from "./ssr/useIsMounted";
 export * from "./ssr/useIsomorphicLayoutEffect";
 export * from "./useKeyboardButtonPressedFunc";

--- a/packages/shared/src/hooks/useLastNavigationDirection.ts
+++ b/packages/shared/src/hooks/useLastNavigationDirection.ts
@@ -1,0 +1,47 @@
+import type React from "react";
+import { useCallback, useRef } from "react";
+import { useEventListener } from "./useEventListener";
+import { useKeyEvent } from "./useKeyEvent";
+import {
+  ARROW_DOWN_KEYS,
+  ARROW_LEFT_KEYS,
+  ARROW_RIGHT_KEYS,
+  ARROW_UP_KEYS,
+  NavDirections
+} from "../constants/navDirections";
+
+const NAVIGATION_KEYS = [...ARROW_UP_KEYS, ...ARROW_RIGHT_KEYS, ...ARROW_DOWN_KEYS, ...ARROW_LEFT_KEYS];
+
+export const useLastNavigationDirection = () => {
+  const documentRef = useRef(document);
+  const lastNavigationDirectionRef = useRef<NavDirections>();
+
+  const setLastNavigationDirection = useCallback((dir: NavDirections) => {
+    lastNavigationDirectionRef.current = dir;
+  }, []);
+
+  const onKeyEvent = useCallback(
+    (event: KeyboardEvent | React.KeyboardEvent) => {
+      const { key } = event;
+      if (ARROW_UP_KEYS.includes(key)) {
+        setLastNavigationDirection(NavDirections.UP);
+      } else if (ARROW_RIGHT_KEYS.includes(key)) {
+        setLastNavigationDirection(NavDirections.RIGHT);
+      } else if (ARROW_DOWN_KEYS.includes(key)) {
+        setLastNavigationDirection(NavDirections.DOWN);
+      } else if (ARROW_LEFT_KEYS.includes(key)) {
+        setLastNavigationDirection(NavDirections.LEFT);
+      }
+    },
+    [setLastNavigationDirection]
+  );
+
+  const onMousedownAnywhere = useCallback(() => {
+    lastNavigationDirectionRef.current = undefined;
+  }, [lastNavigationDirectionRef]);
+
+  useKeyEvent({ ref: documentRef, capture: true, keys: NAVIGATION_KEYS, callback: onKeyEvent });
+  useEventListener({ eventName: "mousedown", ref: documentRef, capture: true, callback: onMousedownAnywhere });
+
+  return { lastNavigationDirectionRef };
+};


### PR DESCRIPTION
## Summary
Adds two additive exports to `@vibe/shared`:
- `NavDirections` enum + `ARROW_{UP,DOWN,LEFT,RIGHT}_KEYS` constants (`constants/navDirections.ts`)
- `useLastNavigationDirection` hook (`hooks/useLastNavigationDirection.ts`)

## Why
These are needed by leaf component packages (the upcoming `@vibe/a11y` extraction of `GridKeyboardNavigationContext`) which cannot depend on `@vibe/core`. Landing them in `@vibe/shared` first — and releasing `@vibe/shared` with the new exports — lets the follow-up `@vibe/a11y` PR depend on a published shared version that actually contains them, instead of trying to add-and-consume the exports in a single PR.

## Scope
- Additive only — no existing `@vibe/shared` exports change.
- No consumers modified here; the a11y extraction PR wires them up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)