### PR TITLE
feat(Toast): redesign to Sonner-style with top-center placement

### DIFF
--- a/packages/core/src/components/Toast/Toast.module.scss
+++ b/packages/core/src/components/Toast/Toast.module.scss
@@ -1,131 +1,224 @@
 @import "../../styles/keyframes";
 
 .toast {
-  box-shadow: var(--box-shadow-medium);
+  position: fixed;
+  inset-block-start: var(--space-24);
+  inset-inline-start: 50%;
+  z-index: 999999999;
+  transform: translateX(-50%);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  width: fit-content;
+  min-width: 200px;
+  max-width: 356px;
+  padding: var(--space-16);
+  border: 1px solid hsl(0, 0%, 93%);
+  border-radius: var(--border-radius-medium);
+  background-color: #fff;
+  color: hsl(0, 0%, 9%);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.1);
   -webkit-font-smoothing: var(--font-smoothing-webkit);
   -moz-osx-font-smoothing: var(--font-smoothing-moz);
-  margin: var(--spacing-medium);
-  position: fixed;
-  left: 50%;
-  top: 0;
-  margin-right: auto;
-  margin-left: auto;
-  padding: var(--spacing-small);
-  align-items: center;
-  display: flex;
-  min-width: 200px;
-  width: auto;
-  border-radius: var(--border-radius-small);
-  color: var(--fixed-light-color);
-  transform: translateX(-50%);
-  transition: background-color 80ms cubic-bezier(0.6, 0, 0.4, 1), width 200ms cubic-bezier(0, 0, 0.4, 1);
+  transition:
+    transform 400ms ease,
+    opacity 400ms ease,
+    box-shadow 200ms ease;
 
   &.typeNormal {
-    background-color: var(--primary-color);
+    background-color: #fff;
+    color: hsl(0, 0%, 9%);
+    border-color: hsl(0, 0%, 93%);
   }
 
   &.typePositive {
-    background-color: var(--positive-color);
+    background-color: hsl(143, 85%, 96%);
+    color: hsl(140, 100%, 27%);
+    border-color: hsl(145, 92%, 87%);
   }
 
   &.typeNegative {
-    background-color: var(--negative-color);
+    background-color: hsl(359, 100%, 97%);
+    color: hsl(360, 100%, 45%);
+    border-color: hsl(359, 100%, 94%);
   }
 
   &.typeWarning {
-    background-color: var(--warning-color);
-    color: var(--fixed-dark-color);
-
-    .closeButton {
-      color: var(--fixed-dark-color);
-    }
-
-    .actionButton,
-    .actionLink {
-      color: var(--fixed-dark-color);
-      border-color: var(--fixed-dark-color);
-    }
+    background-color: hsl(49, 100%, 97%);
+    color: hsl(31, 92%, 45%);
+    border-color: hsl(49, 91%, 84%);
   }
 
   &.typeDark {
-    background-color: var(--inverted-color-background);
-    color: var(--text-color-on-inverted);
+    background-color: #000;
+    color: hsl(0, 0%, 99%);
+    border-color: hsl(0, 0%, 20%);
+  }
 
-    .closeButton {
-      color: var(--text-color-on-inverted);
-    }
-
-    .actionButton,
-    .actionLink {
-      color: var(--text-color-on-inverted);
-      border-color: var(--text-color-on-inverted);
-    }
+  &.inline {
+    position: relative;
+    inset: unset;
+    transform: none;
+    z-index: auto;
   }
 }
 
 .icon {
   display: flex;
-  margin-left: var(--spacing-small);
-}
-
-.actionButton.withTransition {
-  opacity: 0;
-  animation: bounceIn 150ms cubic-bezier(0, 0, 0.4, 1);
-  animation-delay: 300ms;
-  animation-fill-mode: forwards;
+  flex-shrink: 0;
+  width: 16px;
+  height: 16px;
+  align-items: center;
+  justify-content: center;
+  margin-inline-start: -3px;
+  margin-inline-end: 4px;
 }
 
 .content {
-  margin: 0 var(--spacing-small);
   flex: 1;
+  min-width: 0;
+}
+
+.message {
+  font-weight: 500;
+  line-height: 1.5;
 }
 
 .textContent {
-  display: inline-flex;
-  flex-grow: 1;
+  flex: 1;
+  min-width: 0;
+}
+
+.actions {
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  gap: var(--space-8);
+  margin-inline-start: auto;
+}
+
+.actionButton {
+  flex-shrink: 0;
+  height: 24px;
+  padding: 0 var(--space-8);
+  border: none;
+  border-radius: var(--border-radius-small);
+  background-color: hsl(0, 0%, 9%);
+  color: #fff;
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 24px;
+  white-space: nowrap;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 0.9;
+  }
+
+  &.withTransition {
+    opacity: 0;
+    animation: bounceIn 150ms cubic-bezier(0, 0, 0.4, 1);
+    animation-delay: 300ms;
+    animation-fill-mode: forwards;
+  }
+}
+
+.typePositive .actionButton {
+  background-color: hsl(140, 100%, 27%);
+  color: hsl(143, 85%, 96%);
+}
+
+.typeNegative .actionButton {
+  background-color: hsl(360, 100%, 45%);
+  color: hsl(359, 100%, 97%);
+}
+
+.typeWarning .actionButton {
+  background-color: hsl(31, 92%, 45%);
+  color: hsl(49, 100%, 97%);
+}
+
+.typeDark .actionButton {
+  background-color: hsl(0, 0%, 99%);
+  color: #000;
+}
+
+.actionLink {
+  flex-shrink: 0;
+  color: currentColor;
+  font-weight: 500;
+  text-decoration: underline;
+  white-space: nowrap;
+  -webkit-font-smoothing: auto;
+  -moz-osx-font-smoothing: auto;
+
+  &:hover {
+    opacity: 0.8;
+  }
 }
 
 .enterActive {
   animation-iteration-count: 1;
   animation-fill-mode: forwards;
   animation-name: slideIn;
-  animation-duration: 350ms;
-  animation-timing-function: cubic-bezier(0.6, 0, 0.4, 1);
+  animation-duration: 400ms;
+  animation-timing-function: ease;
 }
 
 .exitActive {
   animation-iteration-count: 1;
   animation-fill-mode: forwards;
   animation-name: slideOut;
-  animation-duration: 350ms;
-  animation-timing-function: cubic-bezier(0.6, 0, 0.4, 1);
+  animation-duration: 400ms;
+  animation-timing-function: ease;
 }
 
 .closeButton {
-  margin-left: var(--spacing-small);
+  display: flex;
+  flex-shrink: 0;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  padding: 0;
+  margin-inline-start: var(--space-4);
+  border: none;
+  border-radius: 50%;
+  background: transparent;
+  color: inherit;
+  opacity: 0.6;
+  cursor: pointer;
+
+  &:hover {
+    opacity: 1;
+    background-color: rgba(0, 0, 0, 0.06);
+  }
+}
+
+.typeDark .closeButton:hover {
+  background-color: rgba(255, 255, 255, 0.12);
 }
 
 @keyframes slideIn {
   0% {
-    transform: translate(-50%, -100px);
-  }
-
-  40% {
-    transform: translate(-50%, 16px);
+    transform: translate(-50%, -100%);
+    opacity: 0;
   }
 
   100% {
-    transform: translate(-50%, 0px);
+    transform: translate(-50%, 0);
+    opacity: 1;
   }
 }
 
 @keyframes slideOut {
   0% {
     transform: translate(-50%, 0);
+    opacity: 1;
   }
 
   100% {
-    transform: translate(-50%, -100px);
+    transform: translate(-50%, -100%);
     opacity: 0;
   }
 }

--- a/packages/core/src/components/Toast/Toast.tsx
+++ b/packages/core/src/components/Toast/Toast.tsx
@@ -2,8 +2,9 @@ import { camelCase } from "es-toolkit";
 import { ComponentDefaultTestId, getTestId } from "../../tests/test-ids-utils";
 import cx from "classnames";
 import React, { type ReactElement, useCallback, useEffect, useMemo, useRef } from "react";
+import { createPortal } from "react-dom";
 import { CSSTransition } from "react-transition-group";
-import { type IconSubComponentProps } from "@vibe/icon";
+import { Icon, type IconSubComponentProps } from "@vibe/icon";
 import { Text } from "@vibe/typography";
 import { Loader } from "@vibe/loader";
 import { Flex } from "@vibe/layout";
@@ -17,7 +18,6 @@ import { NOOP } from "../../utils/function-utils";
 import { getStyle } from "../../helpers/typesciptCssModulesHelper";
 import { type VibeComponentProps, withStaticPropsWithoutForwardRef } from "../../types";
 import styles from "./Toast.module.scss";
-import { IconButton } from "@vibe/icon-button";
 import usePrevious from "../../hooks/usePrevious";
 
 export interface ToastProps extends VibeComponentProps {
@@ -70,6 +70,10 @@ export interface ToastProps extends VibeComponentProps {
    * The aria-label for the close button.
    */
   closeButtonAriaLabel?: string;
+  /**
+   * If true, renders the toast inline (for galleries/previews) instead of fixed at the top of the viewport.
+   */
+  inline?: boolean;
 }
 
 const Toast = ({
@@ -87,6 +91,7 @@ const Toast = ({
   className,
   id,
   closeButtonAriaLabel = "Close",
+  inline = false,
   "data-testid": dataTestId
 }: ToastProps) => {
   const ref = useRef(null);
@@ -123,8 +128,8 @@ const Toast = ({
   }, [actions, shouldShowButtonTransition]);
 
   const classNames = useMemo(
-    () => cx(styles.toast, getStyle(styles, camelCase("type-" + type)), className),
-    [type, className]
+    () => cx(styles.toast, getStyle(styles, camelCase("type-" + type)), { [styles.inline]: inline }, className),
+    [type, inline, className]
   );
 
   const handleClose = useCallback(() => {
@@ -177,7 +182,57 @@ const Toast = ({
     }
   }, [children, recalculateElementWidth]);
 
-  return (
+  const toastElement = (
+    <Text
+      ref={nodeRef}
+      id={id}
+      data-testid={dataTestId || getTestId(ComponentDefaultTestId.TOAST, id)}
+      data-vibe="Toast"
+      type="text2"
+      element="div"
+      className={classNames}
+      role="alert"
+      aria-live="polite"
+    >
+      {iconElement && <div className={cx(styles.icon)}>{iconElement}</div>}
+      <Flex align="center" gap="small" className={styles.content}>
+        <div
+          data-testid={getTestId(ComponentDefaultTestId.TOAST_CONTENT)}
+          className={styles.textContent}
+        >
+          <span className={styles.message}>{children}</span>
+        </div>
+        {(toastLinks || toastButtons || deprecatedAction) && (
+          <div className={styles.actions}>
+            {toastLinks}
+            {(toastButtons || deprecatedAction) && (toastButtons || deprecatedAction)}
+          </div>
+        )}
+        {loading && <Loader size="xs" />}
+      </Flex>
+      {closeable && (
+        <button
+          type="button"
+          className={cx(styles.closeButton)}
+          onClick={handleClose}
+          aria-label={closeButtonAriaLabel}
+          data-testid={getTestId(ComponentDefaultTestId.TOAST_CLOSE_BUTTON)}
+        >
+          <Icon icon={CloseSmall} iconSize={14} ignoreFocusStyle />
+        </button>
+      )}
+    </Text>
+  );
+
+  if (inline) {
+    if (!open) {
+      return null;
+    }
+
+    return toastElement;
+  }
+
+  return createPortal(
     <CSSTransition
       in={open}
       nodeRef={nodeRef}
@@ -185,45 +240,9 @@ const Toast = ({
       timeout={400}
       unmountOnExit
     >
-      <Text
-        ref={nodeRef}
-        id={id}
-        data-testid={dataTestId || getTestId(ComponentDefaultTestId.TOAST, id)}
-        type="text2"
-        element="div"
-        color="fixedLight"
-        className={classNames}
-        role="alert"
-        aria-live="polite"
-      >
-        {iconElement && <div className={cx(styles.icon)}>{iconElement}</div>}
-        <Flex align="center" gap="large" className={styles.content}>
-          <Flex
-            gap="medium"
-            data-testid={getTestId(ComponentDefaultTestId.TOAST_CONTENT)}
-            className={styles.textContent}
-          >
-            <span>{children}</span>
-            {toastLinks}
-          </Flex>
-          {(toastButtons || deprecatedAction) && (toastButtons || deprecatedAction)}
-          {loading && <Loader size="xs" />}
-        </Flex>
-        {closeable && (
-          <IconButton
-            className={cx(styles.closeButton)}
-            onClick={handleClose}
-            size="small"
-            kind="tertiary"
-            color="fixed-light"
-            ariaLabel={closeButtonAriaLabel}
-            data-testid={getTestId(ComponentDefaultTestId.TOAST_CLOSE_BUTTON)}
-            icon={CloseSmall}
-            hideTooltip
-          />
-        )}
-      </Text>
-    </CSSTransition>
+      {toastElement}
+    </CSSTransition>,
+    document.body
   );
 };
 

--- a/packages/core/src/components/Toast/ToastButton/ToastButton.tsx
+++ b/packages/core/src/components/Toast/ToastButton/ToastButton.tsx
@@ -1,27 +1,27 @@
-import { Button, type ButtonProps } from "@vibe/button";
-import React, { type FC } from "react";
+import React, { type ButtonHTMLAttributes, type FC } from "react";
 import { ComponentDefaultTestId } from "../../../tests/constants";
 import { getTestId } from "../../../tests/test-ids-utils";
 
-export type ToastButtonProps = ButtonProps;
+export type ToastButtonProps = ButtonHTMLAttributes<HTMLButtonElement>;
 
 const ToastButton: FC<ToastButtonProps> = ({
   className,
   id,
+  children,
   "data-testid": dataTestId,
+  type = "button",
   ...buttonProps
 }: ToastButtonProps) => {
   return (
-    <Button
+    <button
       {...buttonProps}
       id={id}
-      kind="secondary"
-      marginLeft={false}
+      type={type}
       data-testid={dataTestId || getTestId(ComponentDefaultTestId.TOAST_BUTTON, id)}
       className={className}
-      size="small"
-      color="fixed-light"
-    />
+    >
+      {children}
+    </button>
   );
 };
 

--- a/packages/core/src/components/Toast/ToastHelpers.tsx
+++ b/packages/core/src/components/Toast/ToastHelpers.tsx
@@ -9,6 +9,6 @@ export const getIcon = (type: ToastType, icon: string | React.FC<IconSubComponen
     return icon;
   }
   return icon || defaultIconMap[type] ? (
-    <Icon iconType={icon ? "font" : "svg"} icon={icon || defaultIconMap[type]} iconSize={20} ignoreFocusStyle />
+    <Icon iconType={icon ? "font" : "svg"} icon={icon || defaultIconMap[type]} iconSize={16} ignoreFocusStyle />
   ) : null;
 };

--- a/packages/core/src/components/Toast/ToastLink/ToastLink.module.scss
+++ b/packages/core/src/components/Toast/ToastLink/ToastLink.module.scss
@@ -1,9 +1,11 @@
 .actionLink {
-  color: var(--text-color-on-primary);
+  color: currentColor;
+  font-weight: 500;
+  text-decoration: underline;
   -webkit-font-smoothing: auto;
   -moz-osx-font-smoothing: auto;
 
   &:hover {
-    color: inherit;
+    opacity: 0.8;
   }
 }

--- a/packages/core/src/components/Toast/__tests__/Toast.snapshot.test.tsx
+++ b/packages/core/src/components/Toast/__tests__/Toast.snapshot.test.tsx
@@ -3,6 +3,14 @@ import React from "react";
 import renderer from "react-test-renderer";
 import Toast from "../Toast";
 
+vi.mock("react-dom", async () => {
+  const actual = await vi.importActual<typeof import("react-dom")>("react-dom");
+  return {
+    ...actual,
+    createPortal: (node: React.ReactNode) => node
+  };
+});
+
 vi.mock("react-transition-group", () => {
   const FakeTransition = vi.fn(({ children }) => children);
   const FakeSwitchTransition = vi.fn(({ children }) => children);

--- a/packages/core/src/components/Toast/__tests__/__snapshots__/Toast.snapshot.test.tsx.snap
+++ b/packages/core/src/components/Toast/__tests__/__snapshots__/Toast.snapshot.test.tsx.snap
@@ -3,8 +3,9 @@
 exports[`Toast renders correctly > (renders nothing) with empty props 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -16,9 +17,9 @@ exports[`Toast renders correctly > (renders nothing) with empty props 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -32,43 +33,24 @@ exports[`Toast renders correctly > (renders nothing) with empty props 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span />
+      <span
+        className="message"
+      />
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -77,9 +59,9 @@ exports[`Toast renders correctly > (renders nothing) with empty props 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -92,8 +74,9 @@ exports[`Toast renders correctly > (renders nothing) with empty props 1`] = `
 exports[`Toast renders correctly > and don't renders close button if closeable=false 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -105,9 +88,9 @@ exports[`Toast renders correctly > and don't renders close button if closeable=f
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -121,20 +104,17 @@ exports[`Toast renders correctly > and don't renders close button if closeable=f
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
@@ -145,8 +125,9 @@ exports[`Toast renders correctly > and don't renders close button if closeable=f
 exports[`Toast renders correctly > renders nothing when open is false 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -158,9 +139,9 @@ exports[`Toast renders correctly > renders nothing when open is false 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -174,45 +155,26 @@ exports[`Toast renders correctly > renders nothing when open is false 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -221,9 +183,9 @@ exports[`Toast renders correctly > renders nothing when open is false 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -236,53 +198,35 @@ exports[`Toast renders correctly > renders nothing when open is false 1`] = `
 exports[`Toast renders correctly > when icon is hidden 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -291,9 +235,9 @@ exports[`Toast renders correctly > when icon is hidden 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -306,8 +250,9 @@ exports[`Toast renders correctly > when icon is hidden 1`] = `
 exports[`Toast renders correctly > when open is true 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -319,9 +264,9 @@ exports[`Toast renders correctly > when open is true 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -335,45 +280,26 @@ exports[`Toast renders correctly > when open is true 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -382,9 +308,9 @@ exports[`Toast renders correctly > when open is true 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -397,8 +323,9 @@ exports[`Toast renders correctly > when open is true 1`] = `
 exports[`Toast renders correctly > with button 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -410,9 +337,9 @@ exports[`Toast renders correctly > with button 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -426,60 +353,37 @@ exports[`Toast renders correctly > with button 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
-    <button
-      aria-busy={false}
-      aria-disabled={false}
-      className="actionButton button sizeSmall kindSecondary colorFixedLight"
-      data-testid="toast-button"
-      data-vibe="Button"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      type="button"
+    <div
+      className="actions"
     >
-      Undo 5
-    </button>
+      <button
+        className="actionButton"
+        data-testid="toast-button"
+        type="button"
+      >
+        Undo 5
+      </button>
+    </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -488,9 +392,9 @@ exports[`Toast renders correctly > with button 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -503,8 +407,9 @@ exports[`Toast renders correctly > with button 1`] = `
 exports[`Toast renders correctly > with button and link 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -516,9 +421,9 @@ exports[`Toast renders correctly > with button and link 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -532,22 +437,23 @@ exports[`Toast renders correctly > with button and link 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
+    </div>
+    <div
+      className="actions"
+    >
       <a
         aria-describedby=""
         aria-label=""
@@ -567,44 +473,20 @@ exports[`Toast renders correctly > with button and link 1`] = `
           Lorem ipsum
         </span>
       </a>
+      <button
+        className="actionButton"
+        data-testid="toast-button"
+        type="button"
+      >
+        Undo 5
+      </button>
     </div>
-    <button
-      aria-busy={false}
-      aria-disabled={false}
-      className="actionButton button sizeSmall kindSecondary colorFixedLight"
-      data-testid="toast-button"
-      data-vibe="Button"
-      onBlur={[Function]}
-      onClick={[Function]}
-      onFocus={[Function]}
-      onMouseDown={[Function]}
-      onMouseUp={[Function]}
-      type="button"
-    >
-      Undo 5
-    </button>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -613,9 +495,9 @@ exports[`Toast renders correctly > with button and link 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -628,8 +510,9 @@ exports[`Toast renders correctly > with button and link 1`] = `
 exports[`Toast renders correctly > with link 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -641,9 +524,9 @@ exports[`Toast renders correctly > with link 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -657,22 +540,23 @@ exports[`Toast renders correctly > with link 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
+    </div>
+    <div
+      className="actions"
+    >
       <a
         aria-describedby=""
         aria-label=""
@@ -695,26 +579,10 @@ exports[`Toast renders correctly > with link 1`] = `
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -723,9 +591,9 @@ exports[`Toast renders correctly > with link 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -738,8 +606,9 @@ exports[`Toast renders correctly > with link 1`] = `
 exports[`Toast renders correctly > with loading 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNormal"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNormal"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -751,9 +620,9 @@ exports[`Toast renders correctly > with loading 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -767,20 +636,17 @@ exports[`Toast renders correctly > with loading 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
@@ -813,26 +679,10 @@ exports[`Toast renders correctly > with loading 1`] = `
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -841,9 +691,9 @@ exports[`Toast renders correctly > with loading 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"
@@ -856,8 +706,9 @@ exports[`Toast renders correctly > with loading 1`] = `
 exports[`Toast renders correctly > with negative type 1`] = `
 <div
   aria-live="polite"
-  className="typography fixedLight start singleLineEllipsis text text2Normal toast typeNegative"
+  className="typography primary start singleLineEllipsis text text2Normal toast typeNegative"
   data-testid="toast"
+  data-vibe="Toast"
   role="alert"
 >
   <div
@@ -869,9 +720,9 @@ exports[`Toast renders correctly > with negative type 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="16"
       viewBox="0 0 20 20"
-      width="20"
+      width="16"
     >
       <path
         clipRule="evenodd"
@@ -885,45 +736,26 @@ exports[`Toast renders correctly > with negative type 1`] = `
     className="container directionRow justifyStart alignCenter content"
     style={
       {
-        "gap": "var(--spacing-large)",
+        "gap": "var(--spacing-small)",
       }
     }
   >
     <div
-      className="container directionRow justifyStart alignCenter textContent"
+      className="textContent"
       data-testid="toast-content"
-      style={
-        {
-          "gap": "var(--spacing-medium)",
-        }
-      }
     >
-      <span>
+      <span
+        className="message"
+      >
         Something Happened
       </span>
     </div>
   </div>
   <button
-    aria-busy={false}
-    aria-disabled={false}
     aria-label="Close"
-    className="closeButton button sizeMedium kindTertiary colorFixedLight noSidePadding"
+    className="closeButton"
     data-testid="toast-close-button"
-    data-vibe="Button"
-    onBlur={[Function]}
     onClick={[Function]}
-    onFocus={[Function]}
-    onMouseDown={[Function]}
-    onMouseUp={[Function]}
-    style={
-      {
-        "alignItems": "center",
-        "height": "32px",
-        "justifyContent": "center",
-        "padding": 0,
-        "width": "32px",
-      }
-    }
     type="button"
   >
     <svg
@@ -932,9 +764,9 @@ exports[`Toast renders correctly > with negative type 1`] = `
       data-testid="icon"
       data-vibe="Icon"
       fill="currentColor"
-      height="20"
+      height="14"
       viewBox="0 0 20 20"
-      width="20"
+      width="14"
     >
       <path
         d="M6.331 5.27a.75.75 0 0 0-1.06 1.06L8.94 10l-3.67 3.668a.75.75 0 1 0 1.06 1.06L10 11.06l3.668 3.669a.75.75 0 0 0 1.06-1.06l-3.668-3.67 3.67-3.669a.75.75 0 0 0-1.061-1.06L10 8.939l-3.669-3.67Z"

--- a/packages/kitchen-sink/src/App.tsx
+++ b/packages/kitchen-sink/src/App.tsx
@@ -3,12 +3,13 @@ import { AppThemeShell } from "./components/AppThemeShell";
 import { LeftPane } from "./components/LeftPane";
 import { useKitchenSink } from "./context/KitchenSinkContext";
 import { ComponentsView } from "./components/ComponentsView";
+import { ToastGalleryView } from "./components/ToastGalleryView";
 import { CompareView } from "./components/CompareView";
 import { ThemePanel } from "./components/ThemePanel";
 import { ScreensView } from "./components/ScreensView";
 
 export default function App() {
-  const { view } = useKitchenSink();
+  const { view, componentSubPage } = useKitchenSink();
   const [leftPaneCollapsed, setLeftPaneCollapsed] = useState(false);
 
   return (
@@ -21,7 +22,8 @@ export default function App() {
           onToggleCollapse={() => setLeftPaneCollapsed((c) => !c)}
         />
         <main className={`main-area${view === "screens" ? " main-area--no-padding" : ""}`}>
-          {view === "components" && <ComponentsView />}
+          {view === "components" && componentSubPage === "grid" && <ComponentsView />}
+          {view === "components" && componentSubPage === "toast" && <ToastGalleryView />}
           {view === "compare" && <CompareView />}
           {view === "theme" && <ThemePanel />}
           {view === "screens" && <ScreensView />}

--- a/packages/kitchen-sink/src/components/LeftPane.tsx
+++ b/packages/kitchen-sink/src/components/LeftPane.tsx
@@ -18,9 +18,11 @@ export function LeftPane({ collapsed, onToggleCollapse }: LeftPaneProps) {
   const {
     view,
     themeSubPage,
+    componentSubPage,
     systemTheme,
     setView,
     setThemeSubPage,
+    setComponentSubPage,
     setSystemTheme,
   } = useKitchenSink();
 
@@ -45,6 +47,13 @@ export function LeftPane({ collapsed, onToggleCollapse }: LeftPaneProps) {
           onClick={() => setView("components")}
         >
           Components
+        </button>
+        <button
+          type="button"
+          className={`left-pane-sublink left-pane-sublink--deep${view === "components" && componentSubPage === "toast" ? " is-active" : ""}`}
+          onClick={() => setComponentSubPage("toast")}
+        >
+          Toast
         </button>
         <button
           type="button"

--- a/packages/kitchen-sink/src/components/ToastGalleryView.tsx
+++ b/packages/kitchen-sink/src/components/ToastGalleryView.tsx
@@ -1,0 +1,135 @@
+import { Toast, type ToastProps } from "@vibe/core";
+
+type ToastVariation = {
+  id: string;
+  label: string;
+  props: ToastProps;
+  message: string;
+};
+
+const toastVariations: ToastVariation[] = [
+  {
+    id: "normal",
+    label: "Normal",
+    message: "General message toast",
+    props: { type: "normal" },
+  },
+  {
+    id: "normal-with-button",
+    label: "Normal with button",
+    message: "General message toast",
+    props: {
+      type: "normal",
+      actions: [{ type: "button", content: "Button" }],
+    },
+  },
+  {
+    id: "normal-with-link",
+    label: "Normal with link",
+    message: "General message toast",
+    props: {
+      type: "normal",
+      actions: [{ type: "link", text: "Link to action", href: "https://monday.com" }],
+    },
+  },
+  {
+    id: "normal-with-button-and-link",
+    label: "Normal with button and link",
+    message: "General message toast",
+    props: {
+      type: "normal",
+      actions: [
+        { type: "button", content: "Undo 5" },
+        { type: "link", text: "Lorem ipsum", href: "https://monday.com" },
+      ],
+    },
+  },
+  {
+    id: "normal-loading",
+    label: "Normal with loading",
+    message: "General message toast",
+    props: { type: "normal", loading: true },
+  },
+  {
+    id: "positive",
+    label: "Success (positive)",
+    message: "Positive message toast",
+    props: {
+      type: "positive",
+      actions: [{ type: "button", content: "Undo 5" }],
+    },
+  },
+  {
+    id: "negative",
+    label: "Error (negative)",
+    message: "Negative message toast",
+    props: {
+      type: "negative",
+      actions: [{ type: "button", content: "Button" }],
+    },
+  },
+  {
+    id: "warning",
+    label: "Warning",
+    message: "Warning message toast",
+    props: {
+      type: "warning",
+      actions: [{ type: "button", content: "Button" }],
+    },
+  },
+  {
+    id: "dark",
+    label: "Dark",
+    message: "Dark message toast",
+    props: {
+      type: "dark",
+      actions: [{ type: "button", content: "Button" }],
+    },
+  },
+  {
+    id: "feedback-loop",
+    label: "Feedback loop",
+    message: "We successfully deleted 1 item",
+    props: {
+      type: "positive",
+      actions: [{ type: "button", content: "Undo" }],
+    },
+  },
+  {
+    id: "no-close-button",
+    label: "Without close button",
+    message: "General message toast",
+    props: { type: "normal", closeable: false },
+  },
+  {
+    id: "no-icon",
+    label: "Without icon",
+    message: "General message toast",
+    props: { type: "normal", hideIcon: true },
+  },
+];
+
+export function ToastGalleryView() {
+  return (
+    <div className="toast-gallery">
+      <header className="toast-gallery-header">
+        <h1 className="toast-gallery-title">Toast</h1>
+        <p className="toast-gallery-description">
+          All toast variations currently supported by the component.
+        </p>
+      </header>
+      <div className="toast-gallery-grid">
+        {toastVariations.map(({ id, label, message, props }) => (
+          <article key={id} className="toast-gallery-item">
+            <h2 className="toast-gallery-item-label">{label}</h2>
+            <div className="toast-gallery-item-preview">
+              <Toast {...props} id={`toast-gallery-${id}`} open inline>
+                {message}
+              </Toast>
+            </div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/kitchen-sink/src/context/KitchenSinkContext.tsx
+++ b/packages/kitchen-sink/src/context/KitchenSinkContext.tsx
@@ -11,6 +11,7 @@ import { loadPersistedState, savePersistedState } from "../lib/storage";
 import type {
   AppState,
   AppView,
+  ComponentSubPage,
   SystemTheme,
   ThemeSubPage,
   TokenOverrides,
@@ -19,6 +20,7 @@ import type {
 type KitchenSinkContextValue = AppState & {
   setView: (view: AppView) => void;
   setThemeSubPage: (page: ThemeSubPage) => void;
+  setComponentSubPage: (page: ComponentSubPage) => void;
   setSystemTheme: (theme: SystemTheme) => void;
   setFocusedComponentId: (id: string | null) => void;
   updateComponentState: (id: string, patch: Record<string, unknown>) => void;
@@ -37,12 +39,26 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
     return () => window.clearTimeout(id);
   }, [state]);
 
+  useEffect(() => {
+    if (window.location.hash === "#toast") {
+      setState((s) => ({ ...s, view: "components", componentSubPage: "toast" }));
+    }
+  }, []);
+
   const setView = useCallback((view: AppView) => {
-    setState((s) => ({ ...s, view }));
+    setState((s) => ({
+      ...s,
+      view,
+      componentSubPage: view === "components" ? "grid" : s.componentSubPage,
+    }));
   }, []);
 
   const setThemeSubPage = useCallback((themeSubPage: ThemeSubPage) => {
     setState((s) => ({ ...s, view: "theme", themeSubPage }));
+  }, []);
+
+  const setComponentSubPage = useCallback((componentSubPage: ComponentSubPage) => {
+    setState((s) => ({ ...s, view: "components", componentSubPage }));
   }, []);
 
   const setSystemTheme = useCallback((systemTheme: SystemTheme) => {
@@ -108,6 +124,7 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
       ...state,
       setView,
       setThemeSubPage,
+      setComponentSubPage,
       setSystemTheme,
       setFocusedComponentId,
       updateComponentState,
@@ -119,6 +136,7 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
       state,
       setView,
       setThemeSubPage,
+      setComponentSubPage,
       setSystemTheme,
       setFocusedComponentId,
       updateComponentState,

--- a/packages/kitchen-sink/src/lib/storage.ts
+++ b/packages/kitchen-sink/src/lib/storage.ts
@@ -15,6 +15,7 @@ export function createInitialAppState(): AppState {
   return {
     view: "components",
     themeSubPage: "colors",
+    componentSubPage: "grid",
     systemTheme: "light",
     tokenOverrides: structuredClone(EMPTY_TOKEN_OVERRIDES),
     componentStates: mergeWithDefaults(undefined),
@@ -28,6 +29,7 @@ function toPersisted(state: AppState): PersistedState {
     version: STORAGE_VERSION,
     view: state.view,
     themeSubPage: state.themeSubPage,
+    componentSubPage: state.componentSubPage,
     systemTheme: state.systemTheme,
     tokenOverrides: state.tokenOverrides,
     componentStates: state.componentStates,
@@ -60,6 +62,7 @@ export function loadPersistedState(): AppState {
       ...base,
       view: parsed.view ?? base.view,
       themeSubPage: normalizeThemeSubPage(parsed.themeSubPage, base.themeSubPage),
+      componentSubPage: parsed.componentSubPage ?? base.componentSubPage,
       systemTheme: parsed.systemTheme ?? base.systemTheme,
       tokenOverrides: {
         ...base.tokenOverrides,

--- a/packages/kitchen-sink/src/screens/components/AgentAvatarStub.tsx
+++ b/packages/kitchen-sink/src/screens/components/AgentAvatarStub.tsx
@@ -1,0 +1,8 @@
+import { Avatar, type AvatarProps } from "@vibe/core";
+
+type AgentAvatarProps = Omit<AvatarProps, "square" | "type">;
+
+/** Local stand-in for monday-ui-components AgentAvatar (deep import unavailable in this worktree). */
+export default function AgentAvatar(props: AgentAvatarProps) {
+  return <Avatar {...props} type="img" square />;
+}

--- a/packages/kitchen-sink/src/styles.css
+++ b/packages/kitchen-sink/src/styles.css
@@ -578,3 +578,63 @@ body {
   color: var(--text-color-on-primary, #ffffff);
   font-weight: 600;
 }
+
+.toast-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.toast-gallery-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.toast-gallery-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--primary-text-color, #323338);
+}
+
+.toast-gallery-description {
+  margin: 0;
+  font-size: 14px;
+  color: var(--secondary-text-color, #676879);
+}
+
+.toast-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 20px;
+}
+
+.toast-gallery-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--layout-border-color, #e6e9ef);
+  border-radius: var(--border-radius-medium, 8px);
+  background: var(--secondary-background-color, #ffffff);
+}
+
+.toast-gallery-item-label {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--secondary-text-color, #676879);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.toast-gallery-item-preview {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 88px;
+  padding: 16px;
+  border-radius: var(--border-radius-small, 4px);
+  background: var(--allgrey-background-color, #f6f7fb);
+}

--- a/packages/kitchen-sink/src/types.ts
+++ b/packages/kitchen-sink/src/types.ts
@@ -3,6 +3,7 @@ import type React from "react";
 export type SystemTheme = "light" | "dark" | "black";
 export type AppView = "components" | "compare" | "theme" | "screens";
 export type ThemeSubPage = "colors" | "radius" | "typography";
+export type ComponentSubPage = "grid" | "toast";
 
 export type ThemeColorOverrides = Partial<Record<SystemTheme, Record<string, string>>>;
 
@@ -18,6 +19,7 @@ export type ComponentStateMap = Record<string, Record<string, unknown>>;
 export type AppState = {
   view: AppView;
   themeSubPage: ThemeSubPage;
+  componentSubPage: ComponentSubPage;
   systemTheme: SystemTheme;
   tokenOverrides: TokenOverrides;
   componentStates: ComponentStateMap;
@@ -32,6 +34,7 @@ export type PersistedState = {
   version: number;
   view: AppView;
   themeSubPage: ThemeSubPage;
+  componentSubPage?: ComponentSubPage;
   systemTheme: SystemTheme;
   tokenOverrides: TokenOverrides;
   componentStates: ComponentStateMap;

--- a/packages/kitchen-sink/vite.config.ts
+++ b/packages/kitchen-sink/vite.config.ts
@@ -1,6 +1,9 @@
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
+import { fileURLToPath } from "url";
+
+const rootDir = path.dirname(fileURLToPath(import.meta.url));
 
 export default defineConfig({
   plugins: [react()],
@@ -13,26 +16,29 @@ export default defineConfig({
     alias: {
       // Point directly at the monorepo's built packages/core so source changes
       // (after `yarn workspace @vibe/core build`) are picked up by both apps.
-      "@vibe/core/tokens": path.resolve(__dirname, "../core/dist/tokens/tokens.css"),
-      "@vibe/core": path.resolve(__dirname, "../core/dist/src/index.js"),
-      "@vibe/icons": path.resolve(__dirname, "node_modules/@vibe/icons/dist/react/index.js"),
+      "@vibe/core/tokens": path.resolve(rootDir, "../core/dist/tokens/tokens.css"),
+      "@vibe/core": path.resolve(rootDir, "../core/dist/src/index.js"),
+      "@vibe/icons": path.resolve(rootDir, "node_modules/@vibe/icons/dist/react/index.js"),
+      // Deep AgentAvatar import — package barrel pulls monolith-only deps; stub locally when unavailable.
+      "@mondaydotcomorg/monday-ui-components/dist/esm/monday-ui-components/src/components/AgentAvatar/AgentAvatar.js":
+        path.resolve(rootDir, "./src/screens/components/AgentAvatarStub.tsx"),
       // @ alias used by screens/ (facelift-prototype) components
-      "@": path.resolve(__dirname, "./src/screens"),
+      "@": path.resolve(rootDir, "./src/screens"),
       // figma:asset/... imports used by screens/ (facelift-prototype) components
-      "figma:asset/f0c15171c575bb8aa71b3703f917cb5be31788dd.png": path.resolve(__dirname, "./src/screens/assets/f0c15171c575bb8aa71b3703f917cb5be31788dd.png"),
-      "figma:asset/ec90618f4fe697ef59f9ba376c95f32ab905bf13.png": path.resolve(__dirname, "./src/screens/assets/ec90618f4fe697ef59f9ba376c95f32ab905bf13.png"),
-      "figma:asset/e80552e5cd311931922a10d6dd70061713e6b1ac.png": path.resolve(__dirname, "./src/screens/assets/e80552e5cd311931922a10d6dd70061713e6b1ac.png"),
-      "figma:asset/cf1083401990504fa214e1814dd9e86530f6484c.png": path.resolve(__dirname, "./src/screens/assets/cf1083401990504fa214e1814dd9e86530f6484c.png"),
-      "figma:asset/c3e2da2431edb45e665c1d6bfc0377ef4df16956.png": path.resolve(__dirname, "./src/screens/assets/c3e2da2431edb45e665c1d6bfc0377ef4df16956.png"),
-      "figma:asset/99ba70c9442119f320638528787cb086eabb5871.png": path.resolve(__dirname, "./src/screens/assets/99ba70c9442119f320638528787cb086eabb5871.png"),
-      "figma:asset/956984e2f299222affe9c3f9d1b91d646e618dbf.png": path.resolve(__dirname, "./src/screens/assets/956984e2f299222affe9c3f9d1b91d646e618dbf.png"),
-      "figma:asset/8128ea9b2697cf84d6336d0cf0bbd261c3cae4a6.png": path.resolve(__dirname, "./src/screens/assets/8128ea9b2697cf84d6336d0cf0bbd261c3cae4a6.png"),
-      "figma:asset/6f1e4ef08a4e8899bba87998c3410a8132536714.png": path.resolve(__dirname, "./src/screens/assets/6f1e4ef08a4e8899bba87998c3410a8132536714.png"),
-      "figma:asset/4791b41afa3cbdfd3b5bceec099dbf0fe05b97cd.png": path.resolve(__dirname, "./src/screens/assets/4791b41afa3cbdfd3b5bceec099dbf0fe05b97cd.png"),
-      "figma:asset/44a0d931f8b012dcfc18715f7a64847e76751825.png": path.resolve(__dirname, "./src/screens/assets/44a0d931f8b012dcfc18715f7a64847e76751825.png"),
-      "figma:asset/41836246ebeea8335f78a1ba2a938aabf44d0607.png": path.resolve(__dirname, "./src/screens/assets/41836246ebeea8335f78a1ba2a938aabf44d0607.png"),
-      "figma:asset/31a207ddb210814d45f4e60c5afe26c81fb55207.png": path.resolve(__dirname, "./src/screens/assets/31a207ddb210814d45f4e60c5afe26c81fb55207.png"),
-      "figma:asset/15ef82c8ee79f6111e42949aea8f2307269524d3.png": path.resolve(__dirname, "./src/screens/assets/15ef82c8ee79f6111e42949aea8f2307269524d3.png"),
+      "figma:asset/f0c15171c575bb8aa71b3703f917cb5be31788dd.png": path.resolve(rootDir, "./src/screens/assets/f0c15171c575bb8aa71b3703f917cb5be31788dd.png"),
+      "figma:asset/ec90618f4fe697ef59f9ba376c95f32ab905bf13.png": path.resolve(rootDir, "./src/screens/assets/ec90618f4fe697ef59f9ba376c95f32ab905bf13.png"),
+      "figma:asset/e80552e5cd311931922a10d6dd70061713e6b1ac.png": path.resolve(rootDir, "./src/screens/assets/e80552e5cd311931922a10d6dd70061713e6b1ac.png"),
+      "figma:asset/cf1083401990504fa214e1814dd9e86530f6484c.png": path.resolve(rootDir, "./src/screens/assets/cf1083401990504fa214e1814dd9e86530f6484c.png"),
+      "figma:asset/c3e2da2431edb45e665c1d6bfc0377ef4df16956.png": path.resolve(rootDir, "./src/screens/assets/c3e2da2431edb45e665c1d6bfc0377ef4df16956.png"),
+      "figma:asset/99ba70c9442119f320638528787cb086eabb5871.png": path.resolve(rootDir, "./src/screens/assets/99ba70c9442119f320638528787cb086eabb5871.png"),
+      "figma:asset/956984e2f299222affe9c3f9d1b91d646e618dbf.png": path.resolve(rootDir, "./src/screens/assets/956984e2f299222affe9c3f9d1b91d646e618dbf.png"),
+      "figma:asset/8128ea9b2697cf84d6336d0cf0bbd261c3cae4a6.png": path.resolve(rootDir, "./src/screens/assets/8128ea9b2697cf84d6336d0cf0bbd261c3cae4a6.png"),
+      "figma:asset/6f1e4ef08a4e8899bba87998c3410a8132536714.png": path.resolve(rootDir, "./src/screens/assets/6f1e4ef08a4e8899bba87998c3410a8132536714.png"),
+      "figma:asset/4791b41afa3cbdfd3b5bceec099dbf0fe05b97cd.png": path.resolve(rootDir, "./src/screens/assets/4791b41afa3cbdfd3b5bceec099dbf0fe05b97cd.png"),
+      "figma:asset/44a0d931f8b012dcfc18715f7a64847e76751825.png": path.resolve(rootDir, "./src/screens/assets/44a0d931f8b012dcfc18715f7a64847e76751825.png"),
+      "figma:asset/41836246ebeea8335f78a1ba2a938aabf44d0607.png": path.resolve(rootDir, "./src/screens/assets/41836246ebeea8335f78a1ba2a938aabf44d0607.png"),
+      "figma:asset/31a207ddb210814d45f4e60c5afe26c81fb55207.png": path.resolve(rootDir, "./src/screens/assets/31a207ddb210814d45f4e60c5afe26c81fb55207.png"),
+      "figma:asset/15ef82c8ee79f6111e42949aea8f2307269524d3.png": path.resolve(rootDir, "./src/screens/assets/15ef82c8ee79f6111e42949aea8f2307269524d3.png"),
     },
   },
 });


### PR DESCRIPTION
## Summary
- Redesign Toast to a Sonner-style neutral card with type-specific color tints, updated action buttons, and top-center slide-down animation
- Add `inline` prop for in-place rendering (used by kitchen-sink gallery previews)
- Add kitchen-sink Toast gallery page with all 12 supported variations, plus dev workarounds for AgentAvatar import in the worktree

## Test plan
- [ ] Open kitchen-sink at `/#toast` and verify all 12 toast variations render in the grid
- [ ] Trigger a live toast and confirm it appears top-center with slide-down animation
- [ ] Verify positive, negative, warning, and dark types show correct colors and inverted action buttons
- [ ] Run `yarn workspace @vibe/core test` — Toast snapshot tests updated

Made with [Cursor](https://cursor.com)