### PR TITLE
refactor(core): scope Toggle focus-ring selector to a marker class

### DIFF
--- a/packages/core/src/components/Toggle/Toggle.module.scss
+++ b/packages/core/src/components/Toggle/Toggle.module.scss
@@ -8,7 +8,7 @@
   // When the hidden checkbox will be focused by keyboard navigation events, the toggle appearance will reflect it
   &:focus-visible,
   &.focus-visible { /* stylelint-disable-line selector-class-pattern */
-    & ~ div {
+    & ~ .toggleFocusTarget {
       @include focus-style-css();
     }
   }

--- a/packages/core/src/components/Toggle/Toggle.tsx
+++ b/packages/core/src/components/Toggle/Toggle.tsx
@@ -117,7 +117,7 @@ const Toggle = forwardRef(
           offOverrideText={offOverrideText}
           onOverrideText={onOverrideText}
           disabled={disabled}
-          className={className}
+          className={cx(className, styles.toggleFocusTarget)}
           selectedClassName={toggleSelectedClassName}
           size={size}
         />

--- a/packages/core/src/components/Toggle/__tests__/__snapshots__/Toggle.snapshot.test.tsx.snap
+++ b/packages/core/src/components/Toggle/__tests__/__snapshots__/Toggle.snapshot.test.tsx.snap
@@ -23,7 +23,7 @@ exports[`Toggle renders correctly > renders correctly when disabled 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected disabled"
+    className="toggle medium toggleFocusTarget selected disabled"
     data-testid="toggle"
   />
   <span
@@ -51,7 +51,7 @@ exports[`Toggle renders correctly > renders correctly when labels are hidden 1`]
   />
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
     data-testid="toggle"
   />
 </label>
@@ -79,7 +79,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name notSelected"
+    className="toggle medium dummy-class-name toggleFocusTarget notSelected"
     data-testid="toggle"
   />
   <span
@@ -113,7 +113,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name selected"
+    className="toggle medium dummy-class-name toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span
@@ -147,7 +147,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name notSelected"
+    className="toggle medium dummy-class-name toggleFocusTarget notSelected"
     data-testid="toggle"
   />
   <span
@@ -181,7 +181,7 @@ exports[`Toggle renders correctly > renders correctly when selection defined by 
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium dummy-class-name selected"
+    className="toggle medium dummy-class-name toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span
@@ -216,7 +216,7 @@ exports[`Toggle renders correctly > renders correctly with aria controls 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span
@@ -250,7 +250,7 @@ exports[`Toggle renders correctly > renders correctly with empty props 1`] = `
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span
@@ -284,7 +284,7 @@ exports[`Toggle renders correctly > renders correctly with not default offOverri
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span
@@ -318,7 +318,7 @@ exports[`Toggle renders correctly > renders correctly with not default onOverrid
   </span>
   <div
     aria-hidden="true"
-    className="toggle medium selected"
+    className="toggle medium toggleFocusTarget selected"
     data-testid="toggle"
   />
   <span


### PR DESCRIPTION
## What

Replaces the non-specific `.toggleInput:focus-visible ~ div` selector in the Toggle component with `~ .toggleFocusTarget`, a dedicated marker class applied to the drawn toggle `<div>`.

## Why

The old rule matched a bare `div` type selector under a general sibling combinator. It only worked because there happened to be exactly one `div` sibling inside the `<label>` — non-specific and fragile. This scopes the focus ring to an explicit target.

## Changes

- `Toggle.module.scss`: `& ~ div` → `& ~ .toggleFocusTarget`
- `Toggle.tsx`: pass the marker class to `MockToggle` via `className={cx(className, styles.toggleFocusTarget)}`
- `Toggle.snapshot.test.tsx.snap`: regenerated (drawn div's class now includes `toggleFocusTarget`)

## No behavior change

The same drawn toggle `<div>` still receives `focus-style-css()` on keyboard focus — now via an explicit marker instead of a bare `div` match.

## Testing

- ✅ `@vibe/core` Toggle tests: 18/18 pass
- ✅ stylelint clean

> This is the `version3` counterpart of the same change targeting `master`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)