### PR TITLE
refactor(core): replace non-specific CSS selectors with explicit classes

### DIFF
--- a/packages/core/src/components/Dropdown/components/MultiSelectedValues/MultiSelectedValues.module.scss
+++ b/packages/core/src/components/Dropdown/components/MultiSelectedValues/MultiSelectedValues.module.scss
@@ -3,7 +3,7 @@
   flex-grow: 1;
 
   &.singleChip {
-    > div:first-child {
+    > .chipWrapperWithOverflow:first-child {
       min-width: 50px;
       flex-shrink: 1;
 
@@ -14,7 +14,8 @@
   }
 
   &.measuring {
-    > div:not(.hiddenChip) {
+    > .chipWrapperWithOverflow:not(.hiddenChip),
+    > .inputAndCounterWrapper {
       opacity: 0;
     }
   }

--- a/packages/core/src/components/Slider/SliderBase/SliderBase.module.scss
+++ b/packages/core/src/components/Slider/SliderBase/SliderBase.module.scss
@@ -6,11 +6,14 @@
 }
 
 .disabled {
-  * {
-    pointer-events: none;
-  }
   cursor: not-allowed !important;
   opacity: var(--disabled-component-opacity);
+}
+
+// Disable interaction on the rail (and, via inherited pointer-events, its entire
+// subtree) while keeping the root interactive so its `not-allowed` cursor still shows.
+.railDisabled {
+  pointer-events: none;
 }
 
 .small {

--- a/packages/core/src/components/Slider/SliderBase/SliderBase.tsx
+++ b/packages/core/src/components/Slider/SliderBase/SliderBase.tsx
@@ -84,7 +84,12 @@ const SliderBase: FC<SliderBaseProps> = forwardRef(({ className }, _ref) => {
       data-testid={shapeTestId("base")}
       onKeyDown={handleKeyDown}
     >
-      <SliderRail onClick={handleRailClick} size={size} ref={railRef}>
+      <SliderRail
+        onClick={handleRailClick}
+        size={size}
+        ref={railRef}
+        className={cx({ [styles.railDisabled]: disabled })}
+      >
         <SliderTrack color={color} />
         {railRef.current && (
           <>

--- a/packages/core/src/components/Slider/__tests__/__snapshots__/Slider.snapshot.test.tsx.snap
+++ b/packages/core/src/components/Slider/__tests__/__snapshots__/Slider.snapshot.test.tsx.snap
@@ -198,7 +198,7 @@ exports[`Slider renders correctly > 06. with disabled 1`] = `
     data-testid="monday-slider__base"
   >
     <div
-      class="rail small"
+      class="rail small railDisabled"
       data-testid="monday-slider__rail"
     >
       <div


### PR DESCRIPTION
## What

Follow-up to the Toggle focus-selector cleanup. Replaces two low-specificity selector patterns (found in a repo-wide audit) with explicit class targets. Behavior-preserving.

## Changes

**Slider** — `.disabled * { pointer-events: none }` (universal descendant) → a `.railDisabled` marker class applied to `SliderRail`. Since `pointer-events` is inherited, disabling the rail disables its whole subtree, while the `.disabled` root keeps `cursor: not-allowed`. Same visual/interaction behavior.

**MultiSelectedValues** — bare `div` combinator targets replaced with existing classes:
- `> div:first-child` → `> .chipWrapperWithOverflow:first-child`
- `> div:not(.hiddenChip)` → `> .chipWrapperWithOverflow:not(.hiddenChip), > .inputAndCounterWrapper` (exactly the set the old selector matched: visible chips + the input/counter wrapper)

## Deliberately left unchanged

- `TextField` `.textField * { box-sizing: border-box }` — an idiomatic scoped reset; `box-sizing` isn't inherited so it can't move to the parent, and enumerating descendants would be more fragile.
- The deeply-nested `div { max-width: 100% }` in MultiSelectedValues single-chip — targets the external `Chips` package's internals (no exposed class); out of scope.

## Testing

- ✅ stylelint clean
- ✅ Slider + MultiSelectedValues/Dropdown tests pass (snapshots regenerated for the intended class changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)