### PR TITLE
refactor(core): scope Toggle focus-ring selector to a marker class

### DIFF
--- a/packages/core/src/components/Toggle/Toggle.module.scss
+++ b/packages/core/src/components/Toggle/Toggle.module.scss
@@ -8,7 +8,7 @@
   // When the hidden checkbox will be focused by keyboard navigation events, the toggle appearance will reflect it
   &:focus-visible,
   &.focus-visible { /* stylelint-disable-line selector-class-pattern */
-    & ~ div {
+    & ~ .toggleFocusTarget {
       @include focus-style-css();
     }
   }

--- a/packages/core/src/components/Toggle/Toggle.tsx
+++ b/packages/core/src/components/Toggle/Toggle.tsx
@@ -111,7 +111,7 @@ const Toggle = forwardRef(
           offOverrideText={offOverrideText}
           onOverrideText={onOverrideText}
           disabled={disabled}
-          className={className}
+          className={cx(className, styles.toggleFocusTarget)}
           selectedClassName={toggleSelectedClassName}
           size={size}
         />

--- a/packages/core/src/components/Toggle/__tests__/__snapshots__/Toggle.snapshot.test.tsx.snap
+++ b/packages/core/src/components/Toggle/__tests__/__snapshots__/Toggle.snapshot.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Toggle renders correctly > renders correctly when disabled 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected disabled"
+    className="toggle medium toggleFocusTarget selected disabled"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text disabled"
@@ -50,7 +50,7 @@ exports[`Toggle renders correctly > renders correctly when labels are hidden 1`]
   />
   <div
     aria-hidden="true"
-    className="toggle medium selected noSpacing"
+    className="toggle medium toggleFocusTarget selected noSpacing"
   />
 </label>
 `;
@@ -77,7 +77,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name notSelected"
+    className="toggle medium dummy-class-name toggleFocusTarget notSelected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -110,7 +110,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name selected"
+    className="toggle medium dummy-class-name toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -143,7 +143,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name notSelected"
+    className="toggle medium dummy-class-name toggleFocusTarget notSelected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -176,7 +176,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name selected"
+    className="toggle medium dummy-class-name toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -210,7 +210,7 @@ exports[`Toggle renders correctly > renders correctly with aria controls 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -243,7 +243,7 @@ exports[`Toggle renders correctly > renders correctly with empty props 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -276,7 +276,7 @@ exports[`Toggle renders correctly > renders correctly with not default offOverri
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"
@@ -309,7 +309,7 @@ exports[`Toggle renders correctly > renders correctly with not default onOverrid
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
   />
   <span
     className="typography primary start singleLineEllipsis text text2Normal text"


### PR DESCRIPTION
## What

Replaces the non-specific `.toggleInput:focus-visible ~ div` selector in the Toggle component with `~ .toggleFocusTarget`, a dedicated marker class applied to the drawn toggle `<div>`.

## Why

The old rule matched a bare `div` type selector under a general sibling combinator. It only worked because there happened to be exactly one `div` sibling inside the `<label>` — non-specific and fragile. This scopes the focus ring to an explicit target.

## Changes

- `Toggle.module.scss`: `& ~ div` → `& ~ .toggleFocusTarget`
- `Toggle.tsx`: pass the marker class to `MockToggle` via `className={cx(className, styles.toggleFocusTarget)}`
- `Toggle.snapshot.test.tsx.snap`: regenerated (drawn div's class now includes `toggleFocusTarget`)

## No behavior change

The same drawn toggle `<div>` still receives `focus-style-css()` on keyboard focus — now via an explicit marker instead of a bare `div` match.

## Testing

- ✅ `@vibe/core` Toggle tests: 18/18 pass
- ✅ stylelint clean

> A sibling PR applies the identical change on `version3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)