### PR TITLE
feat(kitchen-sink): add dropdown gallery page with all variants

### DIFF
--- a/packages/kitchen-sink/src/App.tsx
+++ b/packages/kitchen-sink/src/App.tsx
@@ -3,12 +3,13 @@ import { AppThemeShell } from "./components/AppThemeShell";
 import { LeftPane } from "./components/LeftPane";
 import { useKitchenSink } from "./context/KitchenSinkContext";
 import { ComponentsView } from "./components/ComponentsView";
+import { DropdownGalleryView } from "./components/DropdownGalleryView";
 import { CompareView } from "./components/CompareView";
 import { ThemePanel } from "./components/ThemePanel";
 import { ScreensView } from "./components/ScreensView";
 
 export default function App() {
-  const { view } = useKitchenSink();
+  const { view, componentSubPage } = useKitchenSink();
   const [leftPaneCollapsed, setLeftPaneCollapsed] = useState(false);
 
   return (
@@ -21,7 +22,8 @@ export default function App() {
           onToggleCollapse={() => setLeftPaneCollapsed((c) => !c)}
         />
         <main className={`main-area${view === "screens" ? " main-area--no-padding" : ""}`}>
-          {view === "components" && <ComponentsView />}
+          {view === "components" && componentSubPage === "grid" && <ComponentsView />}
+          {view === "components" && componentSubPage === "dropdown" && <DropdownGalleryView />}
           {view === "compare" && <CompareView />}
           {view === "theme" && <ThemePanel />}
           {view === "screens" && <ScreensView />}

--- a/packages/kitchen-sink/src/components/DropdownGalleryView.tsx
+++ b/packages/kitchen-sink/src/components/DropdownGalleryView.tsx
@@ -1,0 +1,464 @@
+import { Dropdown } from "@vibe/core/next";
+import type { ComponentProps } from "react";
+import { Attach, Email, Mobile, Send } from "@vibe/icons";
+import avatar1 from "../screens/assets/31a207ddb210814d45f4e60c5afe26c81fb55207.png";
+import avatar2 from "../screens/assets/44a0d931f8b012dcfc18715f7a64847e76751825.png";
+import avatar3 from "../screens/assets/6f1e4ef08a4e8899bba87998c3410a8132536714.png";
+
+type DropdownVariation = {
+  id: string;
+  label: string;
+  render: () => React.ReactNode;
+};
+
+const basicOptions = [
+  { value: 1, label: "Option 1" },
+  { value: 2, label: "Option 2" },
+  { value: 3, label: "Option 3" },
+];
+
+const chipOptions = [
+  { value: "1", label: "Chip one" },
+  { value: "2", label: "Chip two" },
+  { value: "3", label: "Chip three" },
+  { value: "4", label: "Chip four" },
+];
+
+const iconOptions = [
+  { value: "email", label: "Email", startElement: { type: "icon" as const, value: Email } },
+  { value: "attach", label: "Attach", startElement: { type: "icon" as const, value: Attach } },
+];
+
+const avatarOptions = [
+  { value: "Julia", label: "Julia Martinez", startElement: { type: "avatar" as const, value: avatar1 } },
+  { value: "Sophia", label: "Sophia Johnson", startElement: { type: "avatar" as const, value: avatar2 } },
+  { value: "Marco", label: "Marco DiAngelo", startElement: { type: "avatar" as const, value: avatar3 } },
+];
+
+const groupedOptions = [
+  {
+    label: "Category 1",
+    options: [
+      { value: "1", label: "Item 1" },
+      { value: "2", label: "Item 2" },
+      { value: "3", label: "Item 3" },
+    ],
+  },
+  {
+    label: "Category 2",
+    options: [
+      { value: "4", label: "Item 1" },
+      { value: "5", label: "Item 2" },
+      { value: "6", label: "Item 3" },
+    ],
+  },
+];
+
+const groupedByDividerOptions = [
+  {
+    options: [
+      { value: "1", label: "Item 1" },
+      { value: "2", label: "Item 2" },
+      { value: "3", label: "Item 3" },
+    ],
+  },
+  {
+    options: [
+      { value: "4", label: "Item 1" },
+      { value: "5", label: "Item 2" },
+    ],
+  },
+];
+
+const startElementOptions = [
+  { value: "icon", label: "Item with icon", startElement: { type: "icon" as const, value: Email } },
+  { value: "avatar", label: "Item with avatar", startElement: { type: "avatar" as const, value: avatar1 } },
+  { value: "indent", label: "Item with indent", startElement: { type: "indent" as const } },
+];
+
+const endElementOptions = [
+  { value: "endIcon", label: "Item with icon", endElement: { type: "icon" as const, value: Email } },
+  { value: "hintText", label: "Item with hint text", endElement: { type: "suffix" as const, value: "⌘C" } },
+];
+
+const tooltipOptions = [
+  {
+    value: "Option 1",
+    label: "Tooltip",
+    tooltipProps: { content: "This is a title message for further information will appear here." },
+  },
+  {
+    value: "Option 2",
+    label: "Chip",
+    tooltipProps: { content: "This is a title message for further information will appear here." },
+  },
+  { value: "Option 3", label: "Button" },
+];
+
+const boxModeIconOptions = [
+  { value: "email", label: "Email", startElement: { type: "icon" as const, value: Email } },
+  { value: "send", label: "Send", startElement: { type: "icon" as const, value: Send } },
+  { value: "mobile", label: "Mobile", startElement: { type: "icon" as const, value: Mobile } },
+  { value: "notification", label: "Send notification" },
+];
+
+const peopleOptions = [
+  {
+    label: "Suggested people",
+    options: [
+      { value: "Matt", label: "Matt Gaman", startElement: { type: "avatar" as const, value: avatar1 } },
+      { value: "Jennifer", label: "Jennifer Lawrence", startElement: { type: "avatar" as const, value: avatar2 } },
+      { value: "Emma", label: "Emma Stone", startElement: { type: "avatar" as const, value: avatar3 } },
+    ],
+  },
+];
+
+function DropdownPreview(props: ComponentProps<typeof Dropdown>) {
+  return (
+    <div style={{ width: 300 }}>
+      <Dropdown clearAriaLabel="Clear" {...props} />
+    </div>
+  );
+}
+
+const dropdownVariations: DropdownVariation[] = [
+  {
+    id: "overview",
+    label: "Overview",
+    render: () => (
+      <DropdownPreview
+        id="gallery-overview"
+        ariaLabel="Overview dropdown"
+        options={basicOptions}
+        label="Label"
+        helperText="Helper text"
+        placeholder="Placeholder text here"
+      />
+    ),
+  },
+  {
+    id: "size-large",
+    label: "Size — Large",
+    render: () => (
+      <DropdownPreview
+        id="gallery-size-large"
+        ariaLabel="Large dropdown"
+        options={basicOptions}
+        label="Label"
+        size="large"
+        placeholder="Placeholder text here"
+      />
+    ),
+  },
+  {
+    id: "size-medium",
+    label: "Size — Medium",
+    render: () => (
+      <DropdownPreview
+        id="gallery-size-medium"
+        ariaLabel="Medium dropdown"
+        options={basicOptions}
+        label="Label"
+        size="medium"
+        placeholder="Placeholder text here"
+      />
+    ),
+  },
+  {
+    id: "size-small",
+    label: "Size — Small",
+    render: () => (
+      <DropdownPreview
+        id="gallery-size-small"
+        ariaLabel="Small dropdown"
+        options={basicOptions}
+        label="Label"
+        size="small"
+        placeholder="Placeholder text here"
+      />
+    ),
+  },
+  {
+    id: "state-default",
+    label: "State — Default",
+    render: () => (
+      <DropdownPreview id="gallery-state-default" ariaLabel="Default dropdown" options={[]} placeholder="Default" />
+    ),
+  },
+  {
+    id: "state-disabled",
+    label: "State — Disabled",
+    render: () => (
+      <DropdownPreview
+        id="gallery-state-disabled"
+        ariaLabel="Disabled dropdown"
+        options={[]}
+        placeholder="Disabled"
+        disabled
+      />
+    ),
+  },
+  {
+    id: "state-error",
+    label: "State — Error",
+    render: () => (
+      <DropdownPreview id="gallery-state-error" ariaLabel="Error dropdown" options={[]} placeholder="Error" error />
+    ),
+  },
+  {
+    id: "state-readonly",
+    label: "State — Read only",
+    render: () => (
+      <DropdownPreview
+        id="gallery-state-readonly"
+        ariaLabel="Readonly dropdown"
+        options={[]}
+        placeholder="Readonly"
+        readOnly
+      />
+    ),
+  },
+  {
+    id: "multi-single-line",
+    label: "Multi select — Single line",
+    render: () => (
+      <div style={{ width: 350 }}>
+        <Dropdown
+          placeholder="Single line multi state"
+          defaultValue={[chipOptions[0]!, chipOptions[1]!, chipOptions[2]!]}
+          options={chipOptions}
+          multi
+          clearAriaLabel="Clear"
+        />
+      </div>
+    ),
+  },
+  {
+    id: "multi-multiline",
+    label: "Multi select — Multiple lines",
+    render: () => (
+      <div style={{ width: 350 }}>
+        <Dropdown
+          placeholder="Multiple line multi state"
+          defaultValue={[chipOptions[0]!, chipOptions[1]!, chipOptions[2]!]}
+          options={chipOptions}
+          multi
+          multiline
+          clearAriaLabel="Clear"
+        />
+      </div>
+    ),
+  },
+  {
+    id: "multi-hide-selected",
+    label: "Multi select — Hide selected in menu",
+    render: () => (
+      <DropdownPreview
+        options={[
+          { value: "Option 1", label: "Label" },
+          { value: "Option 2", label: "Label" },
+          { value: "Option 3", label: "Label" },
+          { value: "Option 4", label: "Label" },
+          { value: "Option 5", label: "Label" },
+          { value: "Option 6", label: "Label" },
+        ]}
+        defaultValue={[
+          { value: "Option 1", label: "Label" },
+          { value: "Option 3", label: "Label" },
+          { value: "Option 4", label: "Label" },
+        ]}
+        label="Label"
+        required
+        multi
+        showSelectedOptions={false}
+        placeholder="Placeholder text here"
+      />
+    ),
+  },
+  {
+    id: "icon-single",
+    label: "With icon — Single value",
+    render: () => <DropdownPreview defaultValue={iconOptions[0]} options={iconOptions} />,
+  },
+  {
+    id: "icon-multi",
+    label: "With icon — Multi value",
+    render: () => <DropdownPreview defaultValue={[iconOptions[0]!]} options={iconOptions} multi />,
+  },
+  {
+    id: "avatar-single",
+    label: "With avatar — Single value",
+    render: () => <DropdownPreview defaultValue={avatarOptions[0]} options={avatarOptions} />,
+  },
+  {
+    id: "avatar-multi",
+    label: "With avatar — Multi value",
+    render: () => <DropdownPreview defaultValue={[avatarOptions[0]!]} options={avatarOptions} multi />,
+  },
+  {
+    id: "searchable",
+    label: "Searchable",
+    render: () => (
+      <DropdownPreview
+        placeholder="Search an item"
+        options={[
+          { value: "Item 1", label: "Item 1" },
+          { value: "Item 2", label: "Item 2" },
+          { value: "Item 3", label: "Item 3" },
+        ]}
+        searchable
+        maxMenuHeight={170}
+      />
+    ),
+  },
+  {
+    id: "group-divider",
+    label: "Groups — Divider",
+    render: () => (
+      <DropdownPreview
+        placeholder="Group by divider"
+        options={groupedByDividerOptions}
+        withGroupDivider
+        maxMenuHeight={170}
+      />
+    ),
+  },
+  {
+    id: "group-category",
+    label: "Groups — Category",
+    render: () => (
+      <DropdownPreview placeholder="Group by category" options={groupedOptions} maxMenuHeight={170} />
+    ),
+  },
+  {
+    id: "group-sticky",
+    label: "Groups — Sticky category title",
+    render: () => (
+      <DropdownPreview
+        placeholder="Group by category title sticky"
+        options={groupedOptions}
+        stickyGroupTitle
+        maxMenuHeight={170}
+      />
+    ),
+  },
+  {
+    id: "start-element",
+    label: "Item elements — Start",
+    render: () => (
+      <DropdownPreview
+        placeholder="Start element"
+        options={startElementOptions}
+        label="Start element"
+        required
+      />
+    ),
+  },
+  {
+    id: "end-element",
+    label: "Item elements — End",
+    render: () => (
+      <DropdownPreview placeholder="End element" options={endElementOptions} label="End element" required />
+    ),
+  },
+  {
+    id: "tooltips",
+    label: "With tooltips",
+    render: () => <DropdownPreview placeholder="Placeholder text here" options={tooltipOptions} />,
+  },
+  {
+    id: "box-mode-default",
+    label: "Box mode — Default",
+    render: () => (
+      <DropdownPreview
+        id="gallery-box-mode"
+        ariaLabel="Box mode dropdown"
+        options={basicOptions}
+        label="Label"
+        placeholder="Placeholder text here"
+        helperText="Helper text"
+        searchable
+        boxMode
+      />
+    ),
+  },
+  {
+    id: "box-mode-multi-single",
+    label: "Box mode — Multi single line",
+    render: () => (
+      <DropdownPreview
+        options={basicOptions}
+        placeholder="Placeholder text"
+        searchable
+        multi
+        boxMode
+      />
+    ),
+  },
+  {
+    id: "box-mode-multi-multiline",
+    label: "Box mode — Multi multiline",
+    render: () => (
+      <DropdownPreview
+        options={basicOptions}
+        placeholder="Placeholder text"
+        searchable
+        multi
+        multiline
+        boxMode
+      />
+    ),
+  },
+  {
+    id: "box-mode-icons",
+    label: "Box mode — With icons",
+    render: () => (
+      <DropdownPreview
+        options={boxModeIconOptions}
+        label="Notify via"
+        placeholder="You can choose multiple options"
+        searchable
+        multi
+        boxMode
+      />
+    ),
+  },
+  {
+    id: "box-mode-people",
+    label: "Box mode — People picker",
+    render: () => (
+      <div style={{ width: 350 }}>
+        <Dropdown
+          options={peopleOptions}
+          label="Person"
+          placeholder="Search for people"
+          searchable
+          boxMode
+          multi
+          clearAriaLabel="Clear"
+        />
+      </div>
+    ),
+  },
+];
+
+export function DropdownGalleryView() {
+  return (
+    <div className="component-gallery">
+      <header className="component-gallery-header">
+        <h1 className="component-gallery-title">Dropdown</h1>
+        <p className="component-gallery-description">
+          All dropdown variations currently supported by the component.
+        </p>
+      </header>
+      <div className="component-gallery-grid">
+        {dropdownVariations.map(({ id, label, render }) => (
+          <article key={id} className="component-gallery-item">
+            <h2 className="component-gallery-item-label">{label}</h2>
+            <div className="component-gallery-item-preview">{render()}</div>
+          </article>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/packages/kitchen-sink/src/components/LeftPane.tsx
+++ b/packages/kitchen-sink/src/components/LeftPane.tsx
@@ -18,9 +18,11 @@ export function LeftPane({ collapsed, onToggleCollapse }: LeftPaneProps) {
   const {
     view,
     themeSubPage,
+    componentSubPage,
     systemTheme,
     setView,
     setThemeSubPage,
+    setComponentSubPage,
     setSystemTheme,
   } = useKitchenSink();
 
@@ -45,6 +47,13 @@ export function LeftPane({ collapsed, onToggleCollapse }: LeftPaneProps) {
           onClick={() => setView("components")}
         >
           Components
+        </button>
+        <button
+          type="button"
+          className={`left-pane-sublink left-pane-sublink--deep${view === "components" && componentSubPage === "dropdown" ? " is-active" : ""}`}
+          onClick={() => setComponentSubPage("dropdown")}
+        >
+          Dropdown
         </button>
         <button
           type="button"

--- a/packages/kitchen-sink/src/context/KitchenSinkContext.tsx
+++ b/packages/kitchen-sink/src/context/KitchenSinkContext.tsx
@@ -11,6 +11,7 @@ import { loadPersistedState, savePersistedState } from "../lib/storage";
 import type {
   AppState,
   AppView,
+  ComponentSubPage,
   SystemTheme,
   ThemeSubPage,
   TokenOverrides,
@@ -19,6 +20,7 @@ import type {
 type KitchenSinkContextValue = AppState & {
   setView: (view: AppView) => void;
   setThemeSubPage: (page: ThemeSubPage) => void;
+  setComponentSubPage: (page: ComponentSubPage) => void;
   setSystemTheme: (theme: SystemTheme) => void;
   setFocusedComponentId: (id: string | null) => void;
   updateComponentState: (id: string, patch: Record<string, unknown>) => void;
@@ -37,12 +39,26 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
     return () => window.clearTimeout(id);
   }, [state]);
 
+  useEffect(() => {
+    if (window.location.hash === "#dropdown") {
+      setState((s) => ({ ...s, view: "components", componentSubPage: "dropdown" }));
+    }
+  }, []);
+
   const setView = useCallback((view: AppView) => {
-    setState((s) => ({ ...s, view }));
+    setState((s) => ({
+      ...s,
+      view,
+      componentSubPage: view === "components" ? "grid" : s.componentSubPage,
+    }));
   }, []);
 
   const setThemeSubPage = useCallback((themeSubPage: ThemeSubPage) => {
     setState((s) => ({ ...s, view: "theme", themeSubPage }));
+  }, []);
+
+  const setComponentSubPage = useCallback((componentSubPage: ComponentSubPage) => {
+    setState((s) => ({ ...s, view: "components", componentSubPage }));
   }, []);
 
   const setSystemTheme = useCallback((systemTheme: SystemTheme) => {
@@ -108,6 +124,7 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
       ...state,
       setView,
       setThemeSubPage,
+      setComponentSubPage,
       setSystemTheme,
       setFocusedComponentId,
       updateComponentState,
@@ -119,6 +136,7 @@ export function KitchenSinkProvider({ children }: { children: ReactNode }) {
       state,
       setView,
       setThemeSubPage,
+      setComponentSubPage,
       setSystemTheme,
       setFocusedComponentId,
       updateComponentState,

--- a/packages/kitchen-sink/src/lib/storage.ts
+++ b/packages/kitchen-sink/src/lib/storage.ts
@@ -15,6 +15,7 @@ export function createInitialAppState(): AppState {
   return {
     view: "components",
     themeSubPage: "colors",
+    componentSubPage: "grid",
     systemTheme: "light",
     tokenOverrides: structuredClone(EMPTY_TOKEN_OVERRIDES),
     componentStates: mergeWithDefaults(undefined),
@@ -28,6 +29,7 @@ function toPersisted(state: AppState): PersistedState {
     version: STORAGE_VERSION,
     view: state.view,
     themeSubPage: state.themeSubPage,
+    componentSubPage: state.componentSubPage,
     systemTheme: state.systemTheme,
     tokenOverrides: state.tokenOverrides,
     componentStates: state.componentStates,
@@ -60,6 +62,7 @@ export function loadPersistedState(): AppState {
       ...base,
       view: parsed.view ?? base.view,
       themeSubPage: normalizeThemeSubPage(parsed.themeSubPage, base.themeSubPage),
+      componentSubPage: parsed.componentSubPage ?? base.componentSubPage,
       systemTheme: parsed.systemTheme ?? base.systemTheme,
       tokenOverrides: {
         ...base.tokenOverrides,

--- a/packages/kitchen-sink/src/styles.css
+++ b/packages/kitchen-sink/src/styles.css
@@ -578,3 +578,63 @@ body {
   color: var(--text-color-on-primary, #ffffff);
   font-weight: 600;
 }
+
+.component-gallery {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.component-gallery-header {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.component-gallery-title {
+  margin: 0;
+  font-size: 28px;
+  font-weight: 600;
+  color: var(--primary-text-color, #323338);
+}
+
+.component-gallery-description {
+  margin: 0;
+  font-size: 14px;
+  color: var(--secondary-text-color, #676879);
+}
+
+.component-gallery-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(380px, 1fr));
+  gap: 20px;
+}
+
+.component-gallery-item {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 20px;
+  border: 1px solid var(--layout-border-color, #e6e9ef);
+  border-radius: var(--border-radius-medium, 8px);
+  background: var(--secondary-background-color, #ffffff);
+}
+
+.component-gallery-item-label {
+  margin: 0;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--secondary-text-color, #676879);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}
+
+.component-gallery-item-preview {
+  display: flex;
+  align-items: flex-start;
+  justify-content: center;
+  min-height: 88px;
+  padding: 16px;
+  border-radius: var(--border-radius-small, 4px);
+  background: var(--allgrey-background-color, #f6f7fb);
+}

--- a/packages/kitchen-sink/src/types.ts
+++ b/packages/kitchen-sink/src/types.ts
@@ -3,6 +3,7 @@ import type React from "react";
 export type SystemTheme = "light" | "dark" | "black";
 export type AppView = "components" | "compare" | "theme" | "screens";
 export type ThemeSubPage = "colors" | "radius" | "typography";
+export type ComponentSubPage = "grid" | "dropdown";
 
 export type ThemeColorOverrides = Partial<Record<SystemTheme, Record<string, string>>>;
 
@@ -18,6 +19,7 @@ export type ComponentStateMap = Record<string, Record<string, unknown>>;
 export type AppState = {
   view: AppView;
   themeSubPage: ThemeSubPage;
+  componentSubPage: ComponentSubPage;
   systemTheme: SystemTheme;
   tokenOverrides: TokenOverrides;
   componentStates: ComponentStateMap;
@@ -32,6 +34,7 @@ export type PersistedState = {
   version: number;
   view: AppView;
   themeSubPage: ThemeSubPage;
+  componentSubPage?: ComponentSubPage;
   systemTheme: SystemTheme;
   tokenOverrides: TokenOverrides;
   componentStates: ComponentStateMap;

--- a/packages/kitchen-sink/tsconfig.json
+++ b/packages/kitchen-sink/tsconfig.json
@@ -18,7 +18,9 @@
     "types": ["vite/client"],
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/screens/*"]
+      "@/*": ["./src/screens/*"],
+      "@vibe/core/next": ["../core/dist/components/next.d.ts"],
+      "@vibe/core": ["../core/dist/index.d.ts"]
     }
   },
   "include": ["src"]

--- a/packages/kitchen-sink/vite.config.ts
+++ b/packages/kitchen-sink/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
       // Point directly at the monorepo's built packages/core so source changes
       // (after `yarn workspace @vibe/core build`) are picked up by both apps.
       "@vibe/core/tokens": path.resolve(__dirname, "../core/dist/tokens/tokens.css"),
+      "@vibe/core/next": path.resolve(__dirname, "../core/dist/src/components/next.js"),
       "@vibe/core": path.resolve(__dirname, "../core/dist/src/index.js"),
       "@vibe/icons": path.resolve(__dirname, "node_modules/@vibe/icons/dist/react/index.js"),
       // @ alias used by screens/ (facelift-prototype) components


### PR DESCRIPTION
## Summary
- Add a dedicated **Dropdown** page to the facelift kitchen sink with 27 variants covering sizes, states, multi-select, icons, avatars, search, groups, box mode, and more
- Wire the page into sidebar navigation under Components → Dropdown, with `#dropdown` hash support
- Add `@vibe/core/next` alias in Vite and TypeScript config so the gallery uses the new Dropdown component

## Test plan
- [ ] Run `yarn dev` in `packages/kitchen-sink` (after `yarn workspace @vibe/core build`)
- [ ] Open the app and click **Components → Dropdown** in the sidebar
- [ ] Verify all 27 variant cards render correctly in light, dark, and black themes
- [ ] Confirm `#dropdown` hash navigates directly to the gallery page


Made with [Cursor](https://cursor.com)